### PR TITLE
Always use PNG favicon with redirect view

### DIFF
--- a/project/urls.py
+++ b/project/urls.py
@@ -26,7 +26,10 @@ from osf_oauth2_adapter import views as osf_oauth2_adapter_views
 from project import settings
 from web import urls as web_urls
 
+favicon_view = RedirectView.as_view(url="/static/favicon.png", permanent=True)
+
 urlpatterns = [
+    url(r"^favicon\.png$", favicon_view),
     url(r"^admin/", admin.site.urls),
     url(r"^api/", include(api_urls)),
     url(
@@ -44,14 +47,10 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    favicon_view = RedirectView.as_view(url="/static/favicon.png", permanent=True)
     import debug_toolbar
 
     urlpatterns = (
-        [
-            url(r"^favicon\.png$", favicon_view),
-            url(r"^__debug__/", include(debug_toolbar.urls)),
-        ]
+        [url(r"^__debug__/", include(debug_toolbar.urls))]
         + urlpatterns
         + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     )


### PR DESCRIPTION
In the old clusters, we had an nginx reverse proxy handling the path for
the favicon. To replicate this old functionality the same way, we'd need
to create an entirely new ingress rule to redirect to the old favicon.ico file.

Considering the fact that we already have the PNG in our staging bucket,
we're just going to let django handle this redirect.