### PR TITLE
Bugfix/fix all responses json downloads

### DIFF
--- a/exp/mixins/study_responses_mixin.py
+++ b/exp/mixins/study_responses_mixin.py
@@ -185,7 +185,7 @@ class StudyResponsesMixin(
                     "consent_information": resp.current_consent_details,
                 }
             )
-        return json.dumps(json_responses, indent=4, default=str)
+        return json_responses
 
     def csv_output_and_writer(self):
         output = io.StringIO()

--- a/exp/mixins/study_responses_mixin.py
+++ b/exp/mixins/study_responses_mixin.py
@@ -156,40 +156,36 @@ class StudyResponsesMixin(
         json_responses = []
         for resp in responses:
             json_responses.append(
-                json.dumps(
-                    {
-                        "response": {
-                            "id": resp.id,
-                            "uuid": str(resp.uuid),
-                            "sequence": resp.sequence,
-                            "conditions": resp.conditions,
-                            "exp_data": resp.exp_data,
-                            "global_event_timings": resp.global_event_timings,
-                            "completed": resp.completed,
-                            "withdrawn": resp.withdrawn,
-                        },
-                        "study": {"id": resp.study.id, "uuid": str(resp.study.uuid)},
-                        "participant": {
-                            "id": resp.child.user_id,
-                            "uuid": str(resp.child.user.uuid),
-                            "nickname": resp.child.user.nickname,
-                        },
-                        "child": {
-                            "id": resp.child.id,
-                            "uuid": str(resp.child.uuid),
-                            "name": resp.child.given_name,
-                            "birthday": resp.child.birthday,
-                            "gender": resp.child.gender,
-                            "age_at_birth": resp.child.age_at_birth,
-                            "additional_information": resp.child.additional_information,
-                        },
-                        "consent_information": resp.current_consent_details,
+                {
+                    "response": {
+                        "id": resp.id,
+                        "uuid": str(resp.uuid),
+                        "sequence": resp.sequence,
+                        "conditions": resp.conditions,
+                        "exp_data": resp.exp_data,
+                        "global_event_timings": resp.global_event_timings,
+                        "completed": resp.completed,
+                        "withdrawn": resp.withdrawn,
                     },
-                    indent=4,
-                    default=self.convert_to_string,
-                )
+                    "study": {"id": resp.study.id, "uuid": str(resp.study.uuid)},
+                    "participant": {
+                        "id": resp.child.user_id,
+                        "uuid": str(resp.child.user.uuid),
+                        "nickname": resp.child.user.nickname,
+                    },
+                    "child": {
+                        "id": resp.child.id,
+                        "uuid": str(resp.child.uuid),
+                        "name": resp.child.given_name,
+                        "birthday": resp.child.birthday,
+                        "gender": resp.child.gender,
+                        "age_at_birth": resp.child.age_at_birth,
+                        "additional_information": resp.child.additional_information,
+                    },
+                    "consent_information": resp.current_consent_details,
+                }
             )
-        return json_responses
+        return json.dumps(json_responses, indent=4, default=str)
 
     def csv_output_and_writer(self):
         output = io.StringIO()

--- a/exp/templatetags/exp_extras.py
+++ b/exp/templatetags/exp_extras.py
@@ -40,3 +40,8 @@ def values_list_as_json(queryset, attribute):
         ),
         default=str,
     )
+
+
+@register.filter
+def pretty_json(value):
+    return json.dumps(value, indent=4, default=str)

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -915,7 +915,7 @@ class StudyBuildView(
 
 class StudyResponsesList(StudyResponsesMixin, generic.DetailView, PaginatorMixin):
     """
-    Study Responses View allows user to view individual responses to a study.
+    View to acquire a list of study responses.
     """
 
     template_name = "studies/study_responses.html"
@@ -1153,7 +1153,9 @@ class StudyResponsesAllDownloadJSON(StudyResponsesMixin, generic.DetailView):
     def get(self, request, *args, **kwargs):
         study = self.get_object()
         responses = study.consented_responses.order_by("id")
-        cleaned_data = self.build_responses(responses)
+        cleaned_data = json.dumps(
+            self.build_responses(responses), indent=4, default=str
+        )
         filename = "{}-{}.json".format(study.name, "all_responses")
         response = HttpResponse(cleaned_data, content_type="text/json")
         response["Content-Disposition"] = 'attachment; filename="{}"'.format(filename)

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -1153,7 +1153,7 @@ class StudyResponsesAllDownloadJSON(StudyResponsesMixin, generic.DetailView):
     def get(self, request, *args, **kwargs):
         study = self.get_object()
         responses = study.consented_responses.order_by("id")
-        cleaned_data = ", ".join(self.build_responses(responses))
+        cleaned_data = self.build_responses(responses)
         filename = "{}-{}.json".format(study.name, "all_responses")
         response = HttpResponse(cleaned_data, content_type="text/json")
         response["Content-Disposition"] = 'attachment; filename="{}"'.format(filename)

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -158,7 +158,7 @@
                 </a>
                 {% for response in response_data %}
                     <div class='response-data' id='response-data-{{ forloop.counter }}' style="display:none">
-                        <pre class='json-data individual-block' id='json-data-{{ forloop.counter }}'>{{ response }}</pre>
+                        <pre class='json-data individual-block' id='json-data-{{ forloop.counter }}'>{{ response | pretty_json }}</pre>
                     </div>
                 {% endfor %}
                 {% for csv in csv_data %}


### PR DESCRIPTION
Someone hacked this out in a very silly way, and somehow the work never got checked. The individual response objects were being serialized into json _strings_ before rendering them into the template context - probably because someone couldn't figure out how to have individual objects pretty-print in the `<pre>` part of the template.

Now, we use a template tag to do what a template tag is supposed to do: render aesthetic changes in the view.

Now, people can actually download all their responses as JSON and have other programs read them.