### PR TITLE
downgrade base queryset in view

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -909,7 +909,7 @@ class StudyResponsesConsentManager(
     """Manage videos from here."""
 
     template_name = "studies/study_responses_consent_ruling.html"
-    queryset = Study.objects.prefetch_related("responses", "videos")
+    queryset = Study.objects.all()
     permission_required = "studies.can_view_study_responses"
     raise_exception = True
 


### PR DESCRIPTION
We are using `get_responses_with_current_rulings_and_videos` as the base queryset, effectively - in fact it might make sense to transition this entire view to being based off a ListView at some point and get rid of the study query altogether.

For now, let's just give it a little speed-up.