### PR TITLE
properly align date bins on registration graphs

### DIFF
--- a/studies/templates/studies/study_participant_analytics.html
+++ b/studies/templates/studies/study_participant_analytics.html
@@ -554,7 +554,6 @@
 
             let [cumulativeSeriesComplete, binnedSeries] = generateRegistrationTimeseries(interval);
 
-            // Capturing some of the get() behavior here since we're not
             let cumulativeSeriesPast = cumulativeSeriesComplete.filter(
                 observation => start.isAfter(observation["date"])
             );
@@ -645,7 +644,9 @@
             return RAW_REGISTRATION_DATA.reduce(
                 ([cumulativeSeries, binnedSeries], timestamp) => {
                     // We do not bin for cumulative timeseries.
-                    let observedDate = moment(timestamp).startOf("day").toDate();
+                    let currentDateAsMoment = moment(timestamp);
+                    let observedDate = currentDateAsMoment.startOf("day").toDate();
+                    let observedBin = currentDateAsMoment.startOf(interval).toDate();
 
                     let previousCumulativeObservation = cumulativeSeries.slice(-1)[0];
 
@@ -664,20 +665,19 @@
                     let previousBinnedObservation = binnedSeries.slice(-1)[0];
 
                     if (previousBinnedObservation) {
-                        let currentDateAsMoment = moment(observedDate);
                         if (currentDateAsMoment.isSame(previousBinnedObservation.date, interval)) {
                             // Same day, so just add.
                             previousBinnedObservation.value += 1;
                         } else {
                             // Add new data point.
                             binnedSeries.push({
-                                date: observedDate,
+                                date: observedBin,
                                 value: 1,
                             });
                         }
                     } else {
                         binnedSeries.push({
-                            date: observedDate,
+                            date: observedBin,
                             value: 1,
                         });
                     }


### PR DESCRIPTION
This is an attempt to fix the improper binned graph rendering that doesn't show nearly the amount of variation that it should