### PR TITLE
Reduce query load by using .values()

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -209,7 +209,7 @@ class Study(models.Model):
                 models.Prefetch(
                     "videos",
                     queryset=Video.objects.filter(is_consent_footage=True),
-                    to_attr="consent_videos",
+                    # to_attr="consent_videos",
                 ),
                 "consent_rulings",
             )

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -41,7 +41,7 @@ def get_annotated_responses_qs(include_comments=False):
 
 
 def get_responses_with_current_rulings_and_videos(study_id):
-    """Gets all the responses for a given study, including the current ruling and videos.
+    """Gets all the responses for a given study, including the current ruling and consent videos.
 
     Args:
         study_id: The study ID related to the responses we want.

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -90,8 +90,9 @@ def get_responses_with_current_rulings_and_videos(study_id):
     )
 
     # See: https://code.djangoproject.com/ticket/26565
-    #     The inability to use values() and prefetch in tandem without combinatorial
-    #     explosion of result set is precluding us from being efficient about this.
+    #     The inability to use values() and prefetch_related in tandem without
+    #     combinatorial explosion of result set is precluding us from relying on
+    #     django's join machinery. Instead, we need to manually join here.
     consent_videos = Video.objects.filter(study_id=study_id, is_consent_footage=True)
     videos_per_response = defaultdict(list)
     for video in consent_videos:

--- a/studies/templates/studies/study_responses_consent_ruling.html
+++ b/studies/templates/studies/study_responses_consent_ruling.html
@@ -351,20 +351,20 @@
                     <ul id="list-of-responses" class="list-group">
                         {% for response in loaded_responses %}
                             <li id="response-option-{{ response.uuid }}"
-                                class="response-option list-group-item {{ response.most_recent_ruling }} {% if response.withdrawn %}withdrawn{% endif %}"
+                                class="response-option list-group-item {{ response.current_ruling }} {% if response.withdrawn %}withdrawn{% endif %}"
                                 data-id="{{ response.uuid }}"
-                                data-original-status="{{ response.most_recent_ruling }}">
+                                data-original-status="{{ response.current_ruling }}">
                                 <span>
                                     <strong>{{ response.date_created | date:"D F d, P e" }}</strong>
                                     <p>
-                                        <em class="small">{% if response.withdrawn %}Withdrawn. {% endif %}{{ response.comment_or_reason_for_absence }}</em>
+                                        <em class="small">{% if response.withdrawn %}Withdrawn. {% endif %}{{ response.ruling_comments }}</em>
                                     </p>
                                 </span>
                                 <div class="btn-group btn-group-sm pull-right" role="group">
                                     <button id="response-actor-{{ response.uuid }}" type="button"
                                             class="btn btn-default dropdown-toggle response-actor"
                                             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        {{ response.most_recent_ruling }}
+                                        {{ response.current_ruling }}
                                         <span class="caret"></span>
                                         <span class="sr-only">Toggle Dropdown</span>
                                     </button>
@@ -374,17 +374,17 @@
                                             <a class="consent-judgment" data-action="reset"
                                                style="display:none;">Undo</a>
                                         </li>
-                                        {% if not response.pending_consent_judgement %}
+                                        {% if response.current_ruling != 'pending' %}
                                             <li>
                                                 <a class="consent-judgment" data-action="pending">Revert to Pending</a>
                                             </li>
                                         {% endif %}
-                                        {% if not response.has_valid_consent %}
+                                        {% if response.current_ruling != 'accepted' %}
                                             <li>
                                                 <a class="consent-judgment" data-action="accepted">Accept</a>
                                             </li>
                                         {% endif %}
-                                        {% if not response.currently_rejected %}
+                                        {% if response.current_ruling != 'rejected' %}
                                             <li>
                                                 <a class="consent-judgment" data-action="rejected">Reject</a>
                                             </li>


### PR DESCRIPTION
The tricky part here was in dealing with the related videos - we still
have to do a bit of testing to see if there's no way to keep the
prefetch as it existed rather than doing the manual join in our app
code.

We've also lost some slight distinction in Consent Ruling comments
between "no previous ruling" and "no comment in previous ruling" due to
the nature of the optimized query.