### PR TITLE
let study admins change study status! (tests to come along with study…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,9 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
       - id: black
-        language_version: python3.6
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-black = "==18.9b0"
+black = "==19.10b0"
 django-debug-toolbar = "==2.2"
 django-pdb = "==0.6.2"
 django-shells = "==0.1.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d8531069c9ab057786a1300a9e91e34c8309ece1ebbb4ec3dafbfc2d9402ed10"
+            "sha256": "06c8a60fbf1e7391058bb0e74d5e1b2e94def21849b93050ae0264661b7707d5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -85,18 +85,18 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:b22db58da273b77529edef71425f9c281bc627b1b889f81960750507238abbb8",
-                "sha256:cb0d7511a68439bf6f16683489130e06c5bbf9f5a9d647e0cbf63d79f3d3bdaa"
+                "sha256:45934d880378777cefeca727f369d1f5aebf6b254e9be58e7c77dd0b059338bb",
+                "sha256:a94e0e2307f1b9fe3a84660842909cd2680b57a9fc9fb0c3a03b0afb2eadbe21"
             ],
-            "version": "==1.17.10"
+            "version": "==1.17.12"
         },
         "cachetools": {
             "hashes": [
-                "sha256:1d057645db16ca7fe1f3bd953558897603d6f0b9c51ed9d11eb4d071ec4e2aab",
-                "sha256:de5d88f87781602201cde465d3afe837546663b168e8b39df67411b0bf10cefc"
+                "sha256:513d4ff98dd27f85743a8dc0e92f55ddb1b49e060c2d5961512855cda2c01a98",
+                "sha256:bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20"
             ],
             "markers": "python_version ~= '3.5'",
-            "version": "==4.1.0"
+            "version": "==4.1.1"
         },
         "celery": {
             "hashes": [
@@ -690,10 +690,10 @@
         },
         "python3-openid": {
             "hashes": [
-                "sha256:0086da6b6ef3161cfe50fb1ee5cceaf2cda1700019fda03c2c5c440ca6abe4fa",
-                "sha256:628d365d687e12da12d02c6691170f4451db28d6d68d050007e4a40065868502"
+                "sha256:33fbf6928f401e0b790151ed2b5290b02545e8775f982485205a066f874aaeaf",
+                "sha256:6626f771e0417486701e0b4daff762e7212e820ca5b29fcc0d05f6f8736dfa6b"
             ],
-            "version": "==3.1.0"
+            "version": "==3.2.0"
         },
         "pytz": {
             "hashes": [
@@ -837,11 +837,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:817243426042db1d36617910df579a54f1afd659adb96fc5032fcf4b36209739",
-                "sha256:e030a9a28f542debc08acceb273f228ac422798e5215ba2a791a6ddeaaca22a5"
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
             ],
             "index": "pypi",
-            "version": "==18.9b0"
+            "version": "==19.10b0"
         },
         "cffi": {
             "hashes": [
@@ -926,9 +926,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"
+                "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb",
+                "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "django": {
             "hashes": [
@@ -1051,6 +1052,13 @@
                 "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
             ],
             "version": "==2.3.5"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
+                "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"
+            ],
+            "version": "==0.8.0"
         },
         "pathtools": {
             "hashes": [
@@ -1199,6 +1207,32 @@
             ],
             "version": "==5.3.1"
         },
+        "regex": {
+            "hashes": [
+                "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a",
+                "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938",
+                "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29",
+                "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae",
+                "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387",
+                "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a",
+                "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf",
+                "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610",
+                "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9",
+                "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5",
+                "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3",
+                "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89",
+                "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded",
+                "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754",
+                "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f",
+                "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868",
+                "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd",
+                "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910",
+                "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3",
+                "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac",
+                "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"
+            ],
+            "version": "==2020.6.8"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -1228,6 +1262,32 @@
                 "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"
             ],
             "version": "==4.3.3"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
         },
         "virtualenv": {
             "hashes": [

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -4,21 +4,20 @@ from bitfield.forms import BitFieldCheckboxSelectMultiple
 from django.contrib import admin
 from guardian.admin import GuardedModelAdmin
 
-from accounts.models import Child, DemographicData, User
+from accounts.models import Child, DemographicData, Message, User
 
 
 class ChildAdmin(GuardedModelAdmin):
     list_display = ("id", "uuid", "given_name", "birthday", "user")
-    list_filter = (
-        "id",
-        "uuid",
-        # ("existing_conditions", BitFieldListFilter),
-        # ("multiple_birth", BitFieldListFilter),
-        # leave out until https://github.com/disqus/django-bitfield/issues/64 is fixed
-    )
+    # list_filter = (
+    # ("existing_conditions", BitFieldListFilter),
+    # ("multiple_birth", BitFieldListFilter),
+    # leave out until https://github.com/disqus/django-bitfield/issues/64 is fixed
+    # )
     date_hierarchy = "birthday"
     search_fields = ["uuid", "given_name"]
     formfield_overrides = {BitField: {"widget": BitFieldCheckboxSelectMultiple}}
+    raw_id_fields = ("user",)
 
 
 class UserAdmin(GuardedModelAdmin):
@@ -35,13 +34,28 @@ class UserAdmin(GuardedModelAdmin):
     list_filter = ("is_researcher",)
     exclude = ("is_superuser", "is_staff")
     search_fields = ["uuid", "nickname", "given_name", "family_name"]
+    # make the interface for adding/removing groups and perms easier to use and
+    # harder to screw up
+    filter_horizontal = (
+        "groups",
+        "user_permissions",
+    )
 
 
 class DemographicDataAdmin(GuardedModelAdmin):
-    list_display = ("uuid", "created_at", "user")
-    list_filter = ("user", "country", "lookit_referrer", "number_of_children")
+    list_display = ("uuid", "created_at", "user", "lookit_referrer")
+    raw_id_fields = ("user",)
+
+
+class MessageAdmin(GuardedModelAdmin):
+    list_display = ("date_created", "sender", "subject")
+    list_filter = ("related_study",)
+    raw_id_fields = ("sender", "related_study")
+    filter_horizontal = ("recipients",)
+    search_fields = ["subject", "body"]
 
 
 admin.site.register(User, UserAdmin)
 admin.site.register(DemographicData, DemographicDataAdmin)
 admin.site.register(Child, ChildAdmin)
+admin.site.register(Message, MessageAdmin)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -212,7 +212,10 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
         return f"{self.given_name} {self.middle_name} {self.family_name}"
 
     def __str__(self):
-        return f"<User: ID {self.id}, {self.uuid}>"
+        if self.family_name:
+            return f"<User: {self.given_name} {self.family_name}, ID {self.id}, {self.uuid}>"
+        else:
+            return f"<User: {self.nickname}, ID {self.id}, {self.uuid}>"
 
     objects = UserManager()
 

--- a/exp/admin.py
+++ b/exp/admin.py
@@ -6,7 +6,6 @@ from studies.models import (
     Feedback,
     Lab,
     Response,
-    ResponseLog,
     Study,
     StudyLog,
     StudyType,
@@ -16,14 +15,30 @@ from studies.models import (
 
 class StudyAdmin(GuardedModelAdmin):
     list_display = ("uuid", "name", "state", "public", "creator", "built")
-    list_filter = ("state", "creator")
+    list_filter = ("state", "lab")
     search_fields = ["name"]
-    pass
+    raw_id_fields = (
+        "creator",
+        "lab",
+        "preview_group",
+        "design_group",
+        "analysis_group",
+        "submission_processor_group",
+        "researcher_group",
+        "manager_group",
+        "admin_group",
+    )
 
 
 class LabAdmin(GuardedModelAdmin):
     list_display = ("uuid", "name", "institution", "principal_investigator_name")
     search_fields = ["name", "institution", "principal_investigator_name"]
+    raw_id_fields = ("guest_group", "readonly_group", "member_group", "admin_group")
+    list_filter = ("approved_to_test",)
+    filter_horizontal = (
+        "researchers",
+        "requested_researchers",
+    )
 
 
 class ResponseAdmin(GuardedModelAdmin):
@@ -37,21 +52,30 @@ class ResponseAdmin(GuardedModelAdmin):
         "withdrawn",
         "is_preview",
     )
+    raw_id_fields = (
+        "child",
+        "demographic_snapshot",
+    )
     empty_value_display = "None"
     list_filter = ("study",)
     date_hierarchy = "date_created"
-    pass
 
 
 class FeedbackAdmin(GuardedModelAdmin):
     list_display = ("uuid", "researcher", "response", "comment")
-    list_filter = ("response__study", "researcher")
-    pass
+    search_fields = (
+        "uuid",
+        "researcher__given_name",
+        "researcher__family_name",
+        "response__uuid",
+        "comment",
+    )
+    raw_id_fields = ("researcher", "response")
 
 
 class StudyLogAdmin(GuardedModelAdmin):
     list_filter = ("study",)
-    pass
+    raw_id_fields = ("study", "user")
 
 
 class StudyTypeAdmin(GuardedModelAdmin):
@@ -69,16 +93,22 @@ class VideoAdmin(GuardedModelAdmin):
         "is_consent_footage",
     )
     list_filter = ("study",)
+    # Use raw_id_fields to avoid a large number of queries to display every possible
+    # option for response & study in the update form, which was making it impossible
+    # to use on staging/production. (
+    raw_id_fields = (
+        "response",
+        "study",
+    )
     date_hierarchy = "created_at"
     search_fields = ["uuid", "full_name"]
-    pass
 
 
 class ConsentRulingAdmin(GuardedModelAdmin):
     list_display = ("uuid", "created_at", "action", "arbiter")
     list_filter = ("response__study", "arbiter")
     date_hierarchy = "created_at"
-    pass
+    raw_id_fields = ("arbiter", "response")
 
 
 admin.site.register(Study, StudyAdmin)

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -409,9 +409,11 @@ class StudyDetailView(
             clone = orig_study.clone()
             clone.creator = self.request.user
             # Clone within the current lab if user is allowed to. Otherwise, choose the first possible
-            if not self.request.user.has_perm(
+            if self.request.user.has_perm(
                 LabPermission.CREATE_LAB_ASSOCIATED_STUDY.codename, obj=orig_study.lab
             ):
+                clone.lab = orig_study.lab
+            else:
                 for lab in self.request.user.labs.only("id"):
                     if clone.creator.has_perm(
                         LabPermission.CREATE_LAB_ASSOCIATED_STUDY.codename, obj=lab

--- a/studies/models.py
+++ b/studies/models.py
@@ -777,13 +777,15 @@ def remove_old_lab_researchers(sender, instance, **kwargs):
     if not study_in_db:
         return
     old_lab = study_in_db.lab
-    new_lab = instance.lab
-    if old_lab.pk != new_lab.pk:
-        new_lab_researchers = new_lab.researchers.all()
-        for group in instance.all_study_groups():
-            for user in group.user_set.all():
-                if user not in new_lab_researchers:
-                    group.user_set.remove(user)
+    # When cloning, fks have been emptied so there's no previous lab
+    if old_lab:
+        new_lab = instance.lab
+        if old_lab.pk != new_lab.pk:
+            new_lab_researchers = new_lab.researchers.all()
+            for group in instance.all_study_groups():
+                for user in group.user_set.all():
+                    if user not in new_lab_researchers:
+                        group.user_set.remove(user)
 
 
 class ResponseApiManager(models.Manager):

--- a/studies/models.py
+++ b/studies/models.py
@@ -1087,7 +1087,7 @@ class StudyLog(Log):
     )
 
     def __str__(self):
-        return f"<StudyLog: {self.action} on {self.study.name} at {self.created_at} by {self.user.username}"  # noqa
+        return f"<StudyLog: {self.action} on {self.study.name} at {self.created_at}"  # noqa
 
     class JSONAPIMeta:
         resource_name = "study-logs"

--- a/studies/permissions.py
+++ b/studies/permissions.py
@@ -424,6 +424,7 @@ class StudyGroup(set, Enum):
         StudyPermission.DELETE_ALL_PREVIEW_DATA,
         StudyPermission.WRITE_STUDY_DETAILS,
         StudyPermission.EDIT_STUDY_FEEDBACK,
+        StudyPermission.CHANGE_STUDY_STATUS,
         StudyPermission.MANAGE_STUDY_RESEARCHERS,
         StudyPermission.READ_STUDY_RESPONSE_DATA,
         StudyPermission.CODE_STUDY_CONSENT,

--- a/studies/permissions.py
+++ b/studies/permissions.py
@@ -356,6 +356,7 @@ class LabGroup(set, Enum):
         LabPermission.READ_STUDY_DETAILS,
         LabPermission.READ_STUDY_PREVIEW_DATA,
         LabPermission.CODE_STUDY_PREVIEW_CONSENT,
+        LabPermission.DELETE_ALL_PREVIEW_DATA,
         LabPermission.WRITE_STUDY_DETAILS,
         LabPermission.CHANGE_STUDY_STATUS,
         LabPermission.MANAGE_STUDY_RESEARCHERS,

--- a/studies/templates/emails/custom_email.html
+++ b/studies/templates/emails/custom_email.html
@@ -1,3 +1,7 @@
-<p> {{ custom_message|linebreaks }} </p>
+{% autoescape off %}
+{{ custom_message }}
+{% endautoescape %}
+
+<br>
 
 <a href="{{base_url}}{% url 'web:email-preferences' %}"> Update your email preferences </a>

--- a/studies/templates/emails/custom_email.txt
+++ b/studies/templates/emails/custom_email.txt
@@ -1,3 +1,3 @@
-{{ custom_message }}
+{{ custom_message|striptags }}
 
 Update your email preferences here: {{base_url}}{% url 'web:email-preferences' %}


### PR DESCRIPTION
Most important change (for merging in before pushing to prod) is making sure study admins can change study status.

Using raw_id_fields in the admin forms restores usability of the Video, ConsentRuling, and Feedback forms - otherwise these make a huge number of queries in order to display each of the possible options for response & user fields. (Went from 130 to 10 locally, but probably many more on staging/prod

(tests to come along with study detail view refactor)

Includes fix for video archive download also.

To check on staging:
- non-superuser, non-lab-admin study admin can change study status
- can clone study
- custom email formatting doesn't have all the html markup in it
- admin views load for video, consentruling update pages
- can download video archive & has expected contents