### PR TITLE
Quick fixes: Update Travis repo and fix age calculation bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 env:
   global:
     - DOCKER_REPO_URL=quay.io
-    - DOCKER_REPO_OWNER=centerforopenscience
+    - DOCKER_REPO_OWNER=lookit
     - DOCKER_REPO_NAME=lookit-api
     - DOCKER_BRANCH=${TRAVIS_BRANCH/\//-}
     - DOCKER_IMAGE_URL=$DOCKER_REPO_URL/$DOCKER_REPO_OWNER/$DOCKER_REPO_NAME

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -43,10 +43,12 @@
             document.getElementById('too-young').style.display = 'none';
             var birthday = selected.value.split('|')[1];
             var age = calculateAgeInDays(birthday);
-            if (!isEligible(age)) {
-                if (isOldEnough(age)) {
+            var ineligible = ageCheck(age);
+            if (ineligible) {
+                if (ineligible > 0) {
                     document.getElementById('too-old').style.display = 'inline-block';
                 } else {
+                	$('#wait-until').text(moment.duration(-ineligible, "days").humanize() + ' until ' + moment(moment()._d).add(-ineligible, 'days').format("dddd, MMMM Do YYYY") + ' when ');
                     document.getElementById('too-young').style.display = 'inline-block';
                 }
             }
@@ -57,16 +59,20 @@
         }
 
         function calculateAgeInDays(birthday) {
-            var birthdayDate = new Date(birthday);
-            return moment.duration(moment()._d - birthdayDate).asDays();
+            // Warning: do NOT use moment.duration in the calculation of age! Use diffs
+            // instead to get ACTUAL time difference, without passing through an 
+            // approximation where each month is 30 days and each year is 365.
+            return moment(moment()._d).diff(new Date(birthday), 'days');
         }
 
         function ageCheck(age) {
             // Adapted from experiment model in exp-addons
             var minDays;
             var maxDays;
-            minDays = moment.duration({days: "{{ study.min_age_days }}", months: "{{ study.min_age_months }}", years: "{{ study.min_age_years }}"}).asDays();
-            maxDays = moment.duration({days: "{{ study.max_age_days }}", months: "{{ study.max_age_months }}", years: "{{ study.max_age_years }}"}).asDays();
+            // These are now hard-coded to avoid unpredictable behavior from moment.duration().asDays()
+            // e.g. 1 year = 365 days, 1 month = 30 days, and 1 year + 1 month = 396 days.
+            minDays = Number("{{study.min_age_days}}") + 30 * Number("{{study.min_age_months}}") + 365 * Number("{{study.min_age_years}}");
+            maxDays = Number("{{study.max_age_days}}") + 30 * Number("{{study.max_age_months}}") + 365 * Number("{{study.max_age_years}}");
 
             minDays = minDays || -1;
             maxDays = maxDays || Number.MAX_SAFE_INTEGER;
@@ -148,7 +154,7 @@
                                 <option onemptied="" value="{{child.uuid}}|{{child.birthday}}">{{child.given_name}}</option>
                                 {% endfor %}
                             </select>
-                            <p class="text-warning" style="display:none" id='too-young'>Your child is still younger than the recommended age range for this study. If you can wait until he or she is old enough, we'll be able to use the collected data in our research! </p>
+                            <p class="text-warning" style="display:none" id='too-young'>Your child is still younger than the recommended age range for this study. If you can wait until <span id='wait-until'></span> he or she is old enough, we'll be able to use the collected data in our research! </p>
             	            <p class="text-warning" style="display:none" id='too-old'>Your child is older than the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research.</p>
                             <button type="button" onclick="portToParticipate(this)" disabled class="btn-lg btn-primary" id="participate-button"> Participate now! </button>
                         </div>

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -86,14 +86,6 @@
             }
         }
 
-        function isOldEnough(age) {
-            const check = this.ageCheck(age);
-            return check >= 0;
-        }
-
-        function isEligible(age) {
-            return this.ageCheck(age) === 0;
-        }
     </script>
     <div class='lookit-row lookit-page-title'>
         <div class='container'>
@@ -154,7 +146,7 @@
                                 <option onemptied="" value="{{child.uuid}}|{{child.birthday}}">{{child.given_name}}</option>
                                 {% endfor %}
                             </select>
-                            <p class="text-warning" style="display:none" id='too-young'>Your child is still younger than the recommended age range for this study. If you can wait until <span id='wait-until'></span> he or she is old enough, we'll be able to use the collected data in our research! </p>
+                            <p class="text-warning" style="display:none" id='too-young'>Your child is still younger than the recommended age range for this study. If you can wait <span id='wait-until'>until</span> he or she is old enough, we'll be able to use the collected data in our research! </p>
             	            <p class="text-warning" style="display:none" id='too-old'>Your child is older than the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research.</p>
                             <button type="button" onclick="portToParticipate(this)" disabled class="btn-lg btn-primary" id="participate-button"> Participate now! </button>
                         </div>


### PR DESCRIPTION
* Switch Travis repo owner centerforopenscience -> lookit

* Fix bug in age calculation for study eligibility. Previously a child's age was being calculated by first converting to a moment 'duration', and then converting that back to days. This means that if the child was born, say, February 1st, then on March 1st they would be considered "1 month old" which is 30 days. Actually the child is 28 days old. This was leading to confusion for participants in the Baby Euclid study w/ a narrow age range. It's now fixed & we also display when the child WILL be eligible, so that e.g. someone who's just a few days out of the age range can easily see when they might want to check back.