### PR TITLE
fix queryset for labs on study edit/create forms

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -241,13 +241,6 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
             ]
         )
 
-    def labs_user_can_create_study_in(self):
-        return self.labs.filter(
-            id__in=get_objects_for_user(
-                self, LabPermission.CREATE_LAB_ASSOCIATED_STUDY.prefixed_codename
-            ).only("id")
-        )
-
     def has_any_perms(self, perm_list, obj=None):
         """
         Returns True if the user has ANY of the specified permissions. If

--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -8,7 +8,7 @@ from django.forms.models import model_to_dict
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django_dynamic_fixture import G
-from guardian.shortcuts import assign_perm
+from guardian.shortcuts import assign_perm, get_objects_for_user
 
 from accounts.backends import TWO_FACTOR_AUTH_SESSION_KEY
 from accounts.models import Child, User
@@ -452,7 +452,13 @@ class ResponseViewsTestCase(TestCase):
             ),
             "New researcher able to create studies in demo lab",
         )
-        self.assertEqual(new_researcher.labs_user_can_create_study_in().count(), 1)
+        self.assertEqual(
+            get_objects_for_user(
+                new_researcher,
+                LabPermission.CREATE_LAB_ASSOCIATED_STUDY.prefixed_codename,
+            ).count(),
+            1,
+        )
 
     def test_create_study_buttons_shown_if_allowed(self):
         self.client.force_login(self.lab_researcher)


### PR DESCRIPTION
* Use ...Lab.object.filter... not user.labs.filter... to choose all labs user has perms for, not just those they're in
* Remove User.labs_user_can_create_study_in which was only used twice in these forms, somewhat circuitously, because it doesn't make sense to import Lab in accounts.models
* Add fairly exhaustive tests