### PR TITLE
add a researcher login link at the bottom for people who are willing …

### DIFF
--- a/web/templates/flatpages/default.html
+++ b/web/templates/flatpages/default.html
@@ -56,6 +56,7 @@
 						<ul>
 						<li><a href="/privacy/">Privacy</a></li>
 						<li><a href="/contact_us/">Contact us</a></li>
+						<li><a href="{% url 'exp:study-list' %}">Researcher login</a></li>
 						<li>Connect: 
 						<a href="https://www.facebook.com/lookit.mit.edu" target="_blank"><i class="fa fa-facebook fa-lg social-link"></i> </a>
 						<a href="https://www.instagram.com/babiesoflookit/" target="_blank"><i class="fa fa-instagram fa-lg social-link"></i> </a>


### PR DESCRIPTION
Because people remain confused about this no matter how many times I say that they need to go to [prod/staging]/exp/ to log in. I don't necessarily want to make it more prominent or include info in the participant login, because with substantially more participants than researchers we will end up confusing more people total, but some link on the page may be a reasonable compromise.