### PR TITLE
bypassing gpg nonsense by using debian repo for gosu

### DIFF
--- a/ember_build/Dockerfile
+++ b/ember_build/Dockerfile
@@ -18,17 +18,18 @@ RUN apt-get update \
         libffi-dev \
         python \
         python-dev \
-        python3-pip \
-    # gosu
-    && export GOSU_VERSION='1.10' \
-    && gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-    && gpg --verify /usr/local/bin/gosu.asc \
-    && rm /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # /gosu
-    && apt-get clean \
+        python3-pip
+
+# GOSU -- see https://github.com/tianon/gosu/blob/master/INSTALL.md
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y gosu; \
+	rm -rf /var/lib/apt/lists/*; \
+    # verify that the binary works
+	gosu nobody true
+
+# Clean up.
+RUN apt-get clean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && update-ca-certificates


### PR DESCRIPTION
Hopefully this fixes our issue with GPG key requests failing, thus allowing docker builds to complete.