### PR TITLE
Quick fix for #546 - allow for message.sender being None in participa…

### DIFF
--- a/exp/views/contact.py
+++ b/exp/views/contact.py
@@ -87,8 +87,10 @@ class StudyParticipantContactView(
         ctx["previous_messages"] = [
             {
                 "sender": {
-                    "uuid": message.sender.uuid,
-                    "full_name": message.sender.get_full_name(),
+                    "uuid": message.sender.uuid if message.sender else None,
+                    "full_name": message.sender.get_full_name()
+                    if message.sender
+                    else "<None>",
                 },
                 "subject": message.subject,
                 "recipients": [
@@ -105,7 +107,23 @@ class StudyParticipantContactView(
             for message in previous_messages
         ]
 
-        ctx["researchers"] = self.get_researchers()
+        # Populate options for 'sender' filter with existing senders' uuid & full name.
+        # These may not line up with researchers who currently have perms to send email (e.g.,
+        # when emails have been sent by an RA who has since left the lab), and in some cases
+        # a sender may be null because the account has been deleted or because the message was sent
+        # automatically by Lookit.
+
+        sender_ids = previous_messages.values_list("sender", flat=True)
+        senders = User.objects.filter(id__in=sender_ids).order_by("family_name")
+        ctx["senders"] = (
+            [
+                {"uuid": sender.uuid, "full_name": sender.get_full_name}
+                for sender in senders
+            ]
+            + [{"uuid": None, "full_name": "None"}]
+            if None in sender_ids
+            else []
+        )
         return ctx
 
     def post(self, request, *args, **kwargs):
@@ -136,8 +154,3 @@ class StudyParticipantContactView(
         return HttpResponseRedirect(
             reverse("exp:study-participant-contact", kwargs=dict(pk=study.pk))
         )
-
-    def get_researchers(self):
-        """Pulls researchers that can contact participants."""
-        study = self.get_object()
-        return study.users_with_study_perms(StudyPermission.CONTACT_STUDY_PARTICIPANTS)

--- a/studies/templates/studies/study_participant_contact.html
+++ b/studies/templates/studies/study_participant_contact.html
@@ -101,9 +101,9 @@
                                         <select id="sender-filter"
                                                 class="selectpicker form-control"
                                                 multiple>
-                                            {% for researcher in researchers %}
+                                            {% for researcher in senders %}
                                                 <option value="{{ researcher.uuid }}">
-                                                    {{ researcher.get_full_name }}
+                                                    {{ researcher.full_name }}
                                                 </option>
                                             {% endfor %}
                                         </select>


### PR DESCRIPTION
…nt contact form context. Also correct filtering options to be people who have sent emails before, rather than people who currently could send emails.

No tests yet - planning to fill out test_contact_views tomorrow, but would like to get a fix up asap since it's preventing participant compensation.