### PR TITLE
standardize child age calculation for announcements; update announcement template

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -596,11 +596,13 @@ class Message(models.Model):
             Creates a corresponding message object in the database.
         """
         subject = create_subject_for_study_notification(study, children)
+        children_string = create_string_listing_children(children)
         context = {
             "base_url": settings.BASE_URL,
             "user": user,
             "study": study,
             "children": children,
+            "children_string": children_string,
         }
 
         text_content = get_template("emails/study_announcement.txt").render(context)
@@ -657,16 +659,29 @@ class Message(models.Model):
         self.save()
 
 
+def create_string_listing_children(children):
+    child_names = [child.given_name for child in children]
+    num_children = len(child_names)
+
+    if not num_children:
+        return ""
+    elif num_children == 1:
+        return child_names[0]
+    elif num_children == 2:
+        return " and ".join(child_names)
+    else:
+        return ", ".join(child_names[:-1]) + f", and {child_names[-1]}"
+
+
 def create_subject_for_study_notification(study, children):
     latter_half = f' invited to take part in "{study.name}" on Lookit!'
-    child_names = [child.given_name for child in children]
+    num_children = len(children)
+    children_string = create_string_listing_children(children)
 
-    if (num_children := len(child_names)) == 1:
-        first_half = child_names[0] + " is"
-    elif num_children == 2:
-        first_half = " and ".join(child_names) + " are"
-    elif num_children > 2:
-        first_half = ", ".join(child_names[:-1]) + f", and {child_names[-1]} are"
+    if num_children == 1:
+        first_half = children_string + " is"
+    elif num_children > 1:
+        first_half = children_string + " are"
     else:
         raise RuntimeError("Need at least one child for notification messages")
 

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -675,6 +675,7 @@ def create_string_listing_children(children):
 
 def create_subject_for_study_notification(study, children):
     latter_half = f' invited to take part in "{study.name}" on Lookit!'
+    latter_half_short = f" invited to take part in a new study on Lookit!"
     num_children = len(children)
     children_string = create_string_listing_children(children)
 
@@ -685,4 +686,14 @@ def create_subject_for_study_notification(study, children):
     else:
         raise RuntimeError("Need at least one child for notification messages")
 
-    return first_half + latter_half
+    full_subject_line = first_half + latter_half
+
+    if len(full_subject_line) <= 255:
+        return full_subject_line
+
+    first_half_short = f"Your {'child is' if num_children == 1 else 'children are'}"
+    child_omitted_subject_line = first_half_short + latter_half
+    if len(child_omitted_subject_line) <= 255:
+        return child_omitted_subject_line
+
+    return first_half_short + latter_half_short

--- a/accounts/queries.py
+++ b/accounts/queries.py
@@ -96,28 +96,21 @@ def get_child_eligibility_for_study(child_obj, study_obj):
 
 
 def _child_in_age_range_for_study(child, study):
-    """This is a loose estimate that doesn't account for the weirdness of time.
-
-    Should be good enough for notifications.
+    """Check if child in age range for study, using same age calculations as in study detail and response data.
     """
     if not child.birthday:
         return False
 
-    min_age_in_days_estimate = float(
-        (study.min_age_years * 12 * 30)
-        + (study.min_age_months * 30)
-        + study.min_age_days
+    min_age_in_days_estimate = (
+        (study.min_age_years * 365) + (study.min_age_months * 30) + study.min_age_days
     )
-    latest_birthday = date.today() - timedelta(days=min_age_in_days_estimate)
 
-    max_age_in_days_estimate = float(
-        (study.max_age_years * 12 * 30)
-        + (study.max_age_months * 30)
-        + study.max_age_days
+    max_age_in_days_estimate = (
+        (study.max_age_years * 365) + (study.max_age_months * 30) + study.max_age_days
     )
-    earliest_birthday = date.today() - timedelta(days=max_age_in_days_estimate)
+    age_in_days = (date.today() - child.birthday).days
 
-    return earliest_birthday <= child.birthday <= latest_birthday
+    return min_age_in_days_estimate <= age_in_days <= max_age_in_days_estimate
 
 
 def get_child_eligibility(child_obj, criteria_expr):

--- a/accounts/queries.py
+++ b/accounts/queries.py
@@ -101,6 +101,12 @@ def _child_in_age_range_for_study(child, study):
     if not child.birthday:
         return False
 
+    # Age ranges are defined in DAYS, using shorthand of year = 365 days, month = 30 days,
+    # to provide a reliable actual unit of time rather than calendar "months" and "years" which vary in duration.
+    # See logic used in web/studies/study-detail.html to display eligibility to participant,
+    # help-text provided to researchers in studies/templates/studies/_study_fields.html,
+    # and documentation for researchers at
+    # https://lookit.readthedocs.io/en/develop/researchers-set-study-fields.html#minimum-and-maximum-age-cutoffs
     min_age_in_days_estimate = (
         (study.min_age_years * 365) + (study.min_age_months * 30) + study.min_age_days
     )

--- a/studies/templates/emails/study_announcement.html
+++ b/studies/templates/emails/study_announcement.html
@@ -1,26 +1,27 @@
+<p>Dear {% if user.nickname %}{{ user.nickname }}{% else %}{{ user.given_name }} {{user.family_name}}{% endif %},</p>
 
-<p>Dear {{ user.nickname }},</p>
+<p>
+    We're writing to invite you and your child{{ children|length|pluralize:"ren" }} {{ children_string }} to
+    participate in the study <a href="{{ base_url }}{% url 'web:study-detail' uuid=study.uuid %}">"{{ study.name }}"</a>
+    on Lookit! This study is run by the {{ study.lab.name }} at {{ study.lab.institution }}.
+</p>
 
-<p>We're writing to invite you and your child{{ children|length|pluralize:"ren" }} to participate in the study "{{ study.name }}" that {{ study.lab.name }} is running on Lookit!</p>
-
+<p>More details about the study...</p>
 <ul>
-    <li>Who: {{ study.criteria }}
-        <p>This may include:</p>
-        <ul>
-            {% for child in children %}
-                <li>{{ child.given_name }}</li>
-            {% endfor %}
-        </ul>
-    </li>
-    <li>What happens: {{ study.short_description }}</li>
-    <li>Why: {{ study.long_description }}</li>
-    <li>Compensation: {{ study.compensation_description|default:"This is a volunteer-based study." }}</li>
+    <li><strong>Who:</strong> {{ study.criteria }}</li>
+    <li><strong>What happens:</strong> {{ study.short_description }}</li>
+    <li><strong>Why:</strong> {{ study.long_description }}</li>
+    <li><strong>Compensation:</strong> {{ study.compensation_description|default:"This is a volunteer-based study." }}</li>
 </ul>
 
+<p>
+    You and your child can participate any time you want by going to
+    <a href="{{ base_url }}{% url 'web:study-detail' uuid=study.uuid %}">"{{ study.name }}"</a> on Lookit.
+    If you have any questions, please reply to this email to reach the {{ study.lab.name }} at
+    {{ study.lab.contact_email }}.
+</p>
 
-<p>You and your child can participate any time you want by going to <a href="{{ base_url }}{% url 'web:study-detail' uuid=study.uuid %}">{{ study.name }}</a> on Lookit. If
-    you have any questions, please reply to this email to contact the lab.</p>
+<p>Thanks for contributing to the science of how kids learn - we hope to see you soon!</p>
 
-<p>We hope to see you soon, and thanks for contributing to the science of how kids learn and grow!</p>
+-- the Lookit team
 
--- The Lookit team

--- a/studies/templates/emails/study_announcement.txt
+++ b/studies/templates/emails/study_announcement.txt
@@ -1,20 +1,19 @@
-Dear {{ user.nickname }},
+Dear {% if user.nickname %}{{ user.nickname }}{% else %}{{ user.given_name }} {{user.family_name}}{% endif %},
 
-We're writing to invite you and your child{{ children|length|pluralize:"ren" }} to participate in the study "{{ study.name }}" that {{ study.lab.name }} is running on Lookit!
+We're writing to invite you and your child{{ children|length|pluralize:"ren" }} {{ children_string }} to participate in the study "{{ study.name}}" on Lookit! This study is run by the {{ study.lab.name }} at {{ study.lab.institution }}.
 
-Who: {{study.criteria}}
+More details about the study...
 
-This may include:
-{% for child in children %}- {{ child.given_name }}
-{% endfor %}
+Who: {{ study.criteria }}
+
 What happens: {{ study.short_description }}
 
 Why: {{ study.long_description }}
 
-Compensation: {{ study.compensation_description|default:"This is a volunteer-based study."}}
+Compensation: {{ study.compensation_description|default:"This is a volunteer-based study." }}
 
-You and your child can participate any time you want by going to "{{ study.name }}" on Lookit ({{ base_url }}{% url 'web:study-detail' uuid=study.uuid %}). If you have any questions, please reply to this email to contact the lab.
+You and your child can participate any time you want by going to "{{ study.name }}" on Lookit ({{ base_url }}{% url 'web:study-detail' uuid=study.uuid %}). If you have any questions, please reply to this email to reach the {{ study.lab.name }} at {{ study.lab.contact_email }}.
 
-We hope to see you soon, and thanks for contributing to the science of how kids learn and grow!
+Thanks for contributing to the science of how kids learn - we hope to see you soon!
 
--- The Lookit team
+-- the Lookit team

--- a/studies/templates/studies/_study_type.html
+++ b/studies/templates/studies/_study_type.html
@@ -97,12 +97,19 @@
                         }).done(function(data) {
                             $('#update-button').prop('disabled', false);
                             current_commit_date = data.commit.author.date;
-                            var files_changed = $.map(data.files, function(f) {return f.status + ': ' + f.filename}).join('<br>');
+                            let files_changed_list = $.map(data.files, function(f) {return f.status + ': ' + f.filename});
+                            if (files_changed_list.length > 10) {
+                                files_changed_list = files_changed_list.slice(0, 10);
+                                files_changed_list.push('...');
+                            }
+                            if (data.commit.message.length > 1200) {
+                                data.commit.message = data.commit.message.slice(0, 1200) + "...";
+                            }
                             var commit_description = `<p>Your study will use commit <a target="_blank" href="${data.html_url}">${data.sha}</a>:</p>` + 
                                 `<table><tr><th scope="row">Date</th><td>${data.commit.author.date}</td></tr>` + 
                                 `<tr><th scope="row">Author</th><td>${data.commit.author.name}</td></tr>` + 
                                 `<tr><th scope="row">Message</th><td>${data.commit.message}</td></tr>` +
-                                `<tr><th scope="row">Files changed</th><td>${files_changed}</td></tr></table>`
+                                `<tr><th scope="row">Files changed</th><td>${files_changed_list.join('<br>')}</td></tr></table>`
                            $commit_description.html(commit_description);
                         }).fail(function() {
                             var error_message = `<p> Error: Version ${current_sha} not found! </p>` + 

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -250,14 +250,6 @@ class TestAnnouncementEmailFunctionality(TestCase):
         )
         # Child four would get notified for all studies, but doesn't because of user settings.
 
-        # Add a single child with a long name to the database; not eligible for any studies
-        G(
-            Child,
-            given_name="sixteencharacter" * 16,
-            user=self.participant_one,
-            birthday=date.today() + timedelta(days=365),
-        )
-
     def test_potential_message_targets(self):
         targets = list(potential_message_targets())
         # Two targets for participant 1: three children for both studies. These
@@ -401,19 +393,19 @@ class TestAnnouncementEmailFunctionality(TestCase):
         long_name_family = G(User, nickname="Mama", is_active=True)
         long_name_child = G(
             Child,
-            given_name="sixteencharacter" * 16,
+            given_name="A" * 255,
             user=long_name_family,
             birthday=date.today() - timedelta(days=365),
         )
         short_name_child = G(
             Child,
-            given_name="Bob",
+            given_name="Joe",
             user=long_name_family,
             birthday=date.today() - timedelta(days=365),
         )
 
         message_object = Message.send_announcement_email(
-            long_name_family, self.study_one, [long_name_child, short_name_child],
+            long_name_family, self.study_two, [long_name_child, short_name_child],
         )
         self.assertEqual(
             message_object.subject,
@@ -424,7 +416,7 @@ class TestAnnouncementEmailFunctionality(TestCase):
         # Study with a long name
         long_name_study = G(
             Study,
-            name="A long study name " * 16,
+            name="A" * 255,
             image=SimpleUploadedFile(
                 "fake_image.png", b"fake-stuff-2", content_type="image/png"
             ),
@@ -451,5 +443,5 @@ class TestAnnouncementEmailFunctionality(TestCase):
         )
         self.assertEqual(
             message_object.subject,
-            "Bob is invited to take part in a new study on Lookit!",
+            "Your child is invited to take part in a new study on Lookit!",
         )

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -16,13 +16,11 @@ from studies.tasks import (
 
 TARGET_EMAIL_TEMPLATE = """Dear Charlie,
 
-We're writing to invite you and your children to participate in the study "The Most Fake Study Ever" that MIT is running on Lookit!
+We're writing to invite you and your children Moe and Curly to participate in the study "The Most Fake Study Ever" on Lookit! This study is run by the ECCL at MIT.
+
+More details about the study...
 
 Who: Children who have stopped believing in Santa in the past 6 months.
-
-This may include:
-- Moe
-- Curly
 
 What happens: How fast can your child hand-compute integrals?
 
@@ -30,11 +28,11 @@ Why: We are interested in seeing how fast your child can hand-compute integrals.
 
 Compensation: You child will receive exactly $1 for each integral computed.
 
-You and your child can participate any time you want by going to "The Most Fake Study Ever" on Lookit ({base_url}/studies/{study_uuid}/). If you have any questions, please reply to this email to contact the lab.
+You and your child can participate any time you want by going to "The Most Fake Study Ever" on Lookit ({base_url}/studies/{study_uuid}/). If you have any questions, please reply to this email to reach the ECCL at faker@fakelab.com.
 
-We hope to see you soon, and thanks for contributing to the science of how kids learn and grow!
+Thanks for contributing to the science of how kids learn - we hope to see you soon!
 
--- The Lookit team
+-- the Lookit team
 """
 
 
@@ -51,7 +49,9 @@ class TestAnnouncementEmailFunctionality(TestCase):
         one_year_ago = date.today() - timedelta(days=365)
         four_years_ago = date.today() - timedelta(days=365 * 4)
 
-        self.fake_lab = G(Lab, name="MIT", contact_email="faker@fakelab.com")
+        self.fake_lab = G(
+            Lab, name="ECCL", institution="MIT", contact_email="faker@fakelab.com"
+        )
         self.study_one = G(
             Study,
             name="A Study that should never show up",


### PR DESCRIPTION
Sorry for not catching this earlier - we define a year as 365 days throughout, so to avoid people getting notifications when they "age in" but then being told they're not eligible when they get to Lookit (which would be the case for every study for children at least 1 year old), use that definition here too. 