### PR TITLE
[Do not merge into prod] Feature/Download Endpoints for Response Data

### DIFF
--- a/exp/urls.py
+++ b/exp/urls.py
@@ -22,7 +22,10 @@ from exp.views import (ExperimenterDashboardView, ParticipantDetailView,
                        StudyAttachments, StudyBuildView, StudyCreateView,
                        StudyDemographics, StudyDetailView, StudyListView,
                        StudyParticipantEmailView, StudyPreviewBuildView,
-                       StudyResponsesAll, StudyResponsesList, StudyUpdateView)
+                       StudyResponsesAll, StudyResponsesAllDownloadJSON,
+                       StudyResponsesAllDownloadCSV, StudyResponsesList,
+                       StudyDemographicsDownloadJSON, StudyDemographicsDownloadCSV,
+                       StudyUpdateView)
 
 urlpatterns = [
     url(r'researchers/$', ResearcherListView.as_view(), name='researcher-list'),
@@ -37,7 +40,11 @@ urlpatterns = [
     url(r'studies/(?P<pk>\d+)/edit/build/$', StudyBuildView.as_view(), name='study-build'),
     url(r'studies/(?P<pk>\d+)/responses/$', StudyResponsesList.as_view(), name='study-responses-list'),
     url(r'studies/(?P<pk>\d+)/responses/all/$', StudyResponsesAll.as_view(), name='study-responses-all'),
+    url(r'studies/(?P<pk>\d+)/responses/all/download_json/$', StudyResponsesAllDownloadJSON.as_view(), name='study-responses-download-json'),
+    url(r'studies/(?P<pk>\d+)/responses/all/download_csv/$', StudyResponsesAllDownloadCSV.as_view(), name='study-responses-download-csv'),
     url(r'studies/(?P<pk>\d+)/responses/demographics/$', StudyDemographics.as_view(), name='study-demographics'),
+    url(r'studies/(?P<pk>\d+)/responses/demographics/download_json/$', StudyDemographicsDownloadJSON.as_view(), name='study-demographics-download-json'),
+    url(r'studies/(?P<pk>\d+)/responses/demographics/download_csv/$', StudyDemographicsDownloadCSV.as_view(), name='study-demographics-download-csv'),
     url(r'studies/(?P<pk>\d+)/responses/attachments/$', StudyAttachments.as_view(), name='study-attachments'),
     url(r'studies/(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89ab][0-9a-fA-F]{3}-[0-9a-fA-F]{12})/preview_build/$', StudyPreviewBuildView.as_view(), name='study-preview-build'),
     url(r'studies/(?P<path>(?P<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89ab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}))/preview/$', PreviewProxyView.as_view(), name='preview-proxy'),

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -581,6 +581,33 @@ class StudyResponsesAll(StudyResponsesMixin, generic.DetailView):
         return output.getvalue()
 
 
+class StudyResponsesAllDownloadJSON(StudyResponsesMixin, generic.DetailView):
+    """
+    Hitting this URL downloads all study responses in JSON format.
+    """
+    def get(self, request, *args, **kwargs):
+        study = self.get_object()
+        responses = study.responses.order_by('id')
+        cleaned_data = ', '.join(self.build_responses(responses))
+        filename = '{}-{}.json'.format(study.name, 'all_responses')
+        response = HttpResponse(cleaned_data, content_type='text/json')
+        response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
+        return response
+
+
+class StudyResponsesAllDownloadCSV(StudyResponsesAll):
+    """
+    Hitting this URL downloads all study responses in CSV format.
+    """
+    def get(self, request, *args, **kwargs):
+        study = self.get_object()
+        responses = study.responses.order_by('id')
+        cleaned_data = self.build_all_csv(responses)
+        filename = '{}-{}.csv'.format(study.name, 'all_responses')
+        response = HttpResponse(cleaned_data, content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
+        return response
+
 class StudyDemographics(StudyResponsesMixin, generic.DetailView):
     """
     StudyParticiapnts view shows participant demographic snapshots associated
@@ -608,6 +635,33 @@ class StudyDemographics(StudyResponsesMixin, generic.DetailView):
         for resp in responses:
             writer.writerow(self.build_csv_participant_row_data(resp))
         return output.getvalue()
+
+class StudyDemographicsDownloadJSON(StudyResponsesMixin, generic.DetailView):
+    """
+    Hitting this URL downloads all participant demographics in JSON format.
+    """
+    def get(self, request, *args, **kwargs):
+        study = self.get_object()
+        responses = study.responses.order_by('id')
+        cleaned_data = ', '.join(self.build_participant_data(responses))
+        filename = '{}-{}.json'.format(study.name, 'all_demographic_snapshots')
+        response = HttpResponse(cleaned_data, content_type='text/json')
+        response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
+        return response
+
+
+class StudyDemographicsDownloadCSV(StudyDemographics):
+    """
+    Hitting this URL downloads all participant demographics in CSV format.
+    """
+    def get(self, request, *args, **kwargs):
+        study = self.get_object()
+        responses = study.responses.order_by('id')
+        cleaned_data = self.build_all_participant_csv(responses)
+        filename = '{}-{}.csv'.format(study.name, 'all_demographic_snapshots')
+        response = HttpResponse(cleaned_data, content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
+        return response
 
 
 class StudyAttachments(StudyResponsesMixin, generic.DetailView, PaginatorMixin):

--- a/studies/templates/studies/_all_json_and_csv_data.html
+++ b/studies/templates/studies/_all_json_and_csv_data.html
@@ -7,33 +7,18 @@
     {{ block.super }}
     <script type="application/javascript">
         $(document).ready(function(){
-            prepareDataForDownload('.all-data', 'json');
-            $(".all-csv-data").hide();
-
+            $('#download-all-data-csv').addClass('hidden');
             $('#data-type-selector-all').on('change', function(){
-                // Toggles combined responses between CSV and JSON format
+                // Toggles responses between CSV and JSON format
                 var selected = $(this).find("option:selected").val();
-                $('.all-data').hide();
-                $('.all-csv-data').hide();
                 if (selected === 'CSV'){
-                    $('.all-csv-data').show();
-                    prepareDataForDownload('.all-csv-data', 'csv');
+                    $('#download-all-data-csv').removeClass('hidden');
+                    $('#download-all-data-json').addClass('hidden');
                 } else {
-                    $('.all-data').show();
-                    prepareDataForDownload('.all-data', 'json');
+                    $('#download-all-data-json').removeClass('hidden');
+                    $('#download-all-data-csv').addClass('hidden');
                 }
-                $('#download-data-label').text(selected);
             });
-
-            function prepareDataForDownload(dataClassOrId, ext) {
-                // Preps Download All button to download either all JSON or all CSV responses
-                var data = "data:text/json;charset=utf-8," + encodeURIComponent($(dataClassOrId).html());
-                var elem = $('#download-all-data')[0];
-                if (data && elem) {
-                    elem.href = data;
-                    elem.download = '{{study.name}}-' + '{{download_name}}' + '.' + ext;
-                }
-            }
         });
     </script>
     {{ form.media }}
@@ -84,13 +69,22 @@
                 </div>
             </div>
             <div class="col-sm-3">
-                <a id='download-all-data' class='btn btn-primary'>
-                    Download All {{ response_keyword }} <span id="download-data-label"> JSON</span>
-                </a>
-            </div>
-            <div class="col-xs-12 pt-sm">
-                <pre class='all-data'>{{ all_responses }}</pre>
-                <pre class='all-csv-data'>{{ csv_responses }}</pre>
+                {% if active == 'all' %}
+                    <a id='download-all-data-json' class ='btn btn-primary' href="{% url 'exp:study-responses-download-json' pk=study.id %}">
+                        Download All Responses as JSON</span>
+                    </a>
+                    <a id='download-all-data-csv' class='hidden btn btn-primary' href="{% url 'exp:study-responses-download-csv' pk=study.id %}">
+                        Download All Responses as CSV</span>
+                    </a>
+                {% endif %}
+                {% if active == 'demographics' %}
+                    <a id='download-all-data-json' class ='btn btn-primary' href="{% url 'exp:study-demographics-download-json' pk=study.id %}">
+                        Download All Demographic Snapshots as JSON</span>
+                    </a>
+                    <a id='download-all-data-csv' class='hidden btn btn-primary' href="{% url 'exp:study-demographics-download-csv' pk=study.id %}">
+                        Download All Demographic Snapshots as CSV</span>
+                    </a>
+                {% endif %}
             </div>
         </div>
     {% endif %}

--- a/studies/templates/studies/study_demographics.html
+++ b/studies/templates/studies/study_demographics.html
@@ -1,1 +1,1 @@
-{% include 'studies/_all_json_and_csv_data.html' with active="demographics" response_keyword="Demographic Snapshots as" active_tab="Demographic Snapshots" download_name="all_demographic_snapshots" %}
+{% include 'studies/_all_json_and_csv_data.html' with active="demographics" active_tab="Demographic Snapshots" %}

--- a/studies/templates/studies/study_responses_all.html
+++ b/studies/templates/studies/study_responses_all.html
@@ -1,1 +1,1 @@
-{% include 'studies/_all_json_and_csv_data.html' with active="all" response_keyword="Responses" active_tab="All Responses" download_name="all_responses"%}
+{% include 'studies/_all_json_and_csv_data.html' with active="all" active_tab="All Responses"%}


### PR DESCRIPTION
❗️ Do not merge into production yet
# Purpose

Large Downloads are failing with 'Failed - Network error' in Chrome.  This is mostly happening on the All Responses page where you can download all responses to your study in JSON and CSV.  We are currenly showing a preview of all the json or csv responses to your study on the page, and then pushing that code block into a json file or csv file for download.  As the number of study responses grows, this is becoming unwieldy and slow. 

# Changes

Added four endpoints for downloading data. You must have permission to view study responses to hit these endpoints.
- `/studies/<study_id/responses/all/download_json/`
- `/studies/<study_id/responses/all/download_csv/`
- `/studies/<study_id/responses/demographics/download_json/`
- `studies/<study_id/responses/demographics/download_csv/`

The download buttons on the All Responses page now send requests to these endpoints and the data is downloaded to your machine.  The data preview has been removed.

<img width="1069" alt="screen shot 2018-06-10 at 9 02 10 pm" src="https://user-images.githubusercontent.com/9755598/41209597-14685fee-6cf2-11e8-9d56-42d5a1da2e25.png">

# Testing Notes
This is a potential solution for the Failed - Network error in Chrome @kimberscott.  It improved download speed quite a bit for me locally. I've removed the preview sections here - the page load is going to get more and more laggy if we do not do this. Alternatively, if you want to leave the preview data, you can still hit these endpoints directly to download, without navigating to the preview pages.  You should make sure that only researchers can hit these download links, and that you must have proper permissions to the study to download the data.  Would verify that the downloaded data is what you expect.