### PR TITLE
bcc the sender address when emailing participants on Lookit; stopgap …

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -650,7 +650,7 @@ class StudyParticipantEmailView(
                 "custom_email",
                 subject,
                 settings.EMAIL_FROM_ADDRESS,
-                bcc=recipients,
+                bcc=recipients + [sender],
                 from_email=sender,
                 **context,
             )


### PR DESCRIPTION
…measure to allow researchers some record of what has already been sent, as per https://github.com/lookit/lookit-api/issues/241. If we can deploy this along with the merge-elf-and-exp-addons changes that would be great.