### PR TITLE
Preclude meaningless getter call by forcing non-null/undefined value

### DIFF
--- a/studies/templates/studies/study_responses_consent_ruling.html
+++ b/studies/templates/studies/study_responses_consent_ruling.html
@@ -181,7 +181,7 @@
             function updateResponseDataSection(responseData) {
                 let details = responseData["details"];
                 let expData = details["exp_data"];
-                $responseDataSection.find("#exp-data").html(JSON.stringify(expData, undefined, 2));
+                $responseDataSection.find("#exp-data").html(JSON.stringify(expData, undefined, 2) || "No data");
 
                 $generalRow.empty();
                 $generalRow.append(Array.from(Object.values(details["general"]), val => $(`<td>${val}</td>`)));


### PR DESCRIPTION
Ah, the joys of javascript/jQuery.

Per the API documentation for the .html() method (https://api.jquery.com/html/), an undefined first argument will "dispatch" the getter behavior rather than the setter behavior. We are forcing a value to make sure that the setter is always dispatched.