### PR TITLE
Reverting unhelpful commit

### DIFF
--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -107,7 +107,7 @@ def build_docker_image(player_addons_concat_sha, ember_prepend_replacement_strin
         [
             'docker',
             'build',
-            # '--pull',  # Perhaps we can get around the permissions bug this way?
+            '--pull',
             '--cache-from',
             f'ember_build:{player_addons_concat_sha}-{study_uuid}',
             '--build-arg',


### PR DESCRIPTION
Context: 
```
"image_build": "b'Sending build context to Docker daemon  10.58MB\\r\\r\\nStep 1/21 : FROM node:8-slim\\n ---> 54f6c4036aa5\\nStep 2/21 : ARG player_addons_concat_sha\\n ---> Running in d72c4a488cfa\\nsymlink XRamp_Global_CA_Root.pem /var/lib/docker/overlay/9cd06d5a622ac05dd858489b2e013e325e4bd2658af81a317ae8206643d827f9/tmproot407205009/etc/ssl/certs/76579174.0: no space left on device\\n'"
```

It looks like the actual problem is state diff between staging and dev. Where I am being sparse with containers and regularly `docker system prune`ing, staging has a bunch of cruft that is probably killing the disk.

I'll have to find a way to deal with this elegantly.