### PR TITLE
more intuitive/reasonable default date filtering behavior

### DIFF
--- a/studies/templates/studies/study_participant_contact.html
+++ b/studies/templates/studies/study_participant_contact.html
@@ -397,7 +397,7 @@
 
         // Possibly move everything here later...
         const GLOBAL_QUERY_PARAMS = {
-            after: moment().startOf("month"),
+            after: moment().subtract(29, 'days'),
             before: moment(),
         };
 


### PR DESCRIPTION
This fixes a subtle UX bug - default date filter should encapsulate _the past thirty days_, not from the start of the month. 