### PR TITLE
Slug-based recipients introduced, email filter is now one-shot

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -14,6 +14,7 @@ from django.dispatch import receiver
 from django.conf import settings
 from django.template.loader import get_template
 from django.utils.html import mark_safe
+from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django_countries.fields import CountryField
 from guardian.mixins import GuardianUserMixin
@@ -226,15 +227,9 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
             return "No organization groups"
 
     @property
-    def default_email_preference_group(self):
-        return (
-            "Email Friendly"
-            if self.email_new_studies
-            and self.email_next_session
-            and self.email_response_questions
-            and self.email_study_updates
-            else "Email Discouraged"
-        )
+    def slug(self):
+        """Temporary workaround."""
+        return f"{slugify(self.nickname or 'anonymous')}-{str(self.uuid).split('-')[0]}"
 
     def _make_rainbow(self):
         rbw = []

--- a/exp/static/exp/css/app.css
+++ b/exp/static/exp/css/app.css
@@ -460,7 +460,9 @@ pre.individual-block {
 }
 
 
-/* Participant Contact */
+/*
+------- PARTICIPANT CONTACT FORM ---------
+*/
 #email-participants-form section.form-group {
     padding: 5px 10px;
 }
@@ -509,7 +511,11 @@ pre.individual-block {
     border-radius: 2px;
 }
 
-/* XXX: HACKS for bootstrap-select */
+/*
+-------- BOOTSTRAP-SELECT ---------
+*/
+
+/* We don't want to show the data-content stuff when it's inside the actual select box */
 .filter-option-inner-inner span.hide-if-in-select-box {
     display: none;
 }
@@ -519,6 +525,18 @@ span.hide-if-in-select-box {
     width: 70px;  /* ~4 small glyphicons */
 }
 
+/* Filter title stuff */
+#email-preference-filters {
+    width: 90%; /* space it out a little bit from the close button */
+    margin: auto; /* center it */
+}
+
+#email-preference-filters .input-group-addon {
+    width: 0; /* Ensure that the addon collapses onto the buttons */
+}
+
+
+/* Make sure selections w/ blue background white out the text */
 .dropdown-menu.open li.active span.hide-if-in-select-box span.glyphicon {
     color: white;
 }
@@ -527,6 +545,8 @@ span.hide-if-in-select-box {
     color: white;
 }
 
+
+/* Below is stuff for data-content */
 #email-participants-form .bootstrap-select .dropdown-menu li a span.text {
     width: 98%;
     margin: 2px;
@@ -542,8 +562,9 @@ span.hide-if-in-select-box {
     margin: 0;
 }
 
-/** Overrides for summernote */
-
+/*
+ -------- SUMMERNOTE ---------
+*/
 .dt-button-info#datatables_buttons_info {
     z-index: 2000;  /* Otherwise, the DataTables copy button popup can get clobbered */
 }
@@ -565,7 +586,6 @@ so we have to do this manually.
     transition: max-height 1s cubic-bezier(0, 1.05, 0, 1);
     -webkit-transition: max-height 1s cubic-bezier(0, 1.05, 0, 1);
     -moz-transition: max-height 1s cubic-bezier(0, 1.05, 0, 1);
-
     margin-bottom: 0;
     border: 0;
 }

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -704,6 +704,10 @@ class StudyParticipantContactView(
         return ctx
 
     def post(self, request, *args, **kwargs):
+        """Handles saving message and sending email.
+
+        TODO: enable mail merge with tokens.
+        """
         study = self.get_object()
 
         participant_uuids = request.POST.getlist("recipients")
@@ -721,7 +725,7 @@ class StudyParticipantContactView(
 
         outgoing_message.send_as_email()
 
-        messages.success(self.request, f'Message "{subject}"sent!')
+        messages.success(self.request, f'Message "{subject}" sent!')
         return HttpResponseRedirect(
             reverse("exp:study-participant-contact", kwargs=dict(pk=study.pk))
         )

--- a/studies/templates/studies/_recipient_select_content.html
+++ b/studies/templates/studies/_recipient_select_content.html
@@ -5,24 +5,24 @@ the plugin.
 {% endcomment %}
 
 <span class='hide-if-in-select-box'>
-    <span class='glyphicon glyphicon-calendar
-                 text-{% if recipient.email_next_session %}success email-friendly{% else %}danger{% endif %}'
+    <span class='glyphicon glyphicon-calendar text-muted
+                 {% if recipient.email_next_session %}email-friendly{% endif %}'
           data-filter='next-session'
           aria-hidden='true'></span>
 
-    <span class='glyphicon glyphicon-duplicate
-                 text-{% if recipient.email_new_studies %}success email-friendly{% else %}danger{% endif %}'
+    <span class='glyphicon glyphicon-duplicate text-muted
+                 {% if recipient.email_new_studies %}email-friendly{% endif %}'
           data-filter='new-studies'
           aria-hidden='true'></span>
-    <span class='glyphicon glyphicon-bullhorn
-                 text-{% if recipient.email_study_updates %}success email-friendly{% else %}danger{% endif %}'
+    <span class='glyphicon glyphicon-bullhorn text-muted
+                 {% if recipient.email_study_updates %}email-friendly{% endif %}'
           data-filter='study-updates'
           aria-hidden='true'></span>
 
-    <span class='glyphicon glyphicon-comment
-                 text-{% if recipient.email_response_questions %}success email-friendly{% else %}danger{% endif %}'
+    <span class='glyphicon glyphicon-comment text-muted
+                 {% if recipient.email_response_questions %}email-friendly{% endif %}'
           data-filter='response-questions'
           aria-hidden='true'></span>
 </span>
-<h5>{{ recipient.nickname }} <em class='small'>{{ recipient.uuid }}</em></h5>
+<h5>{{ recipient.slug }} <em class='small'>{{ recipient.uuid }}</em></h5>
 

--- a/studies/templates/studies/_recipient_select_filter_header.html
+++ b/studies/templates/studies/_recipient_select_filter_header.html
@@ -3,18 +3,23 @@ XXX: Only use single quotes in this file, as we're trying to pass it into the da
 bootstrap-select component. It's not really worth filing a bug, seeing as this is sane behavior on part of
 the plugin.
 {% endcomment %}
-<h5><em>Filter by email preferences</em></h5>
-<div id='email-preference-filters' class='btn-group btn-group-xs' role='group' aria-label='email-preference-filters'>
-    <button type='button' class='btn btn-default active' data-filter='next-session'>
-        <span class='glyphicon glyphicon-calendar' aria-hidden='true'></span> Next Session
-    </button>
-    <button type='button' class='btn btn-default active' data-filter='new-studies'>
-        <span class='glyphicon glyphicon-duplicate' aria-hidden='true'></span> New Studies
-    </button>
-    <button type='button' class='btn btn-default active' data-filter='study-updates'>
-        <span class='glyphicon glyphicon-bullhorn' aria-hidden='true'></span> Study Updates
-    </button>
-    <button type='button' class='btn btn-default active' data-filter='response-questions'>
-        <span class='glyphicon glyphicon-comment' aria-hidden='true'></span> Responses
-    </button>
+<div class='input-group input-group-sm' id='email-preference-filters' aria-label='email-preference-filters'>
+    <div class='input-group-btn'>
+        <button type='button' class='btn btn-default' data-filter='next-session'>
+            <span class='glyphicon glyphicon-calendar' aria-hidden='true'></span>
+        </button>
+        <button type='button' class='btn btn-default' data-filter='new-studies'>
+            <span class='glyphicon glyphicon-duplicate' aria-hidden='true'></span>
+        </button>
+        <button type='button' class='btn btn-default' data-filter='study-updates'>
+            <span class='glyphicon glyphicon-bullhorn' aria-hidden='true'></span>
+        </button>
+        <button type='button' class='btn btn-default' data-filter='response-questions'>
+            <span class='glyphicon glyphicon-comment' aria-hidden='true'></span>
+        </button>
+        <button type='button' class='btn btn-default active' data-filter='transactional-message'>
+            <span class='glyphicon glyphicon-transfer' aria-hidden='true'></span>
+        </button>
+    </div>
+    <span id='email-filter-name' class='bg-warning input-group-addon'>Transactional Message</span>
 </div>

--- a/studies/templates/studies/study_participant_contact.html
+++ b/studies/templates/studies/study_participant_contact.html
@@ -78,15 +78,15 @@
                                         data-col-value="{{ message.sender.uuid }}">{{ message.sender.get_full_name }}</td>
                                     <td>{{ message.subject }}</td>
                                     <td data-col-key="recipients"
-                                        data-col-value="{% values_list_as_json message.recipients.all "uuid" %}">
-                                        {% if message.recipients.all|length >= 4 %}
-                                            <span>{{ message.recipients.all|length }} Participants</span>
-                                        {% else %}
-                                            {% for recipient in message.recipients.all %}
-                                                <span>{{ recipient.nickname }}</span>{% if not forloop.last %},
-                                            {% endif %}
-                                            {% endfor %}
-                                        {% endif %}
+                                        data-col-value="{% values_list_as_json message.recipients.all "slug" %}">
+{#                                        {% if message.recipients.all|length >= 2 %}#}
+{#                                            <span>{{ message.recipients.all|length }} Participants</span>#}
+{#                                        {% else %}#}
+{#                                            {% for recipient in message.recipients.all %}#}
+{#                                                <span>{{ recipient.slug }}</span>{% if not forloop.last %},#}
+{#                                            {% endif %}#}
+{#                                            {% endfor %}#}
+{#                                        {% endif %}#}
                                     </td>
                                     <td>
                                         {{ message.date_created|localtime|date:"r" }}
@@ -124,7 +124,7 @@
                                                 class="selectpicker form-control"
                                                 multiple>
                                             {% for person in participants %}
-                                                <option value="{{ person.uuid }}">
+                                                <option value="{{ person.slug }}">
                                                     {{ person.nickname }}
                                                 </option>
                                             {% endfor %}
@@ -160,22 +160,20 @@
                                     class="selectpicker form-control"
                                     data-header="{% include "studies/_recipient_select_filter_header.html" %}"
                                     multiple>
-                                {% regroup participants by default_email_preference_group as grouped_participants %}
-                                {% for group, participants in grouped_participants %}
-                                    <optgroup class="{{ group|slugify }}" label="{{ group }}">
-                                        {% for person in participants %}
-                                            <option value="{{ person.uuid }}"
-                                                         data-content="{% include "studies/_recipient_select_content.html" with recipient=person %}"
-                                                         data-tokens="{{ person.uuid }}"
-                                                         {% if person.email_next_session %}data-email-next-session{% endif %}
-                                                         {% if person.email_new_studies %}data-email-new-studies{% endif %}
-                                                         {% if person.email_study_updates %}data-email-study-updates{% endif %}
-                                                         {% if person.email_response_questions %}data-email-response-questions{% endif %}>
-                                                {{ person.get_full_name }}
-                                            </option>
-                                        {% endfor %}
-                                    </optgroup>
-                                {% endfor %}
+                                <optgroup class="opted-in" label="Opted into email">
+                                    {% for person in participants %}
+                                        <option value="{{ person.uuid }}"
+                                                data-content="{% include "studies/_recipient_select_content.html" with recipient=person %}"
+                                                data-tokens="{{ person.nickname }}"
+                                                {% if person.email_next_session %}data-email-next-session{% endif %}
+                                                {% if person.email_new_studies %}data-email-new-studies{% endif %}
+                                                {% if person.email_study_updates %}data-email-study-updates{% endif %}
+                                                {% if person.email_response_questions %}data-email-response-questions{% endif %}>
+                                            {{ person.uuid }}
+                                        </option>
+                                    {% endfor %}
+                                </optgroup>
+                                <optgroup class="opted-out" label="Opted out of email"></optgroup>
                             </select>
                         </section>
                         <section class="form-group">
@@ -199,6 +197,11 @@
     {#  TODO: move this out to a javascript file so we can defer it!  #}
     <script type="text/javascript">
 
+        const EXPORT_OPTIONS = {
+            columns: ['sender:name', 'subject:name', 'recipients:name', 'sentDate:name', 'body:name'],
+            orthogonal: 'display',
+        };
+
         const DATATABLE_SETTINGS = {
             select: true,
             autoWidth: false,
@@ -211,14 +214,17 @@
                 {
                     extend: 'copy',
                     text: 'Copy to Clipboard',
+                    exportOptions: EXPORT_OPTIONS,
                 },
                 {
                     extend: 'excel',
                     text: 'Excel',
+                    exportOptions: EXPORT_OPTIONS,
                 },
                 {
                     extend: 'csv',
                     text: 'CSV',
+                    exportOptions: EXPORT_OPTIONS,
                 },
             ],
             fixedHeader: true,
@@ -351,14 +357,15 @@
         let MESSAGE_TABLE,
             DATE_RANGE_PICKER,
             RECIPIENT_SELECTOR,
-            $emailPreferenceFilters;
+            $emailPreferenceFilters,
+            $emailFilterNameBox;
 
         // Possibly move everything here later...
         const GLOBAL_QUERY_PARAMS = {
             after: moment().startOf("month"),
             before: moment(),
         };
-        
+
         /**
          * Main function.
          */
@@ -395,15 +402,20 @@
          */
         function initializeHeaderFilters() {
             $emailPreferenceFilters = $('#email-preference-filters');
+            $emailFilterNameBox = $emailPreferenceFilters.find('#email-filter-name');
 
             $emailPreferenceFilters.on('click', 'button', handleEmailPreferenceSelection);
         }
 
         function handleEmailPreferenceSelection() {
-            let currentFilter = $(this).toggleClass('active').data('filter'),  // also toggle button.
+            let $filterBtn = $(this);
+            // Treat this like a radio button set.
+            $filterBtn.addClass('active').siblings().removeClass('active');
+
+            let currentFilter = $filterBtn.data('filter'),
                 $allOptions = $recipientSelector.find('option').detach(),
-                $emailFriendlyGroup = $recipientSelector.find('optgroup.email-friendly'),
-                $doNotEmailGroup = $recipientSelector.find('optgroup.email-discouraged');
+                $emailFriendlyGroup = $recipientSelector.find('optgroup.opted-in'),
+                $doNotEmailGroup = $recipientSelector.find('optgroup.opted-out');
 
             // We have a list of active filters. Now iterate through each option, choose which group it should go
             // to, and prepare the options for re-rendering with mutated data-content.
@@ -419,19 +431,32 @@
                 // TODO: deliberate on whether or not it's worth it to put currentFilter into the accumulator object
                 // so that we can factor out this reducer method.
 
+                $allPreferenceBadges.removeClass('text-success text-danger');
+
+                $emailFilterNameBox.text(
+                    currentFilter.replace(/(\w+)-(\w+)/g,
+                        (match, first, second) => {
+                            return first.charAt(0).toUpperCase() + first.slice(1) +
+                                   ' ' + second.charAt(0).toUpperCase() + second.slice(1);
+                        }));
                 // Switch the context class based on whether or not it's a positive indicator
-                if ($targetPreferenceBadge.hasClass('email-friendly')) {
-                    $targetPreferenceBadge.toggleClass('text-success text-muted');
+                if (!$targetPreferenceBadge.length) {
+                    $allPreferenceBadges.addClass('text-muted');
+                } else if ($targetPreferenceBadge.hasClass('email-friendly')) {
+                    $targetPreferenceBadge.addClass('text-success');
                 } else {
-                    $targetPreferenceBadge.toggleClass('text-danger text-muted');
+                    $targetPreferenceBadge.addClass('text-danger');
                 }
 
-                // If we've got no red flags, we can suggest emailing them.
-                if (!$allPreferenceBadges.is('.text-danger')) {
+                // Sort according to flag. Duplicated logic because it's still unclear as to whether or not we should
+                // break out styling vs sorting for such a simple thing.
+                if (!$targetPreferenceBadge.length || $targetPreferenceBadge.hasClass('email-friendly')) {
                     emailPreferenceBuckets[0].push(option);
+                    option.removeAttribute('disabled');
                 } else {
                     emailPreferenceBuckets[1].push(option);
                     option.removeAttribute('selected');
+                    option.setAttribute('disabled', true);
                 }
 
                 option.setAttribute('data-content', $oldContentDom[0].innerHTML);
@@ -475,7 +500,7 @@
         /**
          * Filter DataTable results based on sender input.
          */
-        function handleSenderFiltering({#$jqEvent, clickedIndex, isSelected, previousValue #}) {
+        function handleSenderFiltering({# $jqEvent, clickedIndex, isSelected, previousValue #}) {
 
             let senders = $(this).val(),
                 searchValue = senders ? senders.map(s => $.fn.dataTable.util.escapeRegex(s)).join('|') : "";
@@ -503,14 +528,18 @@
                     row.recipientsDisplay = value;
                     return;
                 case 'display':
-                    return row.recipientsDisplay;
+                    if (!row.$jqRow) {
+                        row.$jqRow = $(meta.settings.nTBody.children.item(meta.row));
+                    }
+                    row.recipientUuidArray = row.recipientUuidArray ||
+                        row.$jqRow.find("td[data-col-key='recipients']").data()['colValue'];
+                    return row.recipientUuidArray;
                 case 'filter':
                     if (!row.$jqRow) {
                         row.$jqRow = $(meta.settings.nTBody.children.item(meta.row));
                     }
                     row.recipientUuidArray = row.recipientUuidArray ||
                         row.$jqRow.find("td[data-col-key='recipients']").data()['colValue'];
-
                     return row.recipientUuidArray.join(" "); // Regex will successfully execute against this!
                 case 'sort':
                     return row.recipients;


### PR DESCRIPTION
1) You can now only filter by one email preference at a time.
2) recipient filtering still happens with uuid in the "back end" (i.e. in DataTables' internals), however, presentation uses a demi-slug that we're using until we decide on a real slug-generating methodology.