### PR TITLE
allow line breaks in participant emails

### DIFF
--- a/studies/templates/emails/custom_email.html
+++ b/studies/templates/emails/custom_email.html
@@ -1,3 +1,3 @@
-<p> {{ custom_message }} </p>
+<p> {{ custom_message|linebreaks }} </p>
 
 <a href="{{base_url}}{% url 'web:email-preferences' %}"> Update your email preferences </a>


### PR DESCRIPTION
Allow researchers to include \n in participant emails, for readability.