### PR TITLE
detect consent footage in pipe hook, when creating video object, rath…

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -947,7 +947,7 @@ class Video(models.Model):
             except Response.DoesNotExist as ex:
                 logger.error(f"Response with uuid {response_uuid} does not exist. {ex}")
                 raise
-                
+
             frame_type = response.exp_data.get(frame_id, {}).get("frameType", "")
 
             return cls.objects.create(
@@ -959,7 +959,7 @@ class Video(models.Model):
                 full_name=new_full_name,
                 study=study,
                 response=response,
-                is_consent_footage=(frame_type=="CONSENT"),
+                is_consent_footage=(frame_type == "CONSENT"),
             )
 
     @cached_property

--- a/studies/models.py
+++ b/studies/models.py
@@ -947,6 +947,8 @@ class Video(models.Model):
             except Response.DoesNotExist as ex:
                 logger.error(f"Response with uuid {response_uuid} does not exist. {ex}")
                 raise
+                
+            frame_type = response.exp_data.get(frame_id, {}).get("frameType", "")
 
             return cls.objects.create(
                 pipe_name=old_pipe_name,
@@ -957,7 +959,7 @@ class Video(models.Model):
                 full_name=new_full_name,
                 study=study,
                 response=response,
-                is_consent_footage=False,
+                is_consent_footage=(frame_type=="CONSENT"),
             )
 
     @cached_property


### PR DESCRIPTION
…er than immediately upon consent frame being saved (will deprecate that helper) - at that point the video object hasn't been created yet.