### PR TITLE
explicitly choose appropriate on_delete behavior for accounts, studies models

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -1661,13 +1661,8 @@ class StudyResponsesAll(
         for page_num in paginator.page_range:
             page_of_responses = paginator.page(page_num)
             for resp in page_of_responses:
-                # First delete the things that point to the response to avoid db integrity
-                # errors
-                resp.responselog_set.all().delete()
-                resp.consent_rulings.all().delete()
-                resp.feedback.all().delete()
-                for vid in resp.videos.all():
-                    vid.delete(delete_in_s3=True)  # actually delete video
+                # response logs, consent rulings, feedback, videos will all be deleted 
+                # via cascades - videos will be removed from S3 also on pre_delete hook
                 resp.delete()
         return super().get(request, *args, **kwargs)
 

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -90,7 +90,7 @@ class FrameActionDispatcher(object):
         withdrawal = frame_data.get("withdrawal", None)
         if withdrawal:
             for video in response.videos.filter(is_consent_footage=False):
-                video.delete(delete_in_s3=True)
+                video.delete()
         elif withdrawal is None:
             logger.warning(
                 f"withdrawal property not found in exit frame for {response}"

--- a/studies/models.py
+++ b/studies/models.py
@@ -103,7 +103,7 @@ class Study(models.Model):
     comments = models.TextField(blank=True, null=True)
     study_type = models.ForeignKey(
         "StudyType",
-        on_delete=models.SET_NULL,
+        on_delete=models.PROTECT,
         null=False,
         blank=False,
         verbose_name="type",


### PR DESCRIPTION
I skipped the Organization-related ones since we plan to change/remove that model anyway.

Thoughts welcome on how this *should* work. My main motivations are:

- I'd like to be able to manually (via Admin) delete old test studies and responses, especially on staging, to clean things out periodically. Right now that involves manually going through study logs, responses, Videos, consent rulings, etc. and making sure I've gotten everything (in a particular order!), plus going to S3 if I'm feeling ambitious.
- I'd like to make sure we're in a good position to (still manually) delete data if requested by a participant. (We can refine this behavior later in the automated-GDPR-tools ticket.)