### PR TITLE
Proposal: use generics to make PyCharm happy

### DIFF
--- a/exp/views/contact.py
+++ b/exp/views/contact.py
@@ -7,10 +7,7 @@ from django.views import generic
 
 from accounts.models import Message, User
 from accounts.utils import hash_id
-from exp.views.mixins import (
-    ExperimenterLoginRequiredMixin,
-    SingleObjectParsimoniousQueryMixin,
-)
+from exp.views.mixins import ExperimenterLoginRequiredMixin, SingleObjectFetchProtocol
 from studies.models import Study
 from studies.permissions import StudyPermission
 
@@ -18,7 +15,7 @@ from studies.permissions import StudyPermission
 class StudyParticipantContactView(
     ExperimenterLoginRequiredMixin,
     UserPassesTestMixin,
-    SingleObjectParsimoniousQueryMixin,
+    SingleObjectFetchProtocol[Study],
     generic.DetailView,
 ):
     """

--- a/exp/views/lab.py
+++ b/exp/views/lab.py
@@ -8,13 +8,11 @@ from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, reverse
 from django.views import generic
+from django.views.generic.detail import SingleObjectMixin
 
 from accounts.models import User
 from exp.mixins.paginator_mixin import PaginatorMixin
-from exp.views.mixins import (
-    ExperimenterLoginRequiredMixin,
-    SingleObjectParsimoniousQueryMixin,
-)
+from exp.views.mixins import ExperimenterLoginRequiredMixin, SingleObjectFetchProtocol
 from project import settings
 from studies.forms import LabApprovalForm, LabForm
 from studies.helpers import send_mail
@@ -23,7 +21,10 @@ from studies.permissions import LabPermission, SiteAdminGroup
 
 
 class LabDetailView(
-    ExperimenterLoginRequiredMixin, UserPassesTestMixin, generic.DetailView
+    ExperimenterLoginRequiredMixin,
+    UserPassesTestMixin,
+    SingleObjectFetchProtocol[Lab],
+    generic.DetailView,
 ):
     """
     LabDetailView shows information about a lab and provides links to request to join,
@@ -75,7 +76,7 @@ class LabDetailView(
 class LabMembersView(
     ExperimenterLoginRequiredMixin,
     UserPassesTestMixin,
-    SingleObjectParsimoniousQueryMixin,
+    SingleObjectFetchProtocol[Lab],
     PaginatorMixin,
     generic.DetailView,
 ):
@@ -337,14 +338,13 @@ class LabMembersView(
 class LabUpdateView(
     ExperimenterLoginRequiredMixin,
     UserPassesTestMixin,
-    SingleObjectParsimoniousQueryMixin,
+    SingleObjectFetchProtocol[Lab],
     generic.UpdateView,
 ):
     """
     LabUpdateView allows updating lab metadata.
     """
 
-    queryset = Lab.objects.all()
     template_name = "studies/lab_update.html"
     model = Lab
     raise_exception = True
@@ -373,15 +373,13 @@ class LabUpdateView(
 
 
 class LabCreateView(
-    ExperimenterLoginRequiredMixin,
-    UserPassesTestMixin,
-    SingleObjectParsimoniousQueryMixin,
-    generic.CreateView,
+    ExperimenterLoginRequiredMixin, UserPassesTestMixin, generic.CreateView,
 ):
     """
     LabCreateView allows creating a new lab.
     """
 
+    object: Lab
     template_name = "studies/lab_create.html"
     form_class = LabForm
     model = Lab
@@ -434,7 +432,8 @@ class LabCreateView(
 class LabMembershipRequestView(
     ExperimenterLoginRequiredMixin,
     UserPassesTestMixin,
-    SingleObjectParsimoniousQueryMixin,
+    SingleObjectFetchProtocol[Lab],
+    SingleObjectMixin,
     generic.RedirectView,
 ):
 

--- a/exp/views/mixins.py
+++ b/exp/views/mixins.py
@@ -1,24 +1,45 @@
+from abc import abstractmethod
 from functools import cached_property
-from typing import Optional
+from typing import Dict, Iterable, Optional, Protocol, Type, TypeVar, Union
 
 import requests
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.db.models import Model
-from django.http.request import HttpRequest
+from django.contrib.auth.models import AnonymousUser
+from django.core.handlers.wsgi import WSGIRequest
+from django.db.models import Model, QuerySet
 from django.http.response import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.views.generic.detail import SingleObjectMixin
 from guardian.mixins import LoginRequiredMixin
 
 from accounts.backends import TWO_FACTOR_AUTH_SESSION_KEY
-from studies.models import Lab, Study, StudyType
+from accounts.models import User
+from studies.models import Lab, Response, Study, StudyType
 from studies.permissions import StudyPermission
 
+LookitUser = Union[User, AnonymousUser]
+LookitObject = Union[Lab, Study, Response]
+ModelType = TypeVar("ModelType", bound=Model)
 
-class ExperimenterLoginRequiredMixin(LoginRequiredMixin):
+
+class LookitRequest(WSGIRequest):
+    """Custom stub to help recognize custom AUTH_USER_MODEL.
+
+    See: https://github.com/typeddjango/django-stubs#how-can-i-create-a-httprequest-thats-guaranteed-to-have-an-authenticated-user
+    """
+
+    user: LookitUser
+
+
+class LookitHandlerBase:
+    request: LookitRequest
+    args: Iterable
+    kwargs: Dict
+
+
+class ExperimenterLoginRequiredMixin(LookitHandlerBase, LoginRequiredMixin):
     """Require logged-in user; if not logged in, redirect to experimenter login."""
 
     def dispatch(self, request, *args, **kwargs):
@@ -50,7 +71,7 @@ class ExperimenterLoginRequiredMixin(LoginRequiredMixin):
                 return HttpResponseRedirect(reverse("login"))
 
 
-class StudyLookupMixin:
+class StudyLookupMixin(LookitHandlerBase):
     @cached_property
     def study(self):
         return get_object_or_404(Study, pk=self.kwargs.get("pk"))
@@ -74,11 +95,12 @@ class CanViewStudyResponsesMixin(
     test_func = can_view_responses
 
 
-class SingleObjectParsimoniousQueryMixin(SingleObjectMixin):
+class SingleObjectFetchProtocol(Protocol[ModelType]):
 
-    object: Model
+    model: Type[ModelType]
+    object: ModelType
 
-    def get_object(self, queryset=None):
+    def get_object(self, queryset: Optional[QuerySet] = None) -> ModelType:
         """Override get_object() to be smarter.
 
         This is to allow us to get the study for use the predicate function
@@ -87,13 +109,13 @@ class SingleObjectParsimoniousQueryMixin(SingleObjectMixin):
         """
         if getattr(self, "object", None) is None:
             # Only call get_object() when self.object isn't present.
-            self.object = super().get_object()
+            self.object: ModelType = super().get_object(queryset)
         return self.object
 
 
 class StudyTypeMixin:
 
-    request: HttpRequest
+    request: LookitRequest
 
     def validate_and_fetch_metadata(self, study_type: Optional[StudyType] = None):
         """Gets the study type and runs hardcoded validations.


### PR DESCRIPTION
This reduce the noise that PyCharm makes when statically analyzing our code, resulting in more meaningful type hints