### PR TITLE
remove link to wiki from "help" dropdown for clarity. Could also just…

### DIFF
--- a/exp/templates/exp/_navigation.html
+++ b/exp/templates/exp/_navigation.html
@@ -32,7 +32,6 @@
                 </a>
                 <ul class="dropdown-menu">
                   <li><a href="https://lookit.readthedocs.io/" target="_blank">Docs</a></li>
-                  <li><a href="https://github.com/lookit/research-resources/wiki" target="_blank">Wiki</a></li>
                 </ul>
             </li>
             


### PR DESCRIPTION
… make this a link to the docs instead of Help -> Docs; was going for minimal change to UI and ability to add other options in the future if needed.