### PR TITLE
Fixing z-index clobber of summernote options bar with datatables popover

### DIFF
--- a/exp/static/exp/css/app.css
+++ b/exp/static/exp/css/app.css
@@ -544,8 +544,8 @@ span.hide-if-in-select-box {
 
 /** Overrides for summernote */
 
-.note-toolbar {
-    z-index: auto;  /* Otherwise, the DataTables copy button popup can get clobbered */
+.dt-button-info#datatables_buttons_info {
+    z-index: 2000;  /* Otherwise, the DataTables copy button popup can get clobbered */
 }
 
 


### PR DESCRIPTION
This is extremely small but annoying - hopefully we can find another way of dealing with this z-index mess. Too many block formatting contexts for one view! 😒 