### PR TITLE
Feature/drop docker cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,21 +18,7 @@ RUN apt-get update \
         pkg-config \
         curl \
         gosu \
-        # libmagic-dev \
-    # Docker
-    && export DOCKER_CHANNEL=stable \
-    && export DOCKER_VERSION=17.06.1-ce \
-    && export DOCKER_SHA256=e35fe12806eadbb7eb8aa63e3dfb531bda5f901cd2c14ac9cdcd54df6caed697 \
-    && curl -o /tmp/docker.tgz -SL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" \
-    && echo "$DOCKER_SHA256  /tmp/docker.tgz" | sha256sum -c - \
-    && tar --extract --file /tmp/docker.tgz --strip-components 1 --directory /usr/local/bin/ \
-    && rm /tmp/docker.tgz \
-    && dockerd -v \
-    && docker -v \
-    # /Docker
-    # gosu, verify that it works
     && gosu nobody true \
-    # /gosu
     && apt-get clean \
     && apt-get autoremove -y \
         curl \

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -21,7 +21,7 @@
                 "sha256:24dbaff8ce4f30566bb88976b398e8c4e77637171af3af6f1b9650f48890e60b",
                 "sha256:bb68f8d2bced8f93ccfd07d96c689b716b3227720add971be980accfc2952139"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.6.0"
         },
         "asgiref": {
@@ -165,7 +165,7 @@
                 "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
                 "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.6.0"
         },
         "django": {
@@ -417,7 +417,7 @@
                 "sha256:97155236971970382b738921f978a6f86a7b5a0b0311703d991e065d3cb55773",
                 "sha256:cdc64378dc9a7a7bf963a8d0c944c99b549dc0c195a9acbf1fcd465f380b9002"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.5.1"
         },
         "googleapis-common-protos": {
@@ -525,7 +525,7 @@
                 "sha256:f69e0f7b7c09f1f612b1f8f59e2df72faa8a6b41c5a436dde5b615aaf948f107",
                 "sha256:faa42a78d1350b02a7d2f0dbe3c80791cf785663d6997891549d0f86dc49125e"
             ],
-            "markers": "python_version >= '3.6.1'",
+            "markers": "python_full_version >= '3.6.1'",
             "version": "==1.0.5"
         },
         "pillow": {
@@ -881,7 +881,7 @@
                 "sha256:1ccf53320421aeeb915275a196e23b3b8ae87dea8ac6698b1638001d4a486d53",
                 "sha256:c8e8f552ffcc6194f4e18dd4f68d9aef0c0d58ae7e7be8c82bee3c5e9edfa513"
             ],
-            "markers": "python_version >= '3.6.1'",
+            "markers": "python_full_version >= '3.6.1'",
             "version": "==3.1.0"
         },
         "click": {
@@ -889,7 +889,7 @@
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
         "cryptography": {
@@ -914,7 +914,7 @@
                 "sha256:e993468c859d084d5579e2ebee101de8f5a27ce8e2159959b6673b418fd8c785",
                 "sha256:f118a95c7480f5be0df8afeb9a11bd199aa20afab7a96bcf20409b411a3a85f0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.9.2"
         },
         "decorator": {
@@ -1028,7 +1028,7 @@
                 "sha256:1ddb0ec78059e8e27ec9eb5098360b4ea0a3dd840bedf21415ea820c21b40a22",
                 "sha256:807d5d4f96711a2bcfdd5dfa3b1ae6d09aa53832b182090b222b5efb81f52f63"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.17.1"
         },
         "nodeenv": {
@@ -1086,7 +1086,7 @@
                 "sha256:563d1a4140b63ff9dd587bda9557cffb2fe73650205ab6f4383092fb882e7dc8",
                 "sha256:df7e9e63aea609b1da3a65641ceaf5bc7d05e0a04de5bd45d05dbeffbabf9e04"
             ],
-            "markers": "python_version >= '3.6.1'",
+            "markers": "python_full_version >= '3.6.1'",
             "version": "==3.0.5"
         },
         "ptpython": {

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -3,9 +3,7 @@ import datetime
 import hashlib
 import logging
 import os
-import re
 import shutil
-import subprocess
 import tempfile
 import time
 import zipfile
@@ -96,12 +94,7 @@ def cleanup_checkouts(older_than=None):
 @app.task
 def cleanup_docker_images():
     logger.debug("Cleaning up docker images...")
-    images = subprocess.run(
-        ["docker", "images", "--quiet", "--filter", "dangling=true"],
-        stdout=subprocess.PIPE,
-    )
-    for image in images.stdout.splitlines():
-        subprocess.run(["docker", "rmi", "--force", image])
+    DOCKER_CLIENT.images.prune(filters={"dangling": True})
 
 
 @app.task(bind=True, max_retries=10, retry_backoff=10)


### PR DESCRIPTION
Dropping the CLI reduces the weight of our app image while also reducing potential security holes that occur by way of the docker daemon's presence on every lookit-api container.