### PR TITLE
Extend cloudbuild timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -130,3 +130,5 @@ secrets:
 - kmsKeyName: projects/mit-lookit-keys/locations/us-east1/keyRings/lookit-keyring/cryptoKeys/sentry-auth
   secretEnv:
     SENTRY_AUTH_TOKEN: CiQAVYLHlum+JbxvLUXADsLiiIwXjocXFGg5SAsxKyvAkDRjEaESaABnxmN4TReBWF0cY+XPS8xytlGSUhClZewwH7ttpBFKC65+Y0a6W8XIsTjyQMyVzWiLxSOef46bmI1Bo8JIbh/ErIRWm3rPBNFs843z52oF8M93+miMUlt8UOWmIgyq1U/fjThhq0UI
+
+timeout: 1200s


### PR DESCRIPTION
Sets the Cloud Build timeout to 20 minutes. Builds have been timing out under the default 10-minute time limit.