### PR TITLE
actually allow viewing all shared-preview studies through API if rese…

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -232,9 +232,9 @@ class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
 
     def get_queryset(self):
         """
-        Shows studies that are either 1) active or 2) studies you have permission to edit.
+        Shows studies that are either 1) active or 2) studies you have permission to preview.
 
-        "can_edit_study" permissions allows the researcher to preview the study before it has been made active/public
+        "can_view_study" permissions allows the researcher to preview the study before it has been made active/public
         """
         qs = (
             super()
@@ -246,10 +246,11 @@ class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
         if "List" in self.get_view_name():
             qs = qs.filter(public=True)
 
+        # Researchers
         if self.request.user.is_researcher:
-            preview_studies = qs.filter(shared_preview=True) | get_objects_for_user(
-                self.request.user, "studies.can_edit_study"
-            )
+            preview_studies = Study.objects.filter(
+                shared_preview=True
+            ) | get_objects_for_user(self.request.user, "studies.can_view_study")
             qs = qs | preview_studies
 
         return qs.distinct().order_by("-date_modified")


### PR DESCRIPTION
…archer, and any studies with can_view (not can_edit) permissions; expand tests of studies api