### PR TITLE
Many babies at home - internationalization

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -61,7 +61,7 @@ class ParticipantUpdateForm(forms.ModelForm):
     class Meta:
         model = User
         fields = ("username", "nickname")
-        labels = {"username": "Email address"}
+        labels = {"username": _("Email address")}
 
 
 class ParticipantPasswordForm(PasswordChangeForm):
@@ -85,10 +85,10 @@ class EmailPreferencesForm(forms.ModelForm):
             "email_response_questions",
         )
         labels = {
-            "email_next_session": "It's time for another session of a study we are currently participating in",
-            "email_new_studies": "A new study is available for one of my children",
-            "email_study_updates": "There's an update about a study we participated in (for example, results are published)",
-            "email_response_questions": "A researcher has questions about my individual responses (for example, if I report a technical problem during the study)",
+            "email_next_session": _("It's time for another session of a study we are currently participating in"),
+            "email_new_studies": _("A new study is available for one of my children"),
+            "email_study_updates": _("There's an update about a study we participated in (for example, results are published)"),
+            "email_response_questions": _("A researcher has questions about my individual responses (for example, if I report a technical problem during the study)"),
         }
 
 
@@ -96,7 +96,7 @@ class DemographicDataForm(forms.ModelForm):
     race_identification = forms.MultipleChoiceField(
         choices=DemographicData.RACE_CHOICES,
         widget=forms.CheckboxSelectMultiple(),
-        label="What category(ies) does your family identify as?",
+        label=_("What category(ies) does your family identify as?"),
         required=False,
     )
 
@@ -124,8 +124,8 @@ class DemographicDataForm(forms.ModelForm):
         )
 
         help_texts = {
-            "child_birthdays": "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ...",
-            "number_of_books": "Numerical answers only - a rough guess is fine!",
+            "child_birthdays": _("Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."),
+            "number_of_books": _("Numerical answers only - a rough guess is fine!"),
         }
 
         labels = {
@@ -159,13 +159,13 @@ class DemographicDataForm(forms.ModelForm):
 class ChildForm(forms.ModelForm):
     birthday = forms.DateField(
         widget=forms.DateInput(attrs={"class": "datepicker"}),
-        help_text="This lets us figure out exactly how old your child is when they participate in a study. We never publish children's birthdates or information that would allow a reader to calculate the birthdate.",
+        help_text=_("This lets us figure out exactly how old your child is when they participate in a study. We never publish children's birthdates or information that would allow a reader to calculate the birthdate."),
     )
 
     def clean_birthday(self):
         date = self.cleaned_data["birthday"]
         if date > datetime.date.today():
-            raise ValidationError("Birthdays cannot be in the future.")
+            raise ValidationError(_("Birthdays cannot be in the future."))
         return date
 
     class Meta:
@@ -181,18 +181,18 @@ class ChildForm(forms.ModelForm):
         )
 
         labels = {
-            "given_name": "First Name",
-            "birthday": "Birthday",
-            "gestational_age_at_birth": "Gestational Age at Birth",
-            "additional_information": "Any additional information you'd like us to know",
-            "existing_conditions": "Characteristics and conditions",
-            "languages_spoken": "Languages this child is exposed to at home, school, or with another caregiver.",
+            "given_name": _("First Name"),
+            "birthday": _("Birthday"),
+            "gestational_age_at_birth": _("Gestational Age at Birth"),
+            "additional_information": _("Any additional information you'd like us to know"),
+            "existing_conditions": _("Characteristics and conditions"),
+            "languages_spoken": _("Languages this child is exposed to at home, school, or with another caregiver."),
         }
 
         help_texts = {
-            "given_name": "This lets you select the correct child to participate in a particular study. A nickname or initials are fine! We may include your child's name in email to you (for instance, \"There's a new study available for Molly!\") but will never publish names or use them in our research.",
-            "additional_information": "For instance, diagnosed developmental disorders or vision or hearing problems",
-            "gestational_age_at_birth": "Please round down to the nearest full week of pregnancy completed",
+            "given_name": _("This lets you select the correct child to participate in a particular study. A nickname or initials are fine! We may include your child's name in email to you (for instance, \"There's a new study available for Molly!\") but will never publish names or use them in our research."),
+            "additional_information": _("For instance, diagnosed developmental disorders or vision or hearing problems"),
+            "gestational_age_at_birth": _("Please round down to the nearest full week of pregnancy completed"),
         }
 
         widgets = {
@@ -221,17 +221,17 @@ class ChildUpdateForm(forms.ModelForm):
         )
 
         labels = {
-            "given_name": "First Name",
-            "birthday": "Birthday",
-            "gestational_age_at_birth": "Gestational Age at Birth",
-            "additional_information": "Any additional information you'd like us to know",
-            "existing_conditions": "Characteristics and conditions",
-            "languages_spoken": "Languages this child is exposed to at home, school, or with another caregiver.",
+            "given_name": _("First Name"),
+            "birthday": _("Birthday"),
+            "gestational_age_at_birth": _("Gestational Age at Birth"),
+            "additional_information": _("Any additional information you'd like us to know"),
+            "existing_conditions": _("Characteristics and conditions"),
+            "languages_spoken": _("Languages this child is exposed to at home, school, or with another caregiver."),
         }
 
         help_texts = {
-            "given_name": "This lets you select the correct child to participate in a particular study. A nickname or initials are fine! We may include your child's name in email to you (for instance, \"There's a new study available for Molly!\") but will never publish names or use them in our research.",
-            "additional_information": "For instance, diagnosed developmental disorders or vision or hearing problems",
+            "given_name": _("This lets you select the correct child to participate in a particular study. A nickname or initials are fine! We may include your child's name in email to you (for instance, \"There's a new study available for Molly!\") but will never publish names or use them in our research."),
+            "additional_information": _("For instance, diagnosed developmental disorders or vision or hearing problems"),
         }
 
         widgets = {

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 
 from accounts.models import Child, DemographicData, User
 
+from django.utils.translation import gettext_lazy as _
 
 class UserForm(forms.ModelForm):
     class Meta:
@@ -128,23 +129,23 @@ class DemographicDataForm(forms.ModelForm):
         }
 
         labels = {
-            "country": "What country do you live in?",
-            "state": "What state do you live in?",
-            "density": "How would you describe the area where you live?",
-            "languages_spoken_at_home": "What language(s) does your family speak at home?",
-            "number_of_children": "How many children do you have?",
-            "child_birthdays": "For each child, please enter his or her birthdate:",
-            "number_of_guardians": "How many parents/guardians do your children live with?",
-            "race_identification": "What category(ies) does your family identify as?",
-            "age": "What is your age?",
-            "gender": "What is your gender?",
-            "education_level": "What is the highest level of education you've completed?",
-            "spouse_education_level": "What is the highest level of education your spouse has completed?",
-            "annual_income": "What is your approximate family yearly income (in US dollars)?",
-            "number_of_books": "About how many children's books are there in your home?",
-            "additional_comments": "Anything else you'd like us to know?",
-            "lookit_referrer": "How did you hear about Lookit?",
-            "number_of_guardians_explanation": "If the answer varies due to shared custody arrangements or travel, please enter the number of parents/guardians your children are usually living with or explain.",
+            "country": _("What country do you live in?"),
+            "state": _("What state do you live in?"),
+            "density": _("How would you describe the area where you live?"),
+            "languages_spoken_at_home": _( "What language(s) does your family speak at home?"),
+            "number_of_children": _("How many children do you have?"),
+            "child_birthdays": _("For each child, please enter his or her birthdate:"),
+            "number_of_guardians": _("How many parents/guardians do your children live with?"),
+            "race_identification": _("What category(ies) does your family identify as?"),
+            "age": _("What is your age?"),
+            "gender": _("What is your gender?"),
+            "education_level": _("What is the highest level of education you've completed?"),
+            "spouse_education_level": _("What is the highest level of education your spouse has completed?"),
+            "annual_income": _("What is your approximate family yearly income (in US dollars)?"),
+            "number_of_books": _("About how many children's books are there in your home?"),
+            "additional_comments": _("Anything else you'd like us to know?"),
+            "lookit_referrer": _("How did you hear about Lookit?"),
+            "number_of_guardians_explanation": _("If the answer varies due to shared custody arrangements or travel, please enter the number of parents/guardians your children are usually living with or explain."),
         }
 
         widgets = {

--- a/accounts/templates/account/local_user_exists.html
+++ b/accounts/templates/account/local_user_exists.html
@@ -10,17 +10,16 @@
 <div class="container">
   <div class="jumbo" style="padding-top: 25px">
       <h2 style="font-size: 48px; text-align: center; font-weight: 300;">
-          Login Unsuccessful
+          {% trans "Login Unsuccessful" %}
       </h2>
       <h3 style="text-align: center; font-weight: 300;">
-        A Lookit study participant exists with the email address for your OSF user account.
-        Create an OSF user with a different email address and try logging into Experimenter with that.
+        {% trans "A Lookit study participant exists with the email address for your OSF user account. Create an OSF user with a different email address and try logging into Experimenter with that. " %}
       </h3>
       <h3 style="text-align: center; font-weight: 300;">
-          If this should not have occurred and the issue persists, please report it to <a href="mailto:support@osf.io">support@osf.io</a>.
+          {% trans "If this should not have occurred and the issue persists, please report it to <a href="mailto:support@osf.io">support@osf.io" %}</a>.
       </h3>
       <h4 style="text-align: center; font-weight: 300;">
-          <a href="/accounts/login/">Return to Experimenter</a>
+          <a href="/accounts/login/">{% trans "Return to Experimenter" %}</a>
       </h4>
   </div>
 </div>

--- a/accounts/templates/account/login_errored_cancelled.html
+++ b/accounts/templates/account/login_errored_cancelled.html
@@ -10,13 +10,13 @@
 <div class="container">
   <div class="jumbo" style="padding-top: 25px">
       <h1 style="font-size: 48px; text-align: center; font-weight: 300;">
-          Login Unsuccessful
+          {% trans "Login Unsuccessful" %}
       </h1>
       <h4 style="text-align: center; font-weight: 300;">
-          If this should not have occurred and the issue persists, please report it to <a href="mailto:support@osf.io">support@osf.io</a>.
+          {% trans 'If this should not have occurred and the issue persists, please report it to <a href="mailto:support@osf.io">support@osf.io' %}</a>.
       </h4>
       <h3 style="text-align: center; font-weight: 300;">
-          <a href="/exp/">Return to Experimenter</a>
+          <a href="/exp/">{% trans "Return to Experimenter" %}</a>
       </h3>
   </div>
 </div>

--- a/accounts/templates/accounts/participant_detail.html
+++ b/accounts/templates/accounts/participant_detail.html
@@ -1,6 +1,7 @@
 {% extends 'exp/base.html' %}
 {% load bootstrap3 %}
 {% load exp_extras %}
+{% load i18n %}
 
 {% block title %}{{ user.nickname |default:"Participant Detail" }}{% endblock %}
 {% block flash %}
@@ -11,7 +12,7 @@
       <div class='row'>
           <div class="col-xs-12">
               <ol class="breadcrumb">
-                <li><a href="{% url 'exp:participant-list' %}"> All Participants </a></li>
+                <li><a href="{% url 'exp:participant-list' %}"> {% trans "All Participants" %} </a></li>
                 <li class="active"> {{ user.nickname |default:"Participant Detail" }} </li>
               </ol>
           </div>
@@ -19,22 +20,22 @@
 
       <div class="row">
           <div class="col-xs-12">
-              <h1> {{ user.identicon_html }} {% if user.nickname %} {{ user.nickname }}{% else %} Participant ID {{ user.id }} {% endif %}</h1>
-              <span><label class='pr-xs'> Last Active: </label> {{ user.last_login|date:"n/d/Y"|default:"N/A" }} </span>
-              <div><label class='pr-xs'> Participant global ID: </label> {{ user.uuid }} </div>
+              <h1> {{ user.identicon_html }} {% if user.nickname %} {{ user.nickname }}{% else %} {% trans "Participant ID" %} {{ user.id }} {% endif %}</h1>
+              <span><label class='pr-xs'> {% trans "Last Active:" %} </label> {{ user.last_login|date:"n/d/Y"|default:"N/A" }} </span>
+              <div><label class='pr-xs'> {% trans "Participant global ID:" %} </label> {{ user.uuid }} </div>
           </div>
       </div>
 
     <div class='row'>
         <div class='col-md-6 col-sm-5'>
-            <h3>Children</h3>
+            <h3>{% trans "Children" %}</h3>
             {% for child in children %}
             <div class="pb-md">
                 <h4 class="child-name"><em>{{child.given_name}}</em></h4>
                 <div class="pl-md">
                     <div class="row">
                         <div class="col-xs-5">
-                            <b> Birthday: </b>
+                            <b> {% trans "Birthday" %}: </b>
                         </div>
                         <div class="col-xs-7">
                             {{child.birthday|date:"n/d/Y"|default:"N/A"}}
@@ -42,7 +43,7 @@
                     </div>
                     <div class="row">
                         <div class="col-xs-5">
-                            <b> Age: </b>
+                            <b> {% trans "Age" %}: </b>
                         </div>
                         <div class="col-xs-7">
                              {{child.birthday | timesince}}
@@ -50,7 +51,7 @@
                     </div>
                     <div class="row">
                         <div class="col-xs-5">
-                            <b> Gender: </b>
+                            <b> {% trans "Gender" %}: </b>
                         </div>
                         <div class="col-xs-7">
                              {{child.get_gender_display}}
@@ -58,7 +59,7 @@
                     </div>
                     <div class="row">
                         <div class="col-xs-5">
-                            <b> Gestational Age at Birth: </b>
+                            <b> {% trans "Gestational Age at Birth" %}: </b>
                         </div>
                         <div class="col-xs-7">
                              {{child.age_at_birth|default:"No response"}}
@@ -66,7 +67,7 @@
                     </div>
                     <div class="row">
                         <div class="col-xs-5">
-                            <b> Additional Info: </b>
+                            <b> {% trans "Additional Info" %}: </b>
                         </div>
                         <div class="col-xs-7">
                              {{child.additional_information|default:"No response"}}
@@ -75,14 +76,14 @@
                 </div>
             </div>
             {% empty %}
-                <p><em> No children profiles registered! </em></p>
+                <p><em> {% trans "No children profiles registered!" %} </em></p>
             {% endfor %}
         </div>
         <div class='col-md-6 col-sm-7'>
-            <h3>Latest Demographic Data</h3>
+            <h3>{% trans "Latest Demographic Data" %}</h3>
             <div class="row">
                 <div class="col-xs-5">
-                    <b> Country: </b>
+                    <b> {% trans "Country" %}: </b>
                 </div>
                 <div class="col-xs-7">
                     {{ demographics.country|default:"No Response" }}
@@ -90,7 +91,7 @@
             </div>
             <div class="row">
                 <div class="col-xs-5">
-                    <b> State: </b>
+                    <b> {% trans "State" %}: </b>
                 </div>
                 <div class="col-xs-7">
                      {{ demographics.state|default:"No Response" }}
@@ -98,7 +99,7 @@
             </div>
             <div class="row">
                 <div class="col-xs-5">
-                    <b> Area description: </b>
+                    <b> {% trans "Area description" %}: </b>
                 </div>
                 <div class="col-xs-7">
                     {{ demographics.density|default:"No Response" }}
@@ -106,7 +107,7 @@
             </div>
             <div class="row">
                 <div class="col-xs-5">
-                    <b> Languages Spoken at Home: </b>
+                    <b> {% trans "Languages Spoken at Home" %}: </b>
                 </div>
                 <div class="col-xs-7">
                     {{ demographics.languages_spoken_at_home|default:"No Response" }}
@@ -114,7 +115,7 @@
             </div>
             <div class="row">
                 <div class="col-xs-5">
-                    <b> Number of Children: </b>
+                    <b> {% trans "Number of Children" %}: </b>
                 </div>
                 <div class="col-xs-7">
                      {{ demographics.number_of_children|default:"No Response" }}
@@ -122,23 +123,23 @@
             </div>
             <div class="row">
                 <div class="col-xs-5">
-                    <b>  Children current ages: </b>
+                    <b> {% trans "Children current ages" %}: </b>
                 </div>
                 <div class="col-xs-7">
-                    {% for birthday in user.latest_demographics.child_birthdays %}{{birthday | timesince|default:"N/A"}}{% if not forloop.last %}; {% endif %}{% empty %}No Response{% endfor %}
+                    {% for birthday in user.latest_demographics.child_birthdays %}{{birthday | timesince|default:"N/A"}}{% if not forloop.last %}; {% endif %}{% empty %}{% trans No Response %}{% endfor %}
                 </div>
             </div>
             <div class="row">
                 <div class="col-xs-5">
-                    <b> Number of Guardians: </b>
+                    <b> {% trans "Number of Guardians" %}: </b>
                 </div>
                 <div class="col-xs-7">
-                    {{ demographics.number_of_guardians|default:"No Response" }}
+                    {{ demographics.number_of_guardians|default:"No Response"}}
                 </div>
             </div>
             <div class="row">
                 <div class="col-xs-5">
-                    <b> Explanation for Guardians: </b>
+                    <b> {% trans "Explanation for Guardians:" %} </b>
                 </div>
                 <div class="col-xs-7">
                     {{ demographics.number_of_guardians_explanation|default:"No Response" }}
@@ -146,7 +147,7 @@
             </div>
             <div class="row">
                 <div class="col-xs-5">
-                    <b> Race: </b>
+                    <b>{% trans "Race" %}:</b>
                 </div>
                 <div class="col-xs-7">
                     {{ demographics.race_identification|default:"No Response" }}

--- a/accounts/templates/accounts/participant_list.html
+++ b/accounts/templates/accounts/participant_list.html
@@ -34,7 +34,7 @@
            <div class="btn-group">
                <div class="btn-group">
                  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                    Nickname <span class="caret"></span>
+                    {% trans "Nickname" %} <span class="caret"></span>
                  </button>
                  <ul class="dropdown-menu" role="menu">
                    <li> <a aria-label="Sort ascending by nickname" href="{% url 'exp:participant-list' %}?{% query_transform request page='1' sort='nickname' %}">Sort A-Z</a></li>
@@ -52,10 +52,10 @@
              </div>
           </div>
        </div>
-   </div>
+   </div> 
    <div class="row mt-xl visible-md visible-lg visible-xl">
        <div class="col-md-2 col-md-offset-1">
-           <strong> Nickname </strong>
+           <strong> {% trans "Nickname" %} </strong>
            <a class="pl-sm" aria-label="Sort ascending by nickname" href="{% url 'exp:participant-list' %}?{% query_transform request page='1' sort='nickname' %}"><i aria-hidden="true" class="fa fa-chevron-up" role="button" name="name"></i></a>
            <a aria-label="Sort descending by nickname" href="{% url 'exp:participant-list' %}?{% query_transform request page='1' sort='-nickname' %}"><i aria-hidden="true" class="fa fa-chevron-down" role="button" name="name"></i></a>
        </div>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
   args:
     - '-c'
     - |
-      git clone https://github.com/lookit/lookit-api.git --no-checkout
+      git clone https://github.com/rhodricusack/lookit-api.git --no-checkout
       mv lookit-api/.git .
       git fetch --unshallow
       rm -rf lookit-api
@@ -127,6 +127,6 @@ images:
 # SENTRY_AUTH_TOKEN is encrypted with GKMS
 # TODO: bring this back in when the git history thing is resolved.
 secrets:
-- kmsKeyName: projects/mit-lookit-keys/locations/us-east1/keyRings/lookit-keyring/cryptoKeys/sentry-auth
+- kmsKeyName: projects/lookit-mbah-keys/locations/europe-west1/keyRings/lookit-mbah-keys/cryptoKeys/sentry-auth
   secretEnv:
-    SENTRY_AUTH_TOKEN: CiQAVYLHlum+JbxvLUXADsLiiIwXjocXFGg5SAsxKyvAkDRjEaESaABnxmN4TReBWF0cY+XPS8xytlGSUhClZewwH7ttpBFKC65+Y0a6W8XIsTjyQMyVzWiLxSOef46bmI1Bo8JIbh/ErIRWm3rPBNFs843z52oF8M93+miMUlt8UOWmIgyq1U/fjThhq0UI
+    SENTRY_AUTH_TOKEN: CiQAGuTcS/UVjd71yF4x3PtHnYN6NFV5rKFfP88jAW7EirBOVpYScgDwrsX5Hi3S1xdJDxXYomvA82rSAfKkqWhqJhHMMX+o84iHBf4uZ7oL22+47hxkXEI5l3xJg4ni3WgoJtkkGdZhEaFU9pdGkRM/lIwkRLVkU83EM62UqIcu+pu3echPrEGoZINMi9p+xxljo//CHI9/ZA==

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
   args:
     - '-c'
     - |
-      git clone https://github.com/rhodricusack/lookit-api.git --no-checkout
+      git clone https://github.com/lookit/lookit-api.git --no-checkout
       mv lookit-api/.git .
       git fetch --unshallow
       rm -rf lookit-api
@@ -127,6 +127,6 @@ images:
 # SENTRY_AUTH_TOKEN is encrypted with GKMS
 # TODO: bring this back in when the git history thing is resolved.
 secrets:
-- kmsKeyName: projects/lookit-mbah-keys/locations/europe-west1/keyRings/lookit-mbah-keys/cryptoKeys/sentry-auth
+- kmsKeyName: projects/mit-lookit-keys/locations/us-east1/keyRings/lookit-keyring/cryptoKeys/sentry-auth
   secretEnv:
-    SENTRY_AUTH_TOKEN: CiQAGuTcS/UVjd71yF4x3PtHnYN6NFV5rKFfP88jAW7EirBOVpYScgDwrsX5Hi3S1xdJDxXYomvA82rSAfKkqWhqJhHMMX+o84iHBf4uZ7oL22+47hxkXEI5l3xJg4ni3WgoJtkkGdZhEaFU9pdGkRM/lIwkRLVkU83EM62UqIcu+pu3echPrEGoZINMi9p+xxljo//CHI9/ZA==
+    SENTRY_AUTH_TOKEN: CiQAVYLHlum+JbxvLUXADsLiiIwXjocXFGg5SAsxKyvAkDRjEaESaABnxmN4TReBWF0cY+XPS8xytlGSUhClZewwH7ttpBFKC65+Y0a6W8XIsTjyQMyVzWiLxSOef46bmI1Bo8JIbh/ErIRWm3rPBNFs843z52oF8M93+miMUlt8UOWmIgyq1U/fjThhq0UI

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-20 13:48+0100\n"
-"PO-Revision-Date: 2020-07-20 13:49+0100\n"
+"POT-Creation-Date: 2020-07-20 14:25+0100\n"
+"PO-Revision-Date: 2020-07-20 14:26+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ja\n"
@@ -627,15 +627,42 @@ msgid "Select a State"
 msgstr "州を選択してください"
 
 #: accounts/templates/account/local_user_exists.html:7
+#: accounts/templates/account/local_user_exists.html:13
 #: accounts/templates/account/login_errored_cancelled.html:7
+#: accounts/templates/account/login_errored_cancelled.html:13
 msgid "Login Unsuccessful"
 msgstr "ログイン失敗"
+
+#: accounts/templates/account/local_user_exists.html:16
+msgid ""
+"A Lookit study participant exists with the email address for your OSF user "
+"account. Create an OSF user with a different email address and try logging "
+"into Experimenter with that. "
+msgstr ""
+"OSFユーザーアカウントのメールアドレスを持つLookit研究参加者が存在します。別の"
+"メールアドレスでOSFユーザーを作成し、そのメールアドレスでExperimenterにログイ"
+"ンしてみてください。"
+
+#: accounts/templates/account/local_user_exists.html:19
+msgid ""
+"If this should not have occurred and the issue persists, please report it to "
+"<a href="
+msgstr ""
+"この問題が発生していないはずなのに問題が解決しない場合は、<a href=<a href=<a "
+"href=<a href=<a href=<a href=<a href=<a>）まで報告してください。"
+
+#: accounts/templates/account/local_user_exists.html:22
+#: accounts/templates/account/login_errored_cancelled.html:19
+#| msgid "Experimenter"
+msgid "Return to Experimenter"
+msgstr "実験者を見ることができます"
 
 #: accounts/templates/account/login.html:7
 msgid "Sign In"
 msgstr "サインイン"
 
 #: accounts/templates/account/login.html:13
+#: web/templates/registration/login.html:25
 #: web/templates/web/_navigation.html:47
 msgid "Login"
 msgstr "ログイン"
@@ -662,13 +689,19 @@ msgstr ""
 "\"_blank\">プライバシーポリシーを</a>読み、これに同意したことになります。\n"
 "        "
 
+#: accounts/templates/account/login_errored_cancelled.html:16
+msgid ""
+"If this should not have occurred and the issue persists, please report it to "
+"<a href=\"mailto:support@osf.io\">support@osf.io"
+msgstr ""
+"この問題が発生していないはずなのに問題が解決しない場合は、<a href=\"mailto:"
+"support@osf.io\">support@osf.io</a> まで報告してください。"
+
 #: accounts/templates/accounts/participant_detail.html:15
-#| msgid "Participate"
 msgid "All Participants"
 msgstr "参加する"
 
 #: accounts/templates/accounts/participant_detail.html:23
-#| msgid "Participate"
 msgid "Participant ID"
 msgstr "参加する"
 
@@ -677,7 +710,6 @@ msgid "Last Active:"
 msgstr "最後にアクティブになりました。"
 
 #: accounts/templates/accounts/participant_detail.html:25
-#| msgid "Participant account"
 msgid "Participant global ID:"
 msgstr "参加者アカウント"
 
@@ -699,7 +731,6 @@ msgid "Additional Info"
 msgstr "補足情報"
 
 #: accounts/templates/accounts/participant_detail.html:79
-#| msgid "No child profiles registered!"
 msgid "No children profiles registered!"
 msgstr "子供のプロフィールが登録されていません"
 
@@ -803,6 +834,49 @@ msgstr ""
 msgid "The Users who have requested to join this Lab."
 msgstr "本研究室への参加を希望された利用者様。"
 
+#: web/templates/registration/logged_out.html:6
+msgid "You've successfully logged out."
+msgstr "ログアウトに成功しました。"
+
+#: web/templates/registration/login.html:8
+#: web/templates/web/studies-history.html:9
+#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
+msgid "Your username and password didn't match. Please try again."
+msgstr "ユーザー名とパスワードが一致しませんでした。もう一度お試しください。"
+
+#: web/templates/registration/login.html:18
+#| msgid "Participant account"
+msgid "Participant Login"
+msgstr "参加者アカウント"
+
+#: web/templates/registration/login.html:32
+msgid "Forgot password?"
+msgstr "パスワードをお忘れですか?"
+
+#: web/templates/registration/login.html:33
+msgid "Looking for "
+msgstr "を探しています。"
+
+#: web/templates/registration/login.html:33
+msgid "researcher login"
+msgstr "研究者ログイン"
+
+#: web/templates/registration/login.html:33
+msgid "instead?"
+msgstr "を選択してください"
+
+#: web/templates/registration/login.html:34
+msgid "New to Lookit?"
+msgstr "ルキット"
+
+#: web/templates/registration/login.html:34
+msgid "Create an account!"
+msgstr "アカウント作成"
+
+#: web/templates/registration/password_change_done.html:11
+msgid "Password changed"
+msgstr "パスワードが変更されました"
+
 #: web/templates/registration/password_change_done.html:15
 msgid "Your password was changed."
 msgstr "パスワードが変更されていました。"
@@ -848,6 +922,10 @@ msgstr ""
 #: web/templates/registration/password_reset_confirm.html:31
 msgid "Change my password"
 msgstr "パスワードの変更"
+
+#: web/templates/registration/password_reset_complete.html:11
+msgid "Password reset complete"
+msgstr "パスワードリセットの確認"
 
 #: web/templates/registration/password_reset_complete.html:15
 msgid "Your password has been set.  You may go ahead and log in now."
@@ -1019,7 +1097,9 @@ msgstr "子供"
 
 #: web/templates/web/child-update.html:16
 #: web/templates/web/children-list.html:67
+#: web/templates/web/demographic-data-update.html:78
 #: web/templates/web/participant-email-preferences.html:16
+#: web/templates/web/participant-update.html:15
 msgid "My Account"
 msgstr "マイアカウント"
 
@@ -1092,13 +1172,16 @@ msgid "Name"
 msgstr "名前"
 
 #: web/templates/web/children-list.html:121
-#| msgid "Update"
 msgid "Update child"
 msgstr "更新"
 
 #: web/templates/web/children-list.html:128
 msgid "No child profiles registered!"
 msgstr "子供のプロフィールが登録されていません"
+
+#: web/templates/web/demographic-data-update.html:4
+msgid "Update demographics"
+msgstr "最新の人口動態データ"
 
 #: web/templates/web/demographic-data-update.html:89
 msgid ""
@@ -1161,11 +1244,6 @@ msgstr "パスワードの変更"
 #: web/templates/web/studies-history.html:27
 msgid "Past Studies"
 msgstr "これまでの研究"
-
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your username and password didn't match. Please try again."
-msgstr "ユーザー名とパスワードが一致しませんでした。もう一度お試しください。"
 
 #: web/templates/web/studies-history.html:16
 #: web/templates/web/studies-list.html:16

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-10 23:05+0100\n"
-"PO-Revision-Date: 2020-07-10 23:06+0100\n"
+"POT-Creation-Date: 2020-07-20 13:48+0100\n"
+"PO-Revision-Date: 2020-07-20 13:49+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ja\n"
@@ -17,6 +17,46 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3.1\n"
+
+#: accounts/forms.py:64
+msgid "Email address"
+msgstr "メールアドレス"
+
+#: accounts/forms.py:88
+msgid ""
+"It's time for another session of a study we are currently participating in"
+msgstr "現在参加している勉強会の続きの時間になりました"
+
+#: accounts/forms.py:89
+msgid "A new study is available for one of my children"
+msgstr "子供の一人に新しい勉強ができました。"
+
+#: accounts/forms.py:90
+msgid ""
+"There's an update about a study we participated in (for example, results are "
+"published)"
+msgstr "参加した研究の更新があります（例えば、結果が公開されています）。"
+
+#: accounts/forms.py:91
+msgid ""
+"A researcher has questions about my individual responses (for example, if I "
+"report a technical problem during the study)"
+msgstr ""
+"研究者が私の個別対応に疑問を持つ（例えば、研究中に技術的な問題を報告した場合"
+"など"
+
+#: accounts/forms.py:99 accounts/forms.py:139
+msgid "What category(ies) does your family identify as?"
+msgstr "あなたの家族はどのようなカテゴリーに属していますか？"
+
+#: accounts/forms.py:127
+msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
+msgstr ""
+"カンマ区切りのリストとして入力してください。YYYY-MM-DD, YYYY-MM-DD, ..."
+
+#: accounts/forms.py:128
+msgid "Numerical answers only - a rough guess is fine!"
+msgstr "数値回答のみ～大まかな推測でOK!"
 
 #: accounts/forms.py:132
 msgid "What country do you live in?"
@@ -45,10 +85,6 @@ msgstr "お子様一人一人の生年月日をご記入ください。"
 #: accounts/forms.py:138
 msgid "How many parents/guardians do your children live with?"
 msgstr "あなたのお子さんは何人の親御さん・保護者の方と一緒に暮らしていますか？"
-
-#: accounts/forms.py:139
-msgid "What category(ies) does your family identify as?"
-msgstr "あなたの家族はどのようなカテゴリーに属していますか？"
 
 #: accounts/forms.py:140
 msgid "What is your age?"
@@ -90,6 +126,70 @@ msgid ""
 msgstr ""
 "共有親権の取り決めや旅行などで回答が異なる場合は、子どもが普段一緒に暮らして"
 "いる親・保護者の人数を記入するか、説明してください。"
+
+#: accounts/forms.py:162
+msgid ""
+"This lets us figure out exactly how old your child is when they participate "
+"in a study. We never publish children's birthdates or information that would "
+"allow a reader to calculate the birthdate."
+msgstr ""
+"これにより、調査に参加したときに、あなたの子供が何歳であるかを正確に把握する"
+"ことができます。子供の誕生日や、読者が誕生日を計算できるような情報は絶対に公"
+"開しません。"
+
+#: accounts/forms.py:168
+msgid "Birthdays cannot be in the future."
+msgstr "誕生日は未来ではありえない。"
+
+#: accounts/forms.py:184 accounts/forms.py:224
+msgid "First Name"
+msgstr "名"
+
+#: accounts/forms.py:185 accounts/forms.py:225
+#: accounts/templates/accounts/participant_detail.html:38
+#: web/templates/web/children-list.html:112
+msgid "Birthday"
+msgstr "誕生日"
+
+#: accounts/forms.py:186 accounts/forms.py:226
+#: accounts/templates/accounts/participant_detail.html:62
+msgid "Gestational Age at Birth"
+msgstr "出生時の妊娠年齢"
+
+#: accounts/forms.py:187 accounts/forms.py:227
+msgid "Any additional information you'd like us to know"
+msgstr "他に何か知っておいてほしいことは？"
+
+#: accounts/forms.py:188 accounts/forms.py:228
+msgid "Characteristics and conditions"
+msgstr "特徴と条件"
+
+#: accounts/forms.py:189 accounts/forms.py:229
+msgid ""
+"Languages this child is exposed to at home, school, or with another "
+"caregiver."
+msgstr "この子が家庭、学校、または他の保育者と一緒にいるときに接する言語。"
+
+#: accounts/forms.py:193 accounts/forms.py:233
+msgid ""
+"This lets you select the correct child to participate in a particular study. "
+"A nickname or initials are fine! We may include your child's name in email "
+"to you (for instance, \"There's a new study available for Molly!\") but will "
+"never publish names or use them in our research."
+msgstr ""
+"これにより、特定の研究に参加する正しい子供を選択することができます。ニック"
+"ネームやイニシャルでも構いません。あなたへのメールにお子さんの名前を記載する"
+"ことがありますが（例えば、「モリーのための新しい研究があります！」など）、名"
+"前を公表したり、研究に使用したりすることはありません。"
+
+#: accounts/forms.py:194 accounts/forms.py:234
+msgid ""
+"For instance, diagnosed developmental disorders or vision or hearing problems"
+msgstr "例えば、発達障害や視力・聴力に問題があると診断された場合"
+
+#: accounts/forms.py:195
+msgid "Please round down to the nearest full week of pregnancy completed"
+msgstr "妊娠完了週数に近いものに切り捨ててください。"
 
 #: accounts/migrations/0041_add_existing_conditions.py:12
 #: accounts/models.py:250 studies/fields.py:136
@@ -536,6 +636,7 @@ msgid "Sign In"
 msgstr "サインイン"
 
 #: accounts/templates/account/login.html:13
+#: web/templates/web/_navigation.html:47
 msgid "Login"
 msgstr "ログイン"
 
@@ -560,6 +661,87 @@ msgstr ""
 "termsofuse/\" target=\"_blank\">利用規約</a>と<a href=\"/privacy/\" target="
 "\"_blank\">プライバシーポリシーを</a>読み、これに同意したことになります。\n"
 "        "
+
+#: accounts/templates/accounts/participant_detail.html:15
+#| msgid "Participate"
+msgid "All Participants"
+msgstr "参加する"
+
+#: accounts/templates/accounts/participant_detail.html:23
+#| msgid "Participate"
+msgid "Participant ID"
+msgstr "参加する"
+
+#: accounts/templates/accounts/participant_detail.html:24
+msgid "Last Active:"
+msgstr "最後にアクティブになりました。"
+
+#: accounts/templates/accounts/participant_detail.html:25
+#| msgid "Participant account"
+msgid "Participant global ID:"
+msgstr "参加者アカウント"
+
+#: accounts/templates/accounts/participant_detail.html:31
+#: web/templates/web/children-list.html:105
+msgid "Children"
+msgstr "子供"
+
+#: accounts/templates/accounts/participant_detail.html:46
+msgid "Age"
+msgstr "年齢"
+
+#: accounts/templates/accounts/participant_detail.html:54
+msgid "Gender"
+msgstr "性別"
+
+#: accounts/templates/accounts/participant_detail.html:70
+msgid "Additional Info"
+msgstr "補足情報"
+
+#: accounts/templates/accounts/participant_detail.html:79
+#| msgid "No child profiles registered!"
+msgid "No children profiles registered!"
+msgstr "子供のプロフィールが登録されていません"
+
+#: accounts/templates/accounts/participant_detail.html:83
+msgid "Latest Demographic Data"
+msgstr "最新の人口動態データ"
+
+#: accounts/templates/accounts/participant_detail.html:86
+msgid "Country"
+msgstr "国"
+
+#: accounts/templates/accounts/participant_detail.html:94
+msgid "State"
+msgstr "都道府県"
+
+#: accounts/templates/accounts/participant_detail.html:102
+msgid "Area description"
+msgstr "エリアの説明"
+
+#: accounts/templates/accounts/participant_detail.html:110
+msgid "Languages Spoken at Home"
+msgstr "家庭で使われている言語"
+
+#: accounts/templates/accounts/participant_detail.html:118
+msgid "Number of Children"
+msgstr "子供の数"
+
+#: accounts/templates/accounts/participant_detail.html:126
+msgid "Children current ages"
+msgstr "子供の現在の年齢"
+
+#: accounts/templates/accounts/participant_detail.html:134
+msgid "Number of Guardians"
+msgstr "ガーディアンの数"
+
+#: accounts/templates/accounts/participant_detail.html:142
+msgid "Explanation for Guardians:"
+msgstr "ガーディアンズの説明。"
+
+#: accounts/templates/accounts/participant_detail.html:150
+msgid "Race"
+msgstr "人種"
 
 #: exp/templates/exp/dashboard.html:17
 msgid "Dashboard"
@@ -638,6 +820,7 @@ msgid "Log out"
 msgstr "ログアウト"
 
 #: web/templates/registration/password_change_form.html:7
+#: web/templates/web/home.html:3 web/templates/web/home.html:7
 msgid "Home"
 msgstr "ホーム"
 
@@ -758,11 +941,164 @@ msgstr "パスワードをリセットする"
 
 #: web/templates/web/_account-navigation.html:2
 msgid "Account information"
-msgstr ""
+msgstr "口座情報"
 
 #: web/templates/web/_account-navigation.html:2
 msgid "Change your name, email, or password."
 msgstr "パスワードの変更"
+
+#: web/templates/web/_account-navigation.html:3
+msgid "Demographic Survey"
+msgstr "人口動態調査"
+
+#: web/templates/web/_account-navigation.html:3
+msgid "Tell us more about yourself."
+msgstr "あなたのことを詳しく教えてください。"
+
+#: web/templates/web/_account-navigation.html:4
+msgid "Children Information"
+msgstr "子供の情報"
+
+#: web/templates/web/_account-navigation.html:4
+msgid "Add or edit participant information."
+msgstr "参加者情報の追加・編集"
+
+#: web/templates/web/_account-navigation.html:5
+#: web/templates/web/participant-email-preferences.html:4
+msgid "Email Preferences"
+msgstr "電子メールの設定"
+
+#: web/templates/web/_account-navigation.html:5
+msgid "Edit when you can be contacted."
+msgstr "連絡可能な時間帯を編集します。"
+
+#: web/templates/web/_navigation.html:16 web/templates/web/_navigation.html:21
+msgid "Lookit"
+msgstr "ルキット"
+
+#: web/templates/web/_navigation.html:17
+msgid "Experimenter"
+msgstr "実験者を見ることができます"
+
+#: web/templates/web/_navigation.html:30 web/templates/web/studies-list.html:4
+msgid "Studies"
+msgstr "研究"
+
+#: web/templates/web/_navigation.html:31
+msgid "FAQ"
+msgstr "FAQ"
+
+#: web/templates/web/_navigation.html:32
+msgid "The Scientists"
+msgstr "科学者たち"
+
+#: web/templates/web/_navigation.html:33
+msgid "Resources"
+msgstr "リソース"
+
+#: web/templates/web/_navigation.html:40
+msgid "Participant account"
+msgstr "参加者アカウント"
+
+#: web/templates/web/_navigation.html:42
+msgid "Hi"
+msgstr "こんにちは"
+
+#: web/templates/web/_navigation.html:44
+msgid "Logout"
+msgstr "ログアウト"
+
+#: web/templates/web/_navigation.html:46
+msgid "Sign up"
+msgstr "サインアップ"
+
+#: web/templates/web/child-update.html:4
+#: web/templates/web/studies-history.html:116
+msgid "Child"
+msgstr "子供"
+
+#: web/templates/web/child-update.html:16
+#: web/templates/web/children-list.html:67
+#: web/templates/web/participant-email-preferences.html:16
+msgid "My Account"
+msgstr "マイアカウント"
+
+#: web/templates/web/child-update.html:31
+msgid "Update"
+msgstr "更新"
+
+#: web/templates/web/child-update.html:41
+msgid "Delete"
+msgstr "削除"
+
+#: web/templates/web/child-update.html:46
+#: web/templates/web/demographic-data-update.html:102
+#: web/templates/web/participant-email-preferences.html:38
+#: web/templates/web/participant-update.html:35
+#: web/templates/web/participant-update.html:54
+msgid "Save"
+msgstr "保存"
+
+#: web/templates/web/children-list.html:40
+msgid "Empty birthday"
+msgstr "空の誕生日"
+
+#: web/templates/web/children-list.html:47
+msgid " day"
+msgstr " 日"
+
+#: web/templates/web/children-list.html:47
+msgid " days"
+msgstr "日間"
+
+#: web/templates/web/children-list.html:49
+msgid " month"
+msgstr " 月"
+
+#: web/templates/web/children-list.html:49
+msgid " months"
+msgstr " か月"
+
+#: web/templates/web/children-list.html:51
+msgid " year"
+msgstr "年"
+
+#: web/templates/web/children-list.html:51
+msgid " years"
+msgstr "年"
+
+#: web/templates/web/children-list.html:61
+#: web/templates/web/children-list.html:77
+#: web/templates/web/children-list.html:82
+#: web/templates/web/children-list.html:94
+msgid "Add Child"
+msgstr "子を追加"
+
+#: web/templates/web/children-list.html:61
+#: web/templates/web/children-list.html:77
+msgid "Hide Form"
+msgstr "非表示のフォーム"
+
+#: web/templates/web/children-list.html:92
+#: web/templates/web/demographic-data-update.html:100
+#: web/templates/web/participant-email-preferences.html:36
+#: web/templates/web/participant-update.html:33
+#: web/templates/web/participant-update.html:52
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: web/templates/web/children-list.html:111
+msgid "Name"
+msgstr "名前"
+
+#: web/templates/web/children-list.html:121
+#| msgid "Update"
+msgid "Update child"
+msgstr "更新"
+
+#: web/templates/web/children-list.html:128
+msgid "No child profiles registered!"
+msgstr "子供のプロフィールが登録されていません"
 
 #: web/templates/web/demographic-data-update.html:89
 msgid ""
@@ -785,3 +1121,279 @@ msgid ""
 msgstr ""
 "科学や宣伝目的で学習動画の公開を許可したとしても、デモグラフィック情報が動画"
 "と連動して公開されることはありません。"
+
+#: web/templates/web/participant-email-preferences.html:27
+msgid "I would like to be contacted when:"
+msgstr "いつになったら連絡したいと思います。"
+
+#: web/templates/web/participant-signup.html:4
+msgid "Signup"
+msgstr "新規登録"
+
+#: web/templates/web/participant-signup.html:24
+msgid ""
+"By clicking 'Create Account', I agree that I have read and accepted the "
+msgstr ""
+"アカウントを作成する」をクリックすることで、私は以下の内容を読み、同意したも"
+"のとします。"
+
+#: web/templates/web/participant-signup.html:24
+msgid "Privacy Statement"
+msgstr "個人情報保護方針"
+
+#: web/templates/web/participant-signup.html:27
+msgid "Create Account"
+msgstr "アカウント作成"
+
+#: web/templates/web/participant-update.html:4
+msgid "Update account information"
+msgstr "アカウント情報の更新"
+
+#: web/templates/web/participant-update.html:25
+msgid "Account Information"
+msgstr "アカウント情報"
+
+#: web/templates/web/participant-update.html:44
+msgid "Change Your Password"
+msgstr "パスワードの変更"
+
+#: web/templates/web/studies-history.html:4
+#: web/templates/web/studies-history.html:27
+msgid "Past Studies"
+msgstr "これまでの研究"
+
+#: web/templates/web/studies-history.html:9
+#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
+msgid "Your username and password didn't match. Please try again."
+msgstr "ユーザー名とパスワードが一致しませんでした。もう一度お試しください。"
+
+#: web/templates/web/studies-history.html:16
+#: web/templates/web/studies-list.html:16
+msgid ""
+"Your account doesn't have access to this page. To proceed, please login with "
+"an account that has access."
+msgstr ""
+"あなたのアカウントにはこのページへのアクセス権がありません。先に進むには、ア"
+"クセスできるアカウントでログインしてください。"
+
+#: web/templates/web/studies-history.html:18
+#: web/templates/web/studies-list.html:18
+msgid "Please login to see this page."
+msgstr "このページを見るにはログインしてください。"
+
+#: web/templates/web/studies-history.html:34
+#: web/templates/web/studies-list.html:38
+msgid "Current studies"
+msgstr "現在の研究"
+
+#: web/templates/web/studies-history.html:37
+#: web/templates/web/studies-list.html:41
+msgid "Your past studies"
+msgstr "あなたの過去の研究"
+
+#: web/templates/web/studies-history.html:50
+msgid "Here you can view your studies and see comments left by researchers:"
+msgstr ""
+"ここでは、あなたの研究を閲覧したり、研究者が残したコメントを見ることができま"
+"す。"
+
+#: web/templates/web/studies-history.html:67
+msgid "Study Thumbnail"
+msgstr "学習用サムネイル"
+
+#: web/templates/web/studies-history.html:79
+msgid "Eligibility:"
+msgstr "資格を持っていること。"
+
+#: web/templates/web/studies-history.html:80
+msgid "Contact:"
+msgstr "連絡先:"
+
+#: web/templates/web/studies-history.html:81
+msgid "Still collecting data?"
+msgstr "まだデータを集めているのか？"
+
+#: web/templates/web/studies-history.html:81
+msgid "Yes"
+msgstr "はい"
+
+#: web/templates/web/studies-history.html:81
+msgid "No"
+msgstr "いいえ"
+
+#: web/templates/web/studies-history.html:82
+msgid "Compensation: "
+msgstr "ドキュメント"
+
+#: web/templates/web/studies-history.html:87
+msgid "Study Responses"
+msgstr "学習対応"
+
+#: web/templates/web/studies-history.html:118
+msgid "Date"
+msgstr "日付"
+
+#: web/templates/web/studies-history.html:120
+msgid "Consent status"
+msgstr "同意の状況"
+
+#: web/templates/web/studies-history.html:123
+msgid "Approved"
+msgstr "承認済み"
+
+#: web/templates/web/studies-history.html:123
+msgid "Your consent video was reviewed by a researcher and is valid."
+msgstr "あなたの同意ビデオは研究者によってレビューされ、有効です。"
+
+#: web/templates/web/studies-history.html:125
+msgid "Pending"
+msgstr "保留中"
+
+#: web/templates/web/studies-history.html:125
+msgid "Your consent video has not yet been reviewed by a researcher."
+msgstr "あなたの同意ビデオは、研究者によってまだレビューされていません。"
+
+#: web/templates/web/studies-history.html:127
+msgid "Invalid"
+msgstr "無効"
+
+#: web/templates/web/studies-history.html:127
+msgid ""
+"There was a technical problem with your consent video, or it did not show "
+"you reading the consent statement out loud. Your other data from this "
+"session will not be viewed or used by the study researchers."
+msgstr ""
+"同意のビデオに技術的な問題があったか、同意文を読み上げている様子が表示されま"
+"せんでした。このセッションからのあなたの他のデータは、研究者によって閲覧また"
+"は使用されることはありません。"
+
+#: web/templates/web/studies-history.html:129
+msgid "No information about consent video review status."
+msgstr "同意動画の審査状況についての情報はありません。"
+
+#: web/templates/web/studies-history.html:154
+msgid "You have not yet participated in any studies."
+msgstr "あなたはまだ何の研究にも参加していません。"
+
+#: web/templates/web/studies-list.html:32
+msgid "Current Studies"
+msgstr "現在の研究"
+
+#: web/templates/web/studies-list.html:53
+msgid ""
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate."
+msgstr ""
+"参加には、ChromeまたはFirefoxが動作するノートパソコンまたはデスクトップパソコ"
+"ン（モバイル機器ではありません）が必要となりますのでご注意ください。"
+
+#: web/templates/web/studies-list.html:80
+msgid "See details"
+msgstr "詳細を見る"
+
+#: web/templates/web/studies-list.html:87
+msgid "We are not running any studies at this time!"
+msgstr "今のところ勉強はしていません!"
+
+#: web/templates/web/studies-list.html:93
+msgid ""
+"Looking for more ways to contribute to research from home? Check out <a href="
+"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
+"noopener\">Children Helping Science</a> for even more studies!"
+msgstr ""
+"自宅で研究に貢献する方法をお探しですか?<a href=\"https://"
+"childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer noopener"
+"\">Children Helping Science</a>では、さらに多くの研究をご覧いただけます。"
+
+#: web/templates/web/study-detail.html:93
+msgid "Study overview"
+msgstr "研究概要"
+
+#: web/templates/web/study-detail.html:96
+msgid "Back to list"
+msgstr "一覧に戻る"
+
+#: web/templates/web/study-detail.html:112
+msgid "Eligibility criteria"
+msgstr "資格基準"
+
+#: web/templates/web/study-detail.html:116
+msgid "Duration"
+msgstr "期間"
+
+#: web/templates/web/study-detail.html:121
+msgid "Compensation"
+msgstr "報酬"
+
+#: web/templates/web/study-detail.html:126
+msgid "What happens"
+msgstr "何が起こるか"
+
+#: web/templates/web/study-detail.html:130
+msgid "What we're studying"
+msgstr "勉強していること"
+
+#: web/templates/web/study-detail.html:134
+msgid "This study is conducted by"
+msgstr "この研究は"
+
+#: web/templates/web/study-detail.html:138
+msgid "Would you like to participate in this study?"
+msgstr "この研究に参加してみませんか？"
+
+#: web/templates/web/study-detail.html:140
+msgid "Log in to participate"
+msgstr "ログインして参加する"
+
+#: web/templates/web/study-detail.html:148
+msgid "Select a child:"
+msgstr "州を選択してください"
+
+#: web/templates/web/study-detail.html:150
+msgid "None Selected"
+msgstr "None Selected"
+
+#: web/templates/web/study-detail.html:161
+msgid ""
+"Your child is still younger than the recommended age range for this study. "
+"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
+"we'll be able to use the collected data in our research!"
+msgstr ""
+"あなたのお子さんは、この研究のために推奨されている年齢範囲よりもまだ若いで"
+"す。お子さんが十分な年齢になる<span id='wait-until'>まで</span>待っていただけ"
+"れば、収集したデータを研究に使用することができます"
+
+#: web/templates/web/study-detail.html:162
+msgid ""
+"Your child is older than the recommended age range for this study. You're "
+"welcome to try the study anyway, but we won't be able to use the collected "
+"data in our research."
+msgstr ""
+"あなたのお子さんは、この研究の推奨年齢範囲よりも年齢が高いです。この研究を"
+"やってみるのは大歓迎ですが、収集したデータを研究に使うことはできません。"
+
+#: web/templates/web/study-detail.html:163
+msgid ""
+"Your child does not meet the eligibility criteria listed for this study. "
+"You're welcome to try the study anyway, but we won't be able to use the "
+"collected data in our research. Please contact the study researchers"
+msgstr ""
+"あなたのお子さんは、この研究のために記載されている資格基準を満たしていませ"
+"ん。この研究をお試しいただくことは歓迎しますが、収集したデータを研究に使用す"
+"ることはできません。研究者に連絡してください。"
+
+#: web/templates/web/study-detail.html:165
+msgid "Build experiment runner to preview"
+msgstr "プレビューするための実験ランナーを構築する"
+
+#: web/templates/web/study-detail.html:167
+msgid "Participate"
+msgstr "参加する"
+
+#: web/templates/web/study-detail.html:168
+msgid ""
+"For an easy way to see what happens as you update your study protocol, "
+"bookmark the URL the button above sends you to."
+msgstr ""
+"勉強のプロトコルを更新するとどうなるかを簡単に確認するには、上のボタンをク"
+"リックして送信されるURLをブックマークしてください。"

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -1,0 +1,787 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-10 23:05+0100\n"
+"PO-Revision-Date: 2020-07-10 23:06+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.3.1\n"
+
+#: accounts/forms.py:132
+msgid "What country do you live in?"
+msgstr "どこの国に住んでいるの？"
+
+#: accounts/forms.py:133
+msgid "What state do you live in?"
+msgstr "あなたはどの州に住んでいますか？"
+
+#: accounts/forms.py:134
+msgid "How would you describe the area where you live?"
+msgstr "住んでいる地域をどのように表現しますか？"
+
+#: accounts/forms.py:135
+msgid "What language(s) does your family speak at home?"
+msgstr "ご家庭では何語を話しますか？"
+
+#: accounts/forms.py:136
+msgid "How many children do you have?"
+msgstr "子供は何人いるの？"
+
+#: accounts/forms.py:137
+msgid "For each child, please enter his or her birthdate:"
+msgstr "お子様一人一人の生年月日をご記入ください。"
+
+#: accounts/forms.py:138
+msgid "How many parents/guardians do your children live with?"
+msgstr "あなたのお子さんは何人の親御さん・保護者の方と一緒に暮らしていますか？"
+
+#: accounts/forms.py:139
+msgid "What category(ies) does your family identify as?"
+msgstr "あなたの家族はどのようなカテゴリーに属していますか？"
+
+#: accounts/forms.py:140
+msgid "What is your age?"
+msgstr "年齢。"
+
+#: accounts/forms.py:141
+msgid "What is your gender?"
+msgstr "性別は何ですか？"
+
+#: accounts/forms.py:142
+msgid "What is the highest level of education you've completed?"
+msgstr "最高レベルの学歴は？"
+
+#: accounts/forms.py:143
+msgid "What is the highest level of education your spouse has completed?"
+msgstr "配偶者の最高学歴は？"
+
+#: accounts/forms.py:144
+msgid "What is your approximate family yearly income (in US dollars)?"
+msgstr "おおよそのご家族の年収（ドル建て）は？"
+
+#: accounts/forms.py:145
+msgid "About how many children's books are there in your home?"
+msgstr "あなたの家には児童書が何冊あるかについて。"
+
+#: accounts/forms.py:146
+msgid "Anything else you'd like us to know?"
+msgstr "他に何か知っておいてほしいことは？"
+
+#: accounts/forms.py:147
+msgid "How did you hear about Lookit?"
+msgstr "Lookitをどうやって知りましたか？"
+
+#: accounts/forms.py:148
+msgid ""
+"If the answer varies due to shared custody arrangements or travel, please "
+"enter the number of parents/guardians your children are usually living with "
+"or explain."
+msgstr ""
+"共有親権の取り決めや旅行などで回答が異なる場合は、子どもが普段一緒に暮らして"
+"いる親・保護者の人数を記入するか、説明してください。"
+
+#: accounts/migrations/0041_add_existing_conditions.py:12
+#: accounts/models.py:250 studies/fields.py:136
+msgid "Not sure or prefer not to answer"
+msgstr "わからない、または答えたくない"
+
+#: accounts/migrations/0041_add_existing_conditions.py:13
+#: accounts/models.py:251 studies/fields.py:137
+msgid "Under 24 weeks"
+msgstr "24週未満"
+
+#: accounts/migrations/0041_add_existing_conditions.py:14
+#: accounts/models.py:252 studies/fields.py:138
+msgid "24 weeks"
+msgstr "24週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:15
+#: accounts/models.py:253 studies/fields.py:139
+msgid "25 weeks"
+msgstr "25週間"
+
+#: accounts/migrations/0041_add_existing_conditions.py:16
+#: accounts/models.py:254 studies/fields.py:140
+msgid "26 weeks"
+msgstr "26週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:17
+#: accounts/models.py:255 studies/fields.py:141
+msgid "27 weeks"
+msgstr "27週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:18
+#: accounts/models.py:256 studies/fields.py:142
+msgid "28 weeks"
+msgstr "28週間"
+
+#: accounts/migrations/0041_add_existing_conditions.py:19
+#: accounts/models.py:257 studies/fields.py:143
+msgid "29 weeks"
+msgstr "29週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:20
+#: accounts/models.py:258 studies/fields.py:144
+msgid "30 weeks"
+msgstr "30週間"
+
+#: accounts/migrations/0041_add_existing_conditions.py:21
+#: accounts/models.py:259 studies/fields.py:145
+msgid "31 weeks"
+msgstr "31週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:22
+#: accounts/models.py:260 studies/fields.py:146
+msgid "32 weeks"
+msgstr "32週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:23
+#: accounts/models.py:261 studies/fields.py:147
+msgid "33 weeks"
+msgstr "33週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:24
+#: accounts/models.py:262 studies/fields.py:148
+msgid "34 weeks"
+msgstr "34週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:25
+#: accounts/models.py:263 studies/fields.py:149
+msgid "35 weeks"
+msgstr "35週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:26
+#: accounts/models.py:264 studies/fields.py:150
+msgid "36 weeks"
+msgstr "36週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:27
+#: accounts/models.py:265 studies/fields.py:151
+msgid "37 weeks"
+msgstr "37週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:28
+#: accounts/models.py:266 studies/fields.py:152
+msgid "38 weeks"
+msgstr "38週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:29
+#: accounts/models.py:267 studies/fields.py:153
+msgid "39 weeks"
+msgstr "39週"
+
+#: accounts/migrations/0041_add_existing_conditions.py:30
+#: accounts/models.py:268 studies/fields.py:154
+msgid "40 or more weeks"
+msgstr "40週以上"
+
+#: accounts/models.py:66
+msgid "Can View Organization"
+msgstr "組織を見ることができる"
+
+#: accounts/models.py:67
+msgid "Can Edit Organization"
+msgstr "組織を編集することができます"
+
+#: accounts/models.py:68
+msgid "Can Create Organization"
+msgstr "組織を作成することができます"
+
+#: accounts/models.py:69
+msgid "Can Remove Organization"
+msgstr "組織を削除することができます"
+
+#: accounts/models.py:70
+msgid "Can View Experimenter"
+msgstr "実験者を見ることができます"
+
+#: accounts/models.py:71
+msgid "Can View Analytics"
+msgstr "アナリティクスを表示することができます。"
+
+#: accounts/models.py:228
+msgid "Can Create User"
+msgstr "ユーザーを作成することができます"
+
+#: accounts/models.py:229
+msgid "Can View User"
+msgstr "ユーザーを表示することができます。"
+
+#: accounts/models.py:230
+msgid "Can Edit User"
+msgstr "ユーザーを編集することができます"
+
+#: accounts/models.py:231
+msgid "Can Remove User"
+msgstr "ユーザーを削除することができます"
+
+#: accounts/models.py:232
+msgid "Can View User Permissions"
+msgstr "ユーザー権限を表示することができます"
+
+#: accounts/models.py:233
+msgid "Can Edit User Permissions"
+msgstr "ユーザー権限の編集が可能"
+
+#: accounts/models.py:234
+msgid "Can Read All User Data"
+msgstr "すべてのユーザーデータを読み取ることができます"
+
+#: accounts/models.py:235
+msgid "Can Read User Usernames"
+msgstr "ユーザー名を読み取ることができます"
+
+#: accounts/models.py:242 accounts/models.py:345
+msgid "male"
+msgstr "男性"
+
+#: accounts/models.py:243 accounts/models.py:346
+msgid "female"
+msgstr "女性"
+
+#: accounts/models.py:244 accounts/models.py:347
+msgid "other"
+msgstr "人が『いいね』しました。"
+
+#: accounts/models.py:245 accounts/models.py:348 accounts/models.py:424
+msgid "prefer not to answer"
+msgstr "答えたくない"
+
+#: accounts/models.py:335
+msgid "White"
+msgstr "白"
+
+#: accounts/models.py:336
+msgid "Hispanic, Latino, or Spanish origin"
+msgstr "ヒスパニック系、ラテン系、スペイン系"
+
+#: accounts/models.py:337
+msgid "Black or African American"
+msgstr "黒人またはアフリカ系アメリカ人"
+
+#: accounts/models.py:338
+msgid "Asian"
+msgstr "東洋人"
+
+#: accounts/models.py:339
+msgid "American Indian or Alaska Native"
+msgstr "アメリカインディアンまたはアラスカ原住民"
+
+#: accounts/models.py:340
+msgid "Middle Eastern or North African"
+msgstr "中近東または北アフリカ"
+
+#: accounts/models.py:341
+msgid "Native Hawaiian or Other Pacific Islander"
+msgstr "ネイティブハワイアンまたはその他の太平洋諸島人"
+
+#: accounts/models.py:342
+msgid "Another race, ethnicity, or origin"
+msgstr "他の人種、民族、出身"
+
+#: accounts/models.py:351 accounts/models.py:360
+msgid "some or attending high school"
+msgstr "或は高校に通う"
+
+#: accounts/models.py:352 accounts/models.py:361
+msgid "high school diploma or GED"
+msgstr "高卒以上"
+
+#: accounts/models.py:353 accounts/models.py:362
+msgid "some or attending college"
+msgstr "どっか"
+
+#: accounts/models.py:354 accounts/models.py:363
+msgid "2-year college degree"
+msgstr "二年制大学"
+
+#: accounts/models.py:355 accounts/models.py:364
+msgid "4-year college degree"
+msgstr "四年制大学"
+
+#: accounts/models.py:356 accounts/models.py:365
+msgid "some or attending graduate or professional school"
+msgstr "一部"
+
+#: accounts/models.py:357 accounts/models.py:366
+msgid "graduate or professional degree"
+msgstr "卒論"
+
+#: accounts/models.py:367
+msgid "not applicable - no spouse or partner"
+msgstr "該当しない - 配偶者やパートナーがいない"
+
+#: accounts/models.py:370 accounts/models.py:401
+msgid "0"
+msgstr "0"
+
+#: accounts/models.py:371 accounts/models.py:398
+msgid "1"
+msgstr "1"
+
+#: accounts/models.py:372 accounts/models.py:398
+msgid "2"
+msgstr "2"
+
+#: accounts/models.py:373
+msgid "3"
+msgstr "3"
+
+#: accounts/models.py:374
+msgid "4"
+msgstr "4"
+
+#: accounts/models.py:375
+msgid "5"
+msgstr "5"
+
+#: accounts/models.py:376
+msgid "6"
+msgstr "6"
+
+#: accounts/models.py:377
+msgid "7"
+msgstr "7"
+
+#: accounts/models.py:378
+msgid "8"
+msgstr "8"
+
+#: accounts/models.py:379
+msgid "9"
+msgstr "9"
+
+#: accounts/models.py:380
+msgid "10"
+msgstr "10"
+
+#: accounts/models.py:381
+msgid "More than 10"
+msgstr "10名以上"
+
+#: accounts/models.py:384
+msgid "under 18"
+msgstr "18歳未満"
+
+#: accounts/models.py:385
+msgid "18-21"
+msgstr "18-21"
+
+#: accounts/models.py:386
+msgid "22-24"
+msgstr "22-24"
+
+#: accounts/models.py:387
+msgid "25-29"
+msgstr "25-29"
+
+#: accounts/models.py:388
+msgid "30-34"
+msgstr "30-34"
+
+#: accounts/models.py:389
+msgid "35-39"
+msgstr "35-39"
+
+#: accounts/models.py:390
+msgid "40-44"
+msgstr "40-44"
+
+#: accounts/models.py:391
+msgid "45-49"
+msgstr "45-49"
+
+#: accounts/models.py:392
+msgid "50-59"
+msgstr "50-59"
+
+#: accounts/models.py:393
+msgid "60-69"
+msgstr "60-69"
+
+#: accounts/models.py:394
+msgid "70 or over"
+msgstr "70以上"
+
+#: accounts/models.py:398
+msgid "3 or more"
+msgstr "3個以上"
+
+#: accounts/models.py:398
+msgid "varies"
+msgstr "変わる"
+
+#: accounts/models.py:402
+msgid "5000"
+msgstr "5000"
+
+#: accounts/models.py:403
+msgid "10000"
+msgstr "10000"
+
+#: accounts/models.py:404
+msgid "15000"
+msgstr "15000"
+
+#: accounts/models.py:405
+msgid "20000"
+msgstr "20000"
+
+#: accounts/models.py:406
+msgid "30000"
+msgstr "30000"
+
+#: accounts/models.py:407
+msgid "40000"
+msgstr "40000"
+
+#: accounts/models.py:408
+msgid "50000"
+msgstr "50000"
+
+#: accounts/models.py:409
+msgid "60000"
+msgstr "60000"
+
+#: accounts/models.py:410
+msgid "70000"
+msgstr "70000"
+
+#: accounts/models.py:411
+msgid "80000"
+msgstr "80000"
+
+#: accounts/models.py:412
+msgid "90000"
+msgstr "90000"
+
+#: accounts/models.py:413
+msgid "100000"
+msgstr "100000"
+
+#: accounts/models.py:414
+msgid "110000"
+msgstr "110000"
+
+#: accounts/models.py:415
+msgid "120000"
+msgstr "120000"
+
+#: accounts/models.py:416
+msgid "130000"
+msgstr "130000"
+
+#: accounts/models.py:417
+msgid "140000"
+msgstr "140000"
+
+#: accounts/models.py:418
+msgid "150000"
+msgstr "150000"
+
+#: accounts/models.py:419
+msgid "160000"
+msgstr "160000"
+
+#: accounts/models.py:420
+msgid "170000"
+msgstr "170000"
+
+#: accounts/models.py:421
+msgid "180000"
+msgstr "180000"
+
+#: accounts/models.py:422
+msgid "190000"
+msgstr "190000"
+
+#: accounts/models.py:423
+msgid "over 200000"
+msgstr "二十万以上"
+
+#: accounts/models.py:427
+msgid "urban"
+msgstr "アーバン"
+
+#: accounts/models.py:427
+msgid "suburban"
+msgstr "郊外"
+
+#: accounts/models.py:427
+msgid "rural"
+msgstr "田舎"
+
+#: accounts/models.py:477
+msgid "Select a State"
+msgstr "州を選択してください"
+
+#: accounts/templates/account/local_user_exists.html:7
+#: accounts/templates/account/login_errored_cancelled.html:7
+msgid "Login Unsuccessful"
+msgstr "ログイン失敗"
+
+#: accounts/templates/account/login.html:7
+msgid "Sign In"
+msgstr "サインイン"
+
+#: accounts/templates/account/login.html:13
+msgid "Login"
+msgstr "ログイン"
+
+#: accounts/templates/account/login.html:20
+msgid ""
+"\n"
+"          Please sign in to the Open Science Framework or register for an "
+"account and sign in below.\n"
+"      </p>\n"
+"      <p>\n"
+"        By using or requesting access to Lookit, you agree that you have "
+"read and accepted the <a href=\"/termsofuse/\" target=\"_blank\">Terms of "
+"Use</a> and <a href=\"/privacy/\" target=\"_blank\">Privacy Statement</a>.\n"
+"        "
+msgstr ""
+"\n"
+"          オープンサイエンスフレームワークにサインインするか、アカウント登録"
+"をして下記よりサインインしてください。\n"
+"      </p>\n"
+"      <p>\n"
+"        Lookitを使用またはアクセスを要求することで、利用者は<a href=\"/"
+"termsofuse/\" target=\"_blank\">利用規約</a>と<a href=\"/privacy/\" target="
+"\"_blank\">プライバシーポリシーを</a>読み、これに同意したことになります。\n"
+"        "
+
+#: exp/templates/exp/dashboard.html:17
+msgid "Dashboard"
+msgstr "ダッシュボード"
+
+#: studies/fields.py:45
+msgid "Twin"
+msgstr "双子"
+
+#: studies/fields.py:46
+msgid "Triplet"
+msgstr "三つ子"
+
+#: studies/fields.py:47
+msgid "Quadruplet"
+msgstr "四重項"
+
+#: studies/fields.py:48
+msgid "Quintuplet"
+msgstr "五重奏"
+
+#: studies/fields.py:49
+msgid "Sextuplet"
+msgstr "セクスタプレット"
+
+#: studies/fields.py:50
+msgid "Septuplet"
+msgstr "セプトゥプレット"
+
+#: studies/fields.py:51
+msgid "Octuplet"
+msgstr "オクタプレット"
+
+#: studies/fields.py:124
+msgid "Not answered"
+msgstr "未回答"
+
+#: studies/fields.py:125
+msgid "Other"
+msgstr "その他"
+
+#: studies/fields.py:126
+msgid "Male"
+msgstr "男性"
+
+#: studies/fields.py:127
+msgid "Female"
+msgstr "女性"
+
+#: studies/models.py:113
+msgid ""
+"The Users who belong to this Lab. A user in this lab will be able to create "
+"studies associated with this Lab and can be added to this Lab's studies."
+msgstr ""
+"この研究室に所属するユーザーです。本研究室に所属するユーザーは、本研究室に関"
+"連する研究を作成することができ、本研究室の研究に追加することができます。"
+
+#: studies/models.py:122
+msgid "The Users who have requested to join this Lab."
+msgstr "本研究室への参加を希望された利用者様。"
+
+#: web/templates/registration/password_change_done.html:15
+msgid "Your password was changed."
+msgstr "パスワードが変更されていました。"
+
+#: web/templates/registration/password_change_form.html:4
+msgid "Documentation"
+msgstr "ドキュメント"
+
+#: web/templates/registration/password_change_form.html:4
+msgid "Change password"
+msgstr "パスワードの変更"
+
+#: web/templates/registration/password_change_form.html:4
+msgid "Log out"
+msgstr "ログアウト"
+
+#: web/templates/registration/password_change_form.html:7
+msgid "Home"
+msgstr "ホーム"
+
+#: web/templates/registration/password_change_form.html:8
+msgid "Password change"
+msgstr "パスワードの変更"
+
+#: web/templates/registration/password_change_form.html:21
+msgid "Please correct the error below."
+msgstr "下記のエラーの修正をお願いします。"
+
+#: web/templates/registration/password_change_form.html:21
+msgid "Please correct the errors below."
+msgstr "以下、誤りの訂正をお願いします。"
+
+#: web/templates/registration/password_change_form.html:26
+msgid ""
+"Please enter your old password, for security's sake, and then enter your new "
+"password twice so we can verify you typed it in correctly."
+msgstr ""
+"セキュリティのために古いパスワードを入力し、新しいパスワードを2回入力してくだ"
+"さい。"
+
+#: web/templates/registration/password_change_form.html:54
+#: web/templates/registration/password_reset_confirm.html:31
+msgid "Change my password"
+msgstr "パスワードの変更"
+
+#: web/templates/registration/password_reset_complete.html:15
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "パスワードが設定されています。  今すぐログインしてください。"
+
+#: web/templates/registration/password_reset_complete.html:17
+msgid "Log in"
+msgstr "ログイン"
+
+#: web/templates/registration/password_reset_confirm.html:11
+msgid "Password reset confirmation"
+msgstr "パスワードリセットの確認"
+
+#: web/templates/registration/password_reset_confirm.html:17
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly."
+msgstr "新しいパスワードを2回入力してください。"
+
+#: web/templates/registration/password_reset_confirm.html:23
+msgid "New password:"
+msgstr "新しいパスワード："
+
+#: web/templates/registration/password_reset_confirm.html:28
+msgid "Confirm password:"
+msgstr "パスワードの確認："
+
+#: web/templates/registration/password_reset_confirm.html:37
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+"パスワードリセットのリンクが無効になっています。  新しいパスワードリセットを"
+"リクエストしてください。"
+
+#: web/templates/registration/password_reset_done.html:15
+msgid ""
+"We've emailed you instructions for setting your password, if an account "
+"exists with the email you entered. You should receive them shortly."
+msgstr ""
+"入力されたメールにアカウントが存在する場合は、パスワードの設定方法をメールで"
+"お知らせしています。まもなくメールが届きます。"
+
+#: web/templates/registration/password_reset_done.html:17
+msgid ""
+"If you don't receive an email, please make sure you've entered the address "
+"you registered with, and check your spam folder."
+msgstr ""
+"メールが届かない場合は、登録したアドレスが入力されていることを確認し、迷惑"
+"メールフォルダをご確認ください。"
+
+#: web/templates/registration/password_reset_email.html:2
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at %(site_name)s."
+msgstr ""
+"この電子メールを受信しているのは、%(site_name)s のユーザ・アカウントのパス"
+"ワードのリセットを要求したためです。"
+
+#: web/templates/registration/password_reset_email.html:4
+msgid "Please go to the following page and choose a new password:"
+msgstr "以下のページに移動し、新しいパスワードを選択してください。"
+
+#: web/templates/registration/password_reset_email.html:8
+msgid "Your username, in case you've forgotten:"
+msgstr "ユーザー名をお忘れですか？こちらになります。"
+
+#: web/templates/registration/password_reset_email.html:10
+msgid "Thanks for using our site!"
+msgstr "当社のサイトをご利用いただき、ありがとうございました"
+
+#: web/templates/registration/password_reset_email.html:12
+#, python-format
+msgid "The %(site_name)s team"
+msgstr "%(site_name) s チーム"
+
+#: web/templates/registration/password_reset_form.html:15
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll email "
+"instructions for setting a new one."
+msgstr "パスワードをお忘れですか？下記にメールアドレスを入力してください。"
+
+#: web/templates/registration/password_reset_form.html:21
+msgid "Email address:"
+msgstr "メールアドレス:"
+
+#: web/templates/registration/password_reset_form.html:24
+msgid "Reset my password"
+msgstr "パスワードをリセットする"
+
+#: web/templates/web/_account-navigation.html:2
+msgid "Account information"
+msgstr ""
+
+#: web/templates/web/_account-navigation.html:2
+msgid "Change your name, email, or password."
+msgstr "パスワードの変更"
+
+#: web/templates/web/demographic-data-update.html:89
+msgid ""
+"One reason we are developing Internet-based experiments is to represent a "
+"more diverse group of families in our research. Your answers to these "
+"questions will help us understand what audience we reach, as well as how "
+"factors like speaking multiple languages or having older siblings affect "
+"children's learning."
+msgstr ""
+"インターネットを利用した実験を開発している理由の一つは、より多様な家族のグ"
+"ループを代表して研究を行うためです。これらの質問への回答は、私たちがどのよう"
+"な対象者に到達するのか、また、多言語を話すことや年上の兄弟がいることなどの要"
+"因が子どもの学習にどのような影響を与えるのかを理解するのに役立ちます。"
+
+#: web/templates/web/demographic-data-update.html:90
+msgid ""
+"Even if you allow your study videos to be published for scientific or "
+"publicity purposes, your demographic information is never published in "
+"conjunction with your video."
+msgstr ""
+"科学や宣伝目的で学習動画の公開を許可したとしても、デモグラフィック情報が動画"
+"と連動して公開されることはありません。"

--- a/project/settings/defaults.py
+++ b/project/settings/defaults.py
@@ -208,7 +208,7 @@ JSON_API_PLURALIZE_TYPES = True
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "ja"
 
 TIME_ZONE = "America/New_York"
 
@@ -370,3 +370,6 @@ OSF_OAUTH_SECRET = os.environ.get(
 )
 
 JAMDB_AUTH_TOKEN = os.environ.get("JAMDB_AUTH_TOKEN", "")
+
+SITE_ROOT = os.path.dirname(os.path.realpath(__name__))
+LOCALE_PATHS = ( os.path.join(SITE_ROOT, 'locale'), )

--- a/project/settings/defaults.py
+++ b/project/settings/defaults.py
@@ -88,6 +88,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -208,7 +209,7 @@ JSON_API_PLURALIZE_TYPES = True
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
 
-LANGUAGE_CODE = "ja"
+LANGUAGE_CODE = "en-us"
 
 TIME_ZONE = "America/New_York"
 

--- a/project/settings/local-dist.py
+++ b/project/settings/local-dist.py
@@ -18,3 +18,5 @@ EMAIL_FROM_ADDRESS = "lookit.robot@some.domain"
 EMAIL_BACKEND = (
     f"django.core.mail.backends.{'console' if DEBUG else 'smtp'}.EmailBackend"
 )
+
+# SESSION_COOKIE_SECURE= False # For local debugging

--- a/project/urls.py
+++ b/project/urls.py
@@ -26,9 +26,11 @@ from osf_oauth2_adapter import views as osf_oauth2_adapter_views
 from project import settings
 from web import urls as web_urls
 
+from django.conf.urls.i18n import i18n_patterns 
+
 favicon_view = RedirectView.as_view(url="/static/favicon.ico", permanent=True)
 
-urlpatterns = [
+urlpatterns = i18n_patterns(
     path("favicon.ico", favicon_view),
     path("__CTRL__/", admin.site.urls),
     path("api/", include((api_urls, "api"))),
@@ -43,7 +45,8 @@ urlpatterns = [
     path("exp/", include(exp_urls)),
     path("", include("django.contrib.auth.urls")),
     path("", include(web_urls)),
-]
+    prefix_default_language=False
+)
 
 if settings.DEBUG:
     import debug_toolbar

--- a/web/templates/registration/logged_out.html
+++ b/web/templates/registration/logged_out.html
@@ -1,7 +1,8 @@
 {% extends "web/base.html" %}
+{% load i18n %}
 
 {% block content %}
 <div class="container mb-lg">
-  <h1>You've successfully logged out.</h1>
+  <h1>{% trans "You've successfully logged out." %}</h1>
 </div>
 {% endblock %}

--- a/web/templates/registration/login.html
+++ b/web/templates/registration/login.html
@@ -1,11 +1,11 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
-
+{% load i18n %}
 {% block flash %}
   {% bootstrap_messages %}
   {% if form.errors %}
   <div class="alert alert-danger" role="alert">
-    <p>Your username and password didn't match. Please try again.</p>
+    <p>{% trans "Your username and password didn't match. Please try again."%}</p>
   </div>
   {% endif %}
 {% endblock %}
@@ -15,23 +15,23 @@
     <div class="pt-lg col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12 col-xs-offset-0">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Participant Login</h3>
+            <h3 class="panel-title">{% trans "Participant Login" %}</h3>
           </div>
           <div class="panel-body">
             <form action="" method="POST" class="form">{% csrf_token %}
               {% bootstrap_form form %}
               {% buttons %}
                   <div class="text-center">
-                       <button type="submit" class="btn btn-success">{% bootstrap_icon "user" %} Login</button>
+                       <button type="submit" class="btn btn-success">{% bootstrap_icon "user" %} {% trans "Login" %}</button>
                   </div>
               {% endbuttons %}
               <input type="hidden" name="next" value="{{ next }}" />
             </form>
 
             {# Assumes you setup the password_reset view in your URLconf #}
-            <p class="text-center"><a href="{% url 'password_reset' %}">Forgot password?</a></p>
-            <p class="text-center">Looking for <a href="{% url 'exp:study-list' %}">researcher login</a> instead?</p>
-            <p class="text-center"><strong>New to Lookit?</strong> <a href="{% url 'web:participant-signup' %}"> Create an account! </a></p>
+            <p class="text-center"><a href="{% url 'password_reset' %}">{% trans "Forgot password?" %}</a></p>
+            <p class="text-center">{% trans "Looking for " %}<a href="{% url 'exp:study-list' %}">{% trans "researcher login"%}</a>{% trans "instead?"%}</p>
+            <p class="text-center"><strong>{% trans "New to Lookit?"%}</strong> <a href="{% url 'web:participant-signup' %}"> {% trans "Create an account!" %} </a></p>
           </div>
         </div>
     </div>

--- a/web/templates/registration/password_change_done.html
+++ b/web/templates/registration/password_change_done.html
@@ -8,7 +8,7 @@
     <div class="pt-lg col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12 col-xs-offset-0">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Password changed</h3>
+            <h3 class="panel-title">{% trans "Password changed" %}</h3>
           </div>
           <div class="panel-body">
           

--- a/web/templates/registration/password_reset_complete.html
+++ b/web/templates/registration/password_reset_complete.html
@@ -8,7 +8,7 @@
     <div class="pt-lg col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12 col-xs-offset-0">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Password reset complete</h3>
+            <h3 class="panel-title">{% trans "Password reset complete" %}</h3>
           </div>
           <div class="panel-body">
           

--- a/web/templates/web/_account-navigation.html
+++ b/web/templates/web/_account-navigation.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 <a class="{% if current_page == 'participant-update' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:participant-update' %}"><strong>{% trans "Account information" %}</strong><br>{% trans "Change your name, email, or password."%}</a>
-<a class="{% if current_page == 'demographic-update' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:demographic-data-update' %}"><strong>Demographic Survey</strong><br>Tell us more about yourself.</a>
-<a class="{% if current_page == 'children-list' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:children-list' %}"><strong>Children Information</strong><br>Add or edit participant information.</a>
-<a class="{% if current_page == 'email-preferences' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:email-preferences' %}"><strong>Email Preferences</strong><br>Edit when you can be contacted.</a>
+<a class="{% if current_page == 'demographic-update' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:demographic-data-update' %}"><strong>{% trans "Demographic Survey" %}</strong><br>{% trans "Tell us more about yourself." %}</a>
+<a class="{% if current_page == 'children-list' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:children-list' %}"><strong>{% trans "Children Information" %}</strong><br>{% trans "Add or edit participant information." %}</a>
+<a class="{% if current_page == 'email-preferences' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:email-preferences' %}"><strong>{% trans "Email Preferences" %}</strong><br>{% trans "Edit when you can be contacted." %}</a>

--- a/web/templates/web/_account-navigation.html
+++ b/web/templates/web/_account-navigation.html
@@ -1,4 +1,5 @@
-<a class="{% if current_page == 'participant-update' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:participant-update' %}"><strong>Account information</strong><br> Change your name, email, or password.</a>
+{% load i18n %}
+<a class="{% if current_page == 'participant-update' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:participant-update' %}"><strong>{% trans "Account information" %}</strong><br>{% trans "Change your name, email, or password."%}</a>
 <a class="{% if current_page == 'demographic-update' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:demographic-data-update' %}"><strong>Demographic Survey</strong><br>Tell us more about yourself.</a>
 <a class="{% if current_page == 'children-list' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:children-list' %}"><strong>Children Information</strong><br>Add or edit participant information.</a>
 <a class="{% if current_page == 'email-preferences' %} active {% endif %} btn btn-default btn-md btn-block" href="{% url 'web:email-preferences' %}"><strong>Email Preferences</strong><br>Edit when you can be contacted.</a>

--- a/web/templates/web/_navigation.html
+++ b/web/templates/web/_navigation.html
@@ -1,4 +1,5 @@
 {% load bootstrap3 %}
+{% load i18n %}
 
 <nav class="navbar-default navbar-static-top">
   <div class="container">
@@ -12,12 +13,12 @@
       
       {% if user.is_researcher %}
         <ul class="nav navbar-nav navbar-left">
-          <li class="nav-item active"><a class="navbar-item" href="{% url 'web:home' %}">Lookit</a></li>
-          <li class="nav-item"><a class="navbar-item active" href="{% url 'exp:study-list' %}">Experimenter</a></li>
+          <li class="nav-item active"><a class="navbar-item" href="{% url 'web:home' %}">{% trans "Lookit" %}</a></li>
+          <li class="nav-item"><a class="navbar-item active" href="{% url 'exp:study-list' %}">{% trans "Experimenter" %}</a></li>
           <li class="divider-vertical"></li>
         </ul>
       {% else %}
-        <a class="navbar-brand" href="{% url 'web:home' %}">Lookit </a>
+        <a class="navbar-brand" href="{% url 'web:home' %}">{% trans "Lookit" %}</a>
       {% endif %}
       
       
@@ -26,24 +27,24 @@
 
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav navbar-left">
-        <li><a href="{% url 'web:studies-list' %}">Studies</a></li>
-        <li><a href="{% url 'web:faq' %}">FAQ</a></li>
-        <li><a href="{% url 'web:scientists' %}">The Scientists</a></li>
-        <li><a href="{% url 'web:resources' %}">Resources</a></li>
+        <li><a href="{% url 'web:studies-list' %}">{% trans "Studies" %}</a></li>
+        <li><a href="{% url 'web:faq' %}">{% trans "FAQ" %}</a></li>
+        <li><a href="{% url 'web:scientists' %}">{% trans "The Scientists" %}</a></li>
+        <li><a href="{% url 'web:resources' %}">{% trans "Resources" %}</a></li>
       </ul>
       
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-2">
         <ul class="nav navbar-nav navbar-right">
           {% if user.is_authenticated %}
             {% if user.is_researcher %}
-              <li><a href="{% url 'web:participant-update' %}">Participant account</a></li>
+              <li><a href="{% url 'web:participant-update' %}">{% trans "Participant account" %}</a></li>
             {% else %}
-              <li><a href="{% url 'web:participant-update' %}">Hi {{ user.nickname }}</a></li>
+              <li><a href="{% url 'web:participant-update' %}">{% trans "Hi" %} {{ user.nickname }}</a></li>
             {% endif %}
-            <li><a href="{% url 'logout' %}">Logout</a></li>
+            <li><a href="{% url 'logout' %}">{% trans "Logout" %}</a></li>
           {% else %}
-            <li><a href="{% url 'web:participant-signup' %}">Sign up</a></li>
-            <li><a href="{% url 'login' %}{% if request.get_full_path != '/logout/' %}?next={{ request.get_full_path }}{% else %}?next=/{%endif %}">Login</a></li>
+            <li><a href="{% url 'web:participant-signup' %}">{% trans "Sign up" %}</a></li>
+            <li><a href="{% url 'login' %}{% if request.get_full_path != '/logout/' %}?next={{ request.get_full_path }}{% else %}?next=/{%endif %}">{% trans "Login" %}</a></li>
           {% endif %}
         </ul>
       </div>

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -1,5 +1,7 @@
 {% load bootstrap3 %}
 {% load static %}
+{% load i18n %}
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/web/templates/web/child-update.html
+++ b/web/templates/web/child-update.html
@@ -1,6 +1,7 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
-{% block title %}Child - {{child.given_name}}{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Child" } - {{child.given_name}}{% endblock %}
 
 
 {% block flash %}
@@ -12,7 +13,7 @@
 {% endblock %}
 {% block content %}
     <div class='lookit-row lookit-page-title'>
-        <h2 class='container'>My Account</h2>
+        <h2 class='container'>{% trans "My Account" %}</h2>
     </div>
     {% bootstrap_messages %}
     <div class="container">
@@ -27,7 +28,7 @@
                 <div id="add-child-form" style="display:{% if form_hidden %} none {% else %} inline {% endif %}">
                     <div class="panel-heading">
                       <h1 class="panel-title">
-                          Update {{ child.given_name }}
+                          {% trans "Update" %} {{ child.given_name }}
                       </h1>
                     </div>
                     <div class="panel panel-default">
@@ -37,12 +38,12 @@
                               {% bootstrap_form form %}
                               {% buttons %}
                               <button name='deleteChild' class="btn btn-danger" type="submit">
-                                  Delete
+                                  {% trans "Delete" %}
                               </button>
                               <div class="pull-right">
                                   <a class="btn btn-default" href="{% url 'web:children-list' %}"> Cancel </a>
                                   <button type="submit" class="btn btn-success">
-                                     Save
+                                     {% trans "Save" %}
                                   </button>
                               </div>
                               {% endbuttons %}

--- a/web/templates/web/children-list.html
+++ b/web/templates/web/children-list.html
@@ -1,6 +1,7 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
 {% block title %}Children{% endblock %}
+{% load i18n %}
 
 {% block flash %}
   {% if form.non_field_errors %}
@@ -11,6 +12,7 @@
 {% endblock %}
 {% block content %}
     <script>
+        
         $(document).ready(function() {
             $('.datepicker').datepicker({
                changeMonth: true,
@@ -35,18 +37,18 @@
         });
         function getAge(dateValue) {
             if (dateValue.value === '') {
-                return "Empty birthday"
+                return '{% trans "Empty birthday" %} '  
             }
             var years = moment().diff(new Date(dateValue.value), 'years');
             if (years === 0) {
                 var months = moment().diff(new Date(dateValue.value), 'months');
                 if (months === 0) {
                     var days = moment().diff(new Date(dateValue.value), 'days');
-                    return days === 1 ? days + ' day': days + ' days';
+                    return days === 1 ? days + '{% trans " day" %}': days + '{% trans " days" %}';
                 }
-                return months === 1 ? months + ' month': months + ' months';
+                return months === 1 ? months + '{% trans " month" %}': months + '{% trans " months" %}';
             } else {
-                return years === 1 ? years + ' year': years + ' years';
+                return years === 1 ? years + '{% trans " year" %}': years + '{% trans " years" %}';
             }
         }
 
@@ -56,13 +58,13 @@
         $(function() {
            $("#toggleAddChildButton").click(function () {
               $(this).text(function(i, text){
-                  return text === "Add Child" ? "Hide Form" : "Add Child";
+                  return text === '{% trans "Add Child" %}' ? '{% trans "Hide Form" %}' : '{% trans "Add Child" %}';
               })
            });
         })
     </script>
     <div class='lookit-row lookit-page-title'>
-        <h2 class='container'>My Account</h2>
+        <h2 class='container'>{% trans "My Account" %}</h2>
     </div>
     {% bootstrap_messages %}
     <div class="container">
@@ -72,12 +74,12 @@
             </div>
             <div class="col-md-8">
                 <div class="pull-right">
-                    <button id="toggleAddChildButton" onclick="toggleAddChildForm()"class="btn btn-primary">{% if form_hidden %}Add Child{% else %} Hide Form {% endif %}</button>
+                    <button id="toggleAddChildButton" onclick="toggleAddChildForm()"class="btn btn-primary">{% if form_hidden %}{% trans "Add Child" %}{% else %} {% trans "Hide Form" %} {% endif %}</button>
                 </div>
                 <div id="add-child-form" style="display:{% if form_hidden %} none {% else %} inline {% endif %}">
                     <div class="panel-heading">
                       <h1 class="panel-title">
-                          Add Child
+                          {% trans "Add Child" %}
                       </h1>
                     </div>
                     <div class="panel panel-default">
@@ -87,9 +89,9 @@
                               {% bootstrap_form form %}
                               {% buttons %}
                               <div class="pull-right">
-                                  <a class="btn btn-default" href="{% url 'web:children-list' %}"> Cancel </a>
+                                  <a class="btn btn-default" href="{% url 'web:children-list' %}"> {% trans "Cancel" %} </a>
                                   <button type="submit" class="btn btn-success">
-                                     {% bootstrap_icon "plus" %} Add Child
+                                     {% bootstrap_icon "plus" %} {% trans "Add Child" %}
                                   </button>
                               </div>
                               {% endbuttons %}
@@ -100,14 +102,14 @@
                 </div>
                 <div class="row">
                     <div class="col-xs-12">
-                        <h2><label> Children </label></h2>
+                        <h2><label> {% trans "Children" %} </label></h2>
                         {% if objects %}
                             <div class="table-responsive">
                                 <table class="table">
                                   <thead>
                                     <tr>
-                                      <th>Name</th>
-                                      <th>Birthday</th>
+                                      <th>{% trans "Name" %}</th>
+                                      <th>{% trans "Birthday" %}</th>
                                       <th></th>
                                     </tr>
                                   </thead>
@@ -116,14 +118,14 @@
                                           <tr>
                                             <td>{{ child.given_name }}</td>
                                             <td>{{ child.birthday }}</td>
-                                            <td> <a href="{% url 'web:child-update' child.uuid %}" class="btn btn-sm btn-primary"> Update child </a></td>
+                                            <td> <a href="{% url 'web:child-update' child.uuid %}" class="btn btn-sm btn-primary"> {% trans "Update child" %} </a></td>
                                           </tr>
                                       {% endfor %}
                                   </tbody>
                                 </table>
                             </div>
                         {% else %}
-                            <p><em> No child profiles registered! </em></p>
+                            <p><em> {% trans "No child profiles registered!" %} </em></p>
                         {% endif %}
                     </div>
                 </div>

--- a/web/templates/web/demographic-data-update.html
+++ b/web/templates/web/demographic-data-update.html
@@ -75,7 +75,7 @@
         }
     </script>
     <div class='lookit-row lookit-page-title'>
-        <h2 class='container'>My Account</h2>
+        <h2 class='container'>{% trans "My Account" %}</h2>
     </div>
     {% bootstrap_messages %}
     <div class="container">

--- a/web/templates/web/demographic-data-update.html
+++ b/web/templates/web/demographic-data-update.html
@@ -1,7 +1,7 @@
 {% extends 'web/base.html' %}
 {% load i18n %}
 {% load bootstrap3 %}
-{% block title %}Update demographics{% endblock %}
+{% block title %}{% trans "Update demographics" %}{% endblock %}
 
 {% block flash %}
   {% if form.non_field_errors %}
@@ -97,9 +97,9 @@
                       {% bootstrap_form form %}
                       {% buttons %}
                       <div class="pull-right">
-                          <a class="btn btn-default" href="{% url 'web:demographic-data-update' %}"> Cancel </a>
+                          <a class="btn btn-default" href="{% url 'web:demographic-data-update' %}"> {% trans "Cancel" %} </a>
                           <button type="submit" class="btn btn-success">
-                             Save
+                             {% trans "Save" %}
                           </button>
                       </div>
                       {% endbuttons %}

--- a/web/templates/web/demographic-data-update.html
+++ b/web/templates/web/demographic-data-update.html
@@ -1,4 +1,5 @@
 {% extends 'web/base.html' %}
+{% load i18n %}
 {% load bootstrap3 %}
 {% block title %}Update demographics{% endblock %}
 
@@ -85,11 +86,8 @@
             <div class="col-md-8">
                 <div class="panel-heading">
                   <h1 class="panel-title">
-                      <p> One reason we are developing Internet-based experiments is to represent a more diverse group of families in our research.
-                      Your answers to these questions will help us understand what audience we reach, as well as how factors like speaking
-                      multiple languages or having older siblings affect children's learning. </p>
-                      <p> Even if you allow your study videos to be published
-                      for scientific or publicity purposes, your demographic information is never published in conjunction with your video. </p>
+                      <p>{% trans "One reason we are developing Internet-based experiments is to represent a more diverse group of families in our research. Your answers to these questions will help us understand what audience we reach, as well as how factors like speaking multiple languages or having older siblings affect children's learning." %}</p>
+                      <p>{% trans "Even if you allow your study videos to be published for scientific or publicity purposes, your demographic information is never published in conjunction with your video." %}</p>
                   </h1>
 
                 </div>

--- a/web/templates/web/home.html
+++ b/web/templates/web/home.html
@@ -1,9 +1,9 @@
 {% extends 'web/base.html' %}
 
-{% block title %}Home{% endblock %}
+{% block title %}{% trans "Home" %}{% endblock %}
 
 {% block content %}
   <div class="container">
-      Home
+      {% trans "Home" %}
   </div>
 {% endblock %}

--- a/web/templates/web/participant-email-preferences.html
+++ b/web/templates/web/participant-email-preferences.html
@@ -1,6 +1,7 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
-{% block title %}Email Preferences{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Email Preferences" %}{% endblock %}
 
 
 {% block flash %}
@@ -12,7 +13,7 @@
 {% endblock %}
 {% block content %}
     <div class='lookit-row lookit-page-title'>
-        <h2 class='container'>My Account</h2>
+        <h2 class='container'>{% trans "My Account" %}</h2>
     </div>
     {% bootstrap_messages %}
     <div class="container">
@@ -23,7 +24,7 @@
             <div class="col-md-8">
                 <div class="panel-heading">
                   <h1 class="panel-title">
-                    I would like to be contacted when:
+                    {% trans "I would like to be contacted when:" %}
                   </h1>
                 </div>
                 <div class="panel panel-default">
@@ -32,9 +33,9 @@
                           {% bootstrap_form form %}
                           {% buttons %}
                           <div class="pull-right">
-                              <a class="btn btn-default" href="{% url 'web:email-preferences' %}"> Cancel </a>
+                              <a class="btn btn-default" href="{% url 'web:email-preferences' %}"> {% trans "Cancel" %} </a>
                               <button name="password_update" type="submit" class="btn btn-success">
-                                 Save
+                                 {% trans "Save" %}
                               </button>
                           </div>
                           {% endbuttons %}

--- a/web/templates/web/participant-signup.html
+++ b/web/templates/web/participant-signup.html
@@ -1,6 +1,7 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
-{% block title %}Signup{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Signup" %}{% endblock %}
 
 {% block flash %}
   {% bootstrap_messages %}
@@ -20,10 +21,10 @@
         <form method="POST" action="">{% csrf_token %}
           {% bootstrap_form form %}
           {% buttons %}
-          <p> By clicking 'Create Account', I agree that I have read and accepted the <a href="/privacy/" target="_blank">Privacy Statement.</a></p>
+          <p> {% trans "By clicking 'Create Account', I agree that I have read and accepted the "%} <a href="/privacy/" target="_blank">{% trans "Privacy Statement" %}.</a></p>
           <div class="pull-right">
             <button type="submit" class="btn btn-success">
-              {% bootstrap_icon "plus" %} Create Account
+              {% bootstrap_icon "plus" %} {% trans "Create Account" %}
             </button>
           </div>
           {% endbuttons %}

--- a/web/templates/web/participant-update.html
+++ b/web/templates/web/participant-update.html
@@ -1,6 +1,7 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
-{% block title %}Update account information{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Update account information" %}{% endblock %}
 
 {% block flash %}
   {% if form.non_field_errors %}
@@ -11,7 +12,7 @@
 {% endblock %}
 {% block content %}
     <div class='lookit-row lookit-page-title'>
-        <h2 class='container'>My Account</h2>
+        <h2 class='container'>{% trans "My Account" %}</h2>
     </div>
     {% bootstrap_messages %}
     <div class="container">
@@ -21,7 +22,7 @@
             </div>
             <div class="col-md-8">
                 <div class="panel-heading">
-                  <h1 class="panel-title">Account Information</h1>
+                  <h1 class="panel-title">{% trans "Account Information" %}</h1>
                 </div>
                 <div class="panel panel-default">
                   <div class="panel-body">
@@ -29,9 +30,9 @@
                       {% bootstrap_form form %}
                       {% buttons %}
                       <div class="pull-right">
-                          <a class="btn btn-default" href="{% url 'web:participant-update' %}"> Cancel </a>
+                          <a class="btn btn-default" href="{% url 'web:participant-update' %}"> {% trans "Cancel" %} </a>
                           <button type="submit" name="participant_update" class="btn btn-success">
-                             Save
+                             {% trans "Save" %}
                           </button>
                       </div>
                       {% endbuttons %}
@@ -40,7 +41,7 @@
               </div>
               {% if not request.user.is_researcher %}
                   <div class="panel-heading">
-                    <h1 class="panel-title"> Change Your Password </h1>
+                    <h1 class="panel-title"> {% trans "Change Your Password" %} </h1>
                   </div>
                   <div class="panel panel-default">
                     <div class="panel-body">
@@ -48,9 +49,9 @@
                           {% bootstrap_form form2 %}
                           {% buttons %}
                           <div class="pull-right">
-                              <a class="btn btn-default" href="{% url 'web:participant-update' %}"> Cancel </a>
+                              <a class="btn btn-default" href="{% url 'web:participant-update' %}"> {% trans "Cancel" %} </a>
                               <button name="password_update" type="submit" class="btn btn-success">
-                                 Save
+                                 {% trans "Save" %}
                               </button>
                           </div>
                           {% endbuttons %}

--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -1,21 +1,21 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
-{% block title %}Past Studies{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Past Studies" %}{% endblock %}
 
 {% block flash %}
     {% if form.errors %}
         <div class="alert alert-danger" role="alert">
-            <p>Your username and password didn't match. Please try again.</p>
+            <p>{% trans "Your username and password didn't match. Please try again." %}</p>
         </div>
     {% endif %}
 
     {% if next %}
         <div class="alert alert-danger" role="alert">
             {% if user.is_authenticated %}
-                <p>Your account doesn't have access to this page. To proceed,
-                    please login with an account that has access.</p>
+                <p>{% trans "Your account doesn't have access to this page. To proceed, please login with an account that has access." %}</p>
             {% else %}
-                <p>Please login to see this page.</p>
+                <p>{% trans "Please login to see this page." %}</p>
             {% endif %}
         </div>
     {% endif %}
@@ -24,17 +24,17 @@
     <div>
         <div class="lookit-row lookit-page-title">
             <div class="container">
-                <h2>Past Studies</h2>
+                <h2>{% trans "Past Studies" %}</h2>
             </div>
         </div>
         {% bootstrap_messages %}
         <div class="container">
             <ul class="pt-sm nav nav-tabs">
                 <li>
-                    <a href="{% url 'web:studies-list' %}">Current studies</a>
+                    <a href="{% url 'web:studies-list' %}">{% trans "Current studies" %}</a>
                 </li>
                 <li class="active">
-                    <a href="{% url 'web:studies-history' %}">Your past studies</a>
+                    <a href="{% url 'web:studies-history' %}">{% trans "Your past studies" %}</a>
                 </li>
             </ul>
         </div>
@@ -47,7 +47,7 @@
                         <div id="past-studies">
                             {% if object_list %}
                                 <div class="row study-detail-caption mb-lg">
-                                    Here you can view your studies and see comments left by researchers:
+                                    {% trans "Here you can view your studies and see comments left by researchers:" %}
                                 </div>
                             {% endif %}
                             <div class="row">
@@ -64,7 +64,7 @@
                                                                 <p class="image-block">
                                                                     <img class="study-list-thumbnail"
                                                                          height="150" width="auto"
-                                                                         alt="Study Thumbnail"
+                                                                         alt='{% trans "Study Thumbnail" %}'
                                                                          src="{{ study.image.url }}">
                                                                 </p>
                                                             {% else %}
@@ -76,15 +76,15 @@
                                                         <div class="study-feedback-description-wrapper">
                                                             {{ study.short_description }}
                                                             <div class="pt-sm">
-                                                                <strong>Eligibility:</strong> {{ study.criteria }}<br>
-                                                                <strong>Contact:</strong> {{study.contact_info}} <br>
-                                                                <strong>Still collecting data?</strong> {% if study.state == 'active' %} Yes {% else %} No {% endif %} <br>
-                                                                {% if study.compensation_description %} <strong>Compensation: </strong>{{study.compensation_description}}  {% endif %}
+                                                                <strong>{% trans "Eligibility:" %}</strong> {{ study.criteria }}<br>
+                                                                <strong>{% trans "Contact:" %}</strong> {{study.contact_info}} <br>
+                                                                <strong>{% trans "Still collecting data?" %}</strong> {% if study.state == 'active' %} {% trans "Yes" %} {% else %} {% trans "No" %} {% endif %} <br>
+                                                                {% if study.compensation_description %} <strong>{% trans "Compensation: " %}</strong>{{study.compensation_description}}  {% endif %}
                                                                 
                                                             </div>
                                                         </div>
                                                     </div><!-- Responses -->
-                                                    <h4 class="study-feedback-label">Study Responses</h4>
+                                                    <h4 class="study-feedback-label">{% trans "Study Responses" %}</h4>
                                                     <section class="session-media-boxes">
                                                         {% for response in study.responses.all %}
                                                             {% with videos=response.videos.all %}
@@ -113,20 +113,20 @@
                                                                     </div>
                                                                     <div class="media-body">
                                                                         <dl class="dl-horizontal">
-                                                                            <dt>Child</dt>
+                                                                            <dt>{% trans "Child" %}</dt>
                                                                             <dd>{{ response.child.given_name }}</dd>
-                                                                            <dt>Date</dt>
+                                                                            <dt>{% trans "Date" %}</dt>
                                                                             <dd>{{ response.date_created }}</dd>
-                                                                            <dt>Consent status</dt>
+                                                                            <dt>{% trans "Consent status" %}</dt>
                                                                             <dd>
                                                                                 {% if response.most_recent_ruling == 'accepted' %}
-                                                                                    Approved <br> Your consent video was reviewed by a researcher and is valid.
+                                                                                    {% trans "Approved" %} <br> {% trans "Your consent video was reviewed by a researcher and is valid." %}
                                                                                 {% elif response.most_recent_ruling == 'pending' %}
-                                                                                    Pending <br> Your consent video has not yet been reviewed by a researcher.
+                                                                                    {% trans "Pending" %} <br> {% trans "Your consent video has not yet been reviewed by a researcher." %}
                                                                                 {% elif response.most_recent_ruling == 'rejected' %}
-                                                                                    Invalid <br> There was a technical problem with your consent video, or it did not show you reading the consent statement out loud. Your other data from this session will not be viewed or used by the study researchers.
+                                                                                    {% trans "Invalid" %} <br> {% trans "There was a technical problem with your consent video, or it did not show you reading the consent statement out loud. Your other data from this session will not be viewed or used by the study researchers." %}
                                                                                 {% else %}
-                                                                                    No information about consent video review status.
+                                                                                    {% trans "No information about consent video review status." %}
                                                                                 {% endif %}
                                                                             </dd>
                                                                             {% if response.feedback.all %}
@@ -151,7 +151,7 @@
                                             </div>
                                         </div>
                                     {% empty %}
-                                        <p><em> You have not yet participated in any studies. </em></p>
+                                        <p><em> {% trans "You have not yet participated in any studies." %} </em></p>
                                     {% endfor %}
                                 </div>
                             </div>

--- a/web/templates/web/studies-list.html
+++ b/web/templates/web/studies-list.html
@@ -1,21 +1,21 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
-{% block title %}Studies{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Studies" %}{% endblock %}
 
 {% block flash %}
   {% if form.errors %}
   <div class="alert alert-danger" role="alert">
-    <p>Your username and password didn't match. Please try again.</p>
+    <p>{% trans "Your username and password didn't match. Please try again." %}</p>
   </div>
   {% endif %}
 
   {% if next %}
   <div class="alert alert-danger" role="alert">
       {% if user.is_authenticated %}
-      <p>Your account doesn't have access to this page. To proceed,
-      please login with an account that has access.</p>
+      <p>{% trans "Your account doesn't have access to this page. To proceed, please login with an account that has access." %}</p>
       {% else %}
-      <p>Please login to see this page.</p>
+      <p>{% trans "Please login to see this page." %}</p>
       {% endif %}
   </div>
   {% endif %}
@@ -29,16 +29,16 @@
         }
     </script>
     <div class='lookit-row lookit-page-title'>
-        <h2 class='container'>Current Studies</h2>
+        <h2 class='container'>{% trans "Current Studies" %}</h2>
     </div>
     {% bootstrap_messages %}
     <div class="container">
         <ul class="pt-sm nav nav-tabs">
             <li class="active">
-                <a href="{% url 'web:studies-list'%}">Current studies</a>
+                <a href="{% url 'web:studies-list'%}">{% trans "Current studies" %}</a>
             </li>
             <li>
-                <a href="{% url 'web:studies-history'%}">Your past studies</a>
+                <a href="{% url 'web:studies-history'%}">{% trans "Your past studies" %}</a>
             </li>
         </ul>
     </div>
@@ -50,7 +50,7 @@
                     <div id="suggested-studies">
                         <div class="row">
                             <div class="col-xs-12">
-                                <p class="study-detail-caption">Please note you'll need a laptop or desktop computer (not a mobile device) running Chrome or Firefox to participate.</p>
+                                <p class="study-detail-caption">{% trans "Please note you'll need a laptop or desktop computer (not a mobile device) running Chrome or Firefox to participate." %}</p>
                             </div>
                               {% for obj in object_list %}
                               <div class="col-xs-4">
@@ -77,20 +77,20 @@
                                               <div class="fadeout"></div>
                                           </div>
                                           <div class="full">
-                                              <p class="text-center"><a href="{% url 'web:study-detail' uuid=obj.uuid %}">See details</a></p>
+                                              <p class="text-center"><a href="{% url 'web:study-detail' uuid=obj.uuid %}">{% trans "See details" %}</a></p>
                                           </div>
                                       </a>
                                   </div>
                                 </div>
                               {% empty %}
                                 <div class="col-xs-12">
-                                    <p><em> We are not running any studies at this time! </em></p>
+                                    <p><em> {% trans "We are not running any studies at this time!" %} </em></p>
                                 </div>
                               {% endfor %}
                         </div>
                     </div>
                     <div class="col-xs-12">
-                        <p class="study-detail-caption">Looking for more ways to contribute to research from home? Check out <a href="https://childrenhelpingscience.com/" target="_blank" rel="noreferrer noopener">Children Helping Science</a> for even more studies!</p>
+                        <p class="study-detail-caption">{% trans 'Looking for more ways to contribute to research from home? Check out <a href="https://childrenhelpingscience.com/" target="_blank" rel="noreferrer noopener">Children Helping Science</a> for even more studies!' %}</p>
                     </div>
                 </div>
             </div>

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -1,6 +1,7 @@
 {% extends 'web/base.html' %}
 {% load bootstrap3 %}
 {% load web_extras %}
+{% load i18n %}
 
 {% block title %}{{ object.name }}{% endblock %}
 
@@ -18,7 +19,7 @@
 {% block flash %}
   {% if form.errors %}
   <div class="alert alert-danger" role="alert">
-    <p>Your username and password didn't match. Please try again.</p>
+    <p>{% trans "Your username and password didn't match. Please try again." %}</p>
   </div>
   {% endif %}
 
@@ -89,10 +90,10 @@
         <div class='container'>
             <div class='row'>
                 <div class='col-sm-10'>
-                    <h2 class="study-detail-title">"{{ object.name }}": Study overview</h2>
+                    <h2 class="study-detail-title">"{{ object.name }}": {% trans "Study overview" %}</h2>
                 </div>
                 <div class='col-sm-1'>
-                    <a href="{% url 'web:studies-list' %}" class="active btn btn-lg btn-primary pull-right back-to-list-button">Back to list</a>
+                    <a href="{% url 'web:studies-list' %}" class="active btn btn-lg btn-primary pull-right back-to-list-button">{% trans "Back to list" %}</a>
                 </div>
                 
             </div>
@@ -108,45 +109,45 @@
                           {% include "studies/_image_display.html" with object=object %}
                               <table class="study-detail-infotable">
                                   <tr>
-                                      <td>Eligibility criteria</td>
+                                      <td>{% trans "Eligibility criteria" %}</td>
                                       <td>{{ object.criteria|linebreaks }}</td>
                                   </tr>
                                   <tr>
-                                      <td>Duration</td>
+                                      <td>{% trans "Duration" %}</td>
                                       <td>{{ object.duration }}</td>
                                   </tr>
                                   {% if object.compensation_description %}
                                   <tr>
-                                      <td>Compensation</td>
+                                      <td>{% trans "Compensation" %}</td>
                                       <td>{{ object.compensation_description|linebreaks }}</td>
                                   </tr>
                                   {% endif %}
                                   <tr>
-                                      <td>What happens</td>
+                                      <td>{% trans "What happens" %}</td>
                                       <td>{{ object.short_description|linebreaks }}</td>
                                   </tr>
                                   <tr>
-                                      <td>What we're studying</td>
+                                      <td>{% trans "What we're studying" %}</td>
                                       <td>{{ object.long_description|linebreaks }}</td>
                                   </tr>
                               </table>
-                          <p class="study-detail-contactinfo"><em>This study is conducted by {{object.contact_info}} </em></p>
+                          <p class="study-detail-contactinfo"><em>{% trans "This study is conducted by" %} {{object.contact_info}} </em></p>
                         </div>
                     </div>
                     <div class='col-md-3'>
-                        <h4>Would you like to participate in this study?</h4>
+                        <h4>{% trans "Would you like to participate in this study?" %}</h4>
                         {% if not request.user.is_authenticated %}
-                            <a class="btn btn-lg btn-default" href="{% url 'login' %}">Log in to participate</a>
+                            <a class="btn btn-lg btn-default" href="{% url 'login' %}">{% trans "Log in to participate" %}</a>
                         {% elif not children %}
-                            <a class="btn btn-lg btn-default" href="{% url 'web:children-list' %}">Add child profile to {% if preview_mode %} preview {% else %} participate {% endif %}</a>
+                            <a class="btn btn-lg btn-default" href="{% url 'web:children-list' %}">{% trans "Add child profile to {% if preview_mode %} preview {% else %} participate {% endif %}" %}</a>
                         {% elif not has_demographic %}
-                            <a class="btn btn-lg btn-default" href="{% url 'web:demographic-data-update' %}">Complete demographic survey to {% if preview_mode %} preview {% else %} participate {% endif %}</a>
+                            <a class="btn btn-lg btn-default" href="{% url 'web:demographic-data-update' %}">{% trans "Complete demographic survey to {% if preview_mode %} preview {% else %} participate {% endif %}" %}</a>
                         {% else %}
                         <div class="form-group">
                         <form method="POST">{% csrf_token %}
-                            <label for="child-dropdown">Select a child:</label>
+                            <label for="child-dropdown">{% trans "Select a child:" %}</label>
                             <select id="child-dropdown" name="child_id" class="childDropdown" onchange="childSelected(this)">
-                                <option value=none >None Selected</option>
+                                <option value=none >{% trans "None Selected" %}</option>
                                 {% for child in children %}
                                     {% child_is_valid_for_study child object as child_is_eligible %}
                                     <option onemptied=""
@@ -157,14 +158,14 @@
                                     </option>
                                 {% endfor %}
                             </select>
-                            <p class="text-warning" style="display:none" id='too-young'>Your child is still younger than the recommended age range for this study. If you can wait <span id='wait-until'>until</span> he or she is old enough, we'll be able to use the collected data in our research! </p>
-            	            <p class="text-warning" style="display:none" id='too-old'>Your child is older than the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research.</p>
-                            <p class="text-warning" style="display:none" id='criteria-not-met'>Your child does not meet the eligibility criteria listed for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research. Please contact the study researchers {{ study.contact_info }} if you feel this is in error.</p>
+                            <p class="text-warning" style="display:none" id='too-young'>{% trans "Your child is still younger than the recommended age range for this study. If you can wait <span id='wait-until'>until</span> he or she is old enough, we'll be able to use the collected data in our research!" %} </p>
+            	            <p class="text-warning" style="display:none" id='too-old'>{% trans "Your child is older than the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research." %}</p>
+                            <p class="text-warning" style="display:none" id='criteria-not-met'>{% trans "Your child does not meet the eligibility criteria listed for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research. Please contact the study researchers" %} {{ study.contact_info }} {% trans "if you feel this is in error."}</p>
                             {% if preview_mode and not object.built %}
-                                <a class="btn btn-lg btn-default" href="{% url 'exp:study-detail' object.pk %}">Build experiment runner to preview</a>
+                                <a class="btn btn-lg btn-default" href="{% url 'exp:study-detail' object.pk %}">{% trans "Build experiment runner to preview" %}</a>
                             {% else %} 
-                                <button type="submit" disabled class="btn-lg btn-primary" id="participate-button"> {% if preview_mode %} Preview {% else %} Participate {% endif %} now! </button>
-                                {% if preview_mode %}<p>For an easy way to see what happens as you update your study protocol, bookmark the URL the button above sends you to. </p> {% endif %}
+                                <button type="submit" disabled class="btn-lg btn-primary" id="participate-button"> {% if preview_mode %} {% trans Preview %} {% else %} {% trans "Participate" %} {% endif %} now! </button>
+                                {% if preview_mode %}<p>{% trans "For an easy way to see what happens as you update your study protocol, bookmark the URL the button above sends you to." %}</p> {% endif %}
                             {% endif %}
                         </form>
                         </div>


### PR DESCRIPTION
Hi,
I've been working on support for internationalization within LookIt.

I modified
* templates, using the {% trans "..." %}
* form and other code, using django.utils.translation import gettext_lazy 

To test things out, we've started working on a Japanese locale file (locale/ja/LC_MESSAGES/django.po) currently just automatically generated. Do you agree that it would be easiest to have a single locale file per language (achieved by setting LOCALE_PATHS in defaults.py)? 

I modified project/settings/local-dist.py to include the hint:
# SESSION_COOKIE_SECURE= False # For local debugging
as this took me a while to discover.

I added two locale-enabling lines to projects/settings/defaults.py 

I modified project/urls.py to support language specific URLs like /ja/studies for Japanese. 

Our changes are far from complete, but I felt it would be best to get your feedback early on the changes, and as so many files are changing, to make sure that we don't end up with a nasty merge problem later.

I look forward to your feedback, thank you very much for the elegant codebase.
Best, Rhodri




