### PR TITLE
Clean up "all response" and demographic views so that we don't load a…

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -565,9 +565,7 @@ class StudyResponsesAll(StudyResponsesMixin, generic.DetailView):
         are paginated.
         """
         context = super().get_context_data(**kwargs)
-        responses = context['study'].responses.order_by('id')
-        context['all_responses'] = ', '.join(self.build_responses(responses))
-        context['csv_responses'] = self.build_all_csv(responses)
+        context['n_responses'] = len(context['study'].responses.order_by('id'))
         return context
 
     def build_all_csv(self, responses):
@@ -621,9 +619,7 @@ class StudyDemographics(StudyResponsesMixin, generic.DetailView):
         are paginated.
         """
         context = super().get_context_data(**kwargs)
-        responses = context['study'].responses.order_by('id')
-        context['all_responses'] = ', '.join(self.build_participant_data(responses))
-        context['csv_responses'] = self.build_all_participant_csv(responses)
+        context['n_responses'] = len(context['study'].responses.order_by('id'))
         return context
 
     def build_all_participant_csv(self, responses):

--- a/studies/templates/studies/_all_json_and_csv_data.html
+++ b/studies/templates/studies/_all_json_and_csv_data.html
@@ -51,14 +51,10 @@
     </div>
     <div class="row">
         <div class="col-xs-12">
-            {% if all_responses %}
-                {% include 'studies/_response_nav_tabs.html' with active=active %}
-            {% else %}
-                <p class="pt-md"><em>No responses recorded! </em></p>
-            {% endif %}
+        	{% include 'studies/_response_nav_tabs.html' with active=active %}
         </div>
     </div>
-    {% if all_responses %}
+	{% if n_responses %}
         <div class='row pt-xl'>
             <div class="col-sm-3">
                 <div class="form-group">
@@ -71,22 +67,28 @@
             <div class="col-sm-3">
                 {% if active == 'all' %}
                     <a id='download-all-data-json' class ='btn btn-primary' href="{% url 'exp:study-responses-download-json' pk=study.id %}">
-                        Download All Responses as JSON</span>
+                        Download all {{ n_responses }} responses as JSON</span>
                     </a>
                     <a id='download-all-data-csv' class='hidden btn btn-primary' href="{% url 'exp:study-responses-download-csv' pk=study.id %}">
-                        Download All Responses as CSV</span>
+                        Download all {{ n_responses }} responses as CSV</span>
                     </a>
                 {% endif %}
                 {% if active == 'demographics' %}
                     <a id='download-all-data-json' class ='btn btn-primary' href="{% url 'exp:study-demographics-download-json' pk=study.id %}">
-                        Download All Demographic Snapshots as JSON</span>
+                        Download all {{ n_responses }} demographic snapshots as JSON</span>
                     </a>
                     <a id='download-all-data-csv' class='hidden btn btn-primary' href="{% url 'exp:study-demographics-download-csv' pk=study.id %}">
-                        Download All Demographic Snapshots as CSV</span>
+                        Download all {{ n_responses }} demographic snapshots as CSV</span>
                     </a>
                 {% endif %}
             </div>
         </div>
+    {% else %}
+    	<div class="row">
+    		<div class="col-xs-12">
+    			<p class="pt-md"><em>No responses recorded!</em></p>
+    		</div>
+    	</div>
     {% endif %}
 </div>
 {% endblock %}

--- a/studies/templates/studies/study_attachments.html
+++ b/studies/templates/studies/study_attachments.html
@@ -41,12 +41,12 @@
             <h1>Attachments</h1>
         </div>
     </div>
-    {% if attachments %}
-        <div class="row">
-            <div class="col-xs-12">
-                {% include 'studies/_response_nav_tabs.html' with active="attachments" %}
-            </div>
+    <div class="row">
+        <div class="col-xs-12">
+            {% include 'studies/_response_nav_tabs.html' with active="attachments" %}
         </div>
+    </div>
+    {% if attachments %}
         <div class='row'>
              <div class="col-xs-12">
                  <span class="pull-right">

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -139,7 +139,8 @@
                                 <center class="mt-sm">
                                     <p><i aria-hidden="true" class="fa-2x fa fa-file-text-o"></i></p>
                                     <h4> View <strong>{{study.completed_responses_count|default:"0" }}</strong> Response{{ study.completed_responses_count|pluralize}}</h4>
-                                    <p> Inspect responses from completed studies </p>
+                                    <p> (plus {{study.incomplete_responses_count|default:"0" }} incomplete)</p>
+                                    <p> Inspect responses from study sessions </p>
                                 </center>
                             </div>
                          </a>

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -144,7 +144,7 @@
                       <strong><span class="hidden-sm">Last</span> Edited:</strong> {{ study.date_modified|date:"M d, Y" }}
                   </div>
 
-                  <a href="{% url 'exp:study-responses-list' study.id %}">
+                  <a href="{% url 'exp:study-responses-list' pk=study.id %}?{% query_transform request sort='-date_modified' %}">
                       <div class="col-sm-3">
                           <strong> Compl<span class="hidden-sm hidden-md">eted</span> Responses: </strong> {{ study.completed_responses_count }}
                       </div>

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -102,11 +102,7 @@
     </div>
     <div class="row">
         <div class="col-xs-12">
-            {% if responses %}
-                {% include 'studies/_response_nav_tabs.html' with active="individual" %}
-            {% else %}
-                <p class="pt-md"><em>No responses recorded! </em></p>
-            {% endif %}
+            {% include 'studies/_response_nav_tabs.html' with active="individual" %}
         </div>
     </div>
     {% if responses %}
@@ -194,6 +190,12 @@
                 </div>
             </div>
         </div>
+    {% else %}
+        <div class="row">
+        	<div class="col-xs-12">
+                <p class="pt-md"><em>No responses recorded!</em></p>
+        	</div>
+    	</div>
     {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
…ll response data upon page load. Put responses in reverse chronological order by default when viewing paginated. Minor formatting changes to show nav bar even when no responses present.