### PR TITLE
Develop

### DIFF
--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -100,16 +100,25 @@ class FrameActionDispatcher(object):
             pass
 
     def consent(self, response, frame_data: dict, current_frame_id, *args, **kwargs):
-        """What do do upon saving data from a consent frame. Could eventually set
-        completed_consent_frame on the response here, rather than relying on ember-lookit-
-        frameplayer to provide that. Note that we can't mark the consent VIDEOS as 
-        is_consent_footage here, because the Video object doesn't exist yet - it will take
-        a second or two before Pipe sends it to S3, so that's handled upon Video creation
-        in from_pipe_payload. 
+        """Upon saving data from a consent frame, mark the video collected as consent footage.
+        This means the participant will have to proceed from the consent frame before 
+        consent footage is accessible to researchers. Video model is ALSO marked as consent
+        footage upon creation if exp_data already has the consent frame added. This hook
+        covers the case where the Video is created first and then exp_data is updated; that
+        hook covers the case where exp_data is updated before the Video model is created.
         
         Args:
             response: Response Model.
             frame_data: dictionary of frame data.
             current_frame_id: ID of the current frame (e.g. 1-my-video-consent)
         """
-        pass
+        for video in response.videos.filter(frame_id=current_frame_id):
+            video.is_consent_footage = True
+            video.save()
+        # Using frame_id as likely to be most robust, even with slightly convoluted generation
+        # of frame IDs during randomizer-generated frames (there should at least never be
+        # duplicate frame IDs because of the incrementing frame number at the start of the
+        # ID). But alternative in case needed in future is to use video filenames -
+        # video.full_name includes extension (.mp4), videoList is filename w/o extension:
+        #
+        # if any([consentFilename in video.full_name for consentFilename in frame_data.get("videoList", [])]):

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -1,5 +1,3 @@
-from unittest import skip
-
 from django.conf import settings
 from django.test import TestCase
 from django_dynamic_fixture import G
@@ -128,9 +126,6 @@ class ResponseSaveHandlingTestCase(TestCase):
         )
 
     # Test labeling of current consent type frame video(s) as consent
-    @skip(
-        "Should now test this in a new test of from_pipe_payload, as is_consent_footage isn't set upon response save"
-    )
     def testMarkConsentTypeVideoAsConsent(self):
         self.response_after_consent_frame.save()  # to run post-save hook
         consent_video = Video.objects.get(pk=self.consent_video.pk)

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -1,3 +1,5 @@
+from unittest import skip
+
 from django.conf import settings
 from django.test import TestCase
 from django_dynamic_fixture import G
@@ -126,6 +128,9 @@ class ResponseSaveHandlingTestCase(TestCase):
         )
 
     # Test labeling of current consent type frame video(s) as consent
+    @skip(
+        "Should now test this in a new test of from_pipe_payload, as is_consent_footage isn't set upon response save"
+    )
     def testMarkConsentTypeVideoAsConsent(self):
         self.response_after_consent_frame.save()  # to run post-save hook
         consent_video = Video.objects.get(pk=self.consent_video.pk)


### PR DESCRIPTION
It turns out the original fix would probably cover 99% of cases and the changes just hadn't been deployed on master. (The earlier solution of detecting consent footage ONLY in the post-save hook probably worked one time because the pipe upload was slow, the consent page didn't proceed automatically, I had to click to proceed, and then the Video model actually existed upon save.) BUT it's still a good idea to cover both orders in any event, so here we go. 