### PR TITLE
Clean up StudyDetailView

### DIFF
--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -1,17 +1,32 @@
 import datetime
 import json
 from unittest import skip
-from unittest.mock import patch
+from unittest.mock import (
+    MagicMock,
+    Mock,
+    PropertyMock,
+    create_autospec,
+    patch,
+    sentinel,
+)
 
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms.models import model_to_dict
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+from django.views.generic.detail import SingleObjectMixin
 from django_dynamic_fixture import G
 from guardian.shortcuts import assign_perm, get_objects_for_user
 
 from accounts.backends import TWO_FACTOR_AUTH_SESSION_KEY
 from accounts.models import Child, User
+from exp.views.mixins import ExperimenterLoginRequiredMixin
+from exp.views.study import (
+    ChangeStudyStatusView,
+    CloneStudyView,
+    ManageResearcherPermissionsView,
+)
 from studies.models import Lab, Study, StudyType
 from studies.permissions import LabPermission, StudyPermission
 
@@ -506,6 +521,628 @@ class StudyViewsTestCase(TestCase):
         )
 
 
+class CloneStudyViewTestCase(TestCase):
+    def test_model(self):
+        clone_study_view = CloneStudyView()
+        self.assertIs(clone_study_view.model, Study)
+
+    def test_permissions(self):
+        self.assertTrue(
+            issubclass(CloneStudyView, ExperimenterLoginRequiredMixin),
+            "CloneStudyView must have ExperimenterLoginRequiredMixin",
+        )
+        self.assertTrue(
+            issubclass(CloneStudyView, UserPassesTestMixin),
+            "CloneStudyView must have UserPassesTestMixin",
+        )
+
+    def test_user_can_clone_study(self):
+        with patch.object(CloneStudyView, "request", create=True):
+            mock_is_researcher = PropertyMock(return_value=True)
+            mock_can_create_study = MagicMock(return_value=True)
+
+            clone_study_view = CloneStudyView()
+            type(clone_study_view.request.user).is_researcher = mock_is_researcher
+            clone_study_view.request.user.can_create_study = mock_can_create_study
+
+            self.assertIs(clone_study_view.user_can_clone_study(), True)
+            mock_can_create_study.assert_called_with()
+            mock_is_researcher.assert_called_with()
+
+    def test_test_func(self):
+        clone_study_view = CloneStudyView()
+        self.assertEqual(
+            clone_study_view.test_func,
+            clone_study_view.user_can_clone_study,
+            "CloneStudyView.test_func must be set to CloneStudyView.user_can_clone_study",
+        )
+
+    @patch.object(CloneStudyView, "request", create=True)
+    def test_add_creator_to_study_admin_group(self, mock_request):
+        clone_study_view = CloneStudyView()
+        mock_study = create_autospec(Study)
+        self.assertEquals(
+            clone_study_view.add_creator_to_study_admin_group(mock_study),
+            mock_study.admin_group,
+        )
+        mock_request.user.groups.add.assert_called_with(mock_study.admin_group)
+
+    @patch.object(CloneStudyView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    @patch("exp.views.study.HttpResponseRedirect")
+    @patch("exp.views.study.reverse")
+    def test_post_redirect(
+        self, mock_reverse, mock_http_response_redirect, mock_get_object, mock_request
+    ):
+        mock_redirect_to = mock_reverse(
+            "exp:study-edit", kwargs={"pk": mock_get_object().clone().pk}
+        )
+        mock_response = mock_http_response_redirect(mock_redirect_to)
+
+        clone_study_view = CloneStudyView()
+
+        self.assertEqual(clone_study_view.post(), mock_response)
+        self.assertEqual(mock_request.user, mock_get_object().clone().creator)
+        mock_request.user.has_perm.assert_called_with(
+            LabPermission.CREATE_LAB_ASSOCIATED_STUDY.codename,
+            obj=mock_get_object().lab,
+        )
+
+    @patch.object(CloneStudyView, "request", create=True)
+    @patch("exp.views.study.HttpResponseForbidden")
+    def test_post_forbidden(self, mock_http_response_forbidden, mock_request):
+        with patch.object(SingleObjectMixin, "get_object"):
+            mock_request.user.has_perm = MagicMock(return_value=False)
+            mock_request.user.labs.only = MagicMock(return_value=[])
+
+            clone_study_view = CloneStudyView()
+
+            self.assertEqual(clone_study_view.post(), mock_http_response_forbidden())
+            mock_request.user.labs.only.assert_called_with("id")
+
+    @patch.object(CloneStudyView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    @patch("exp.views.study.HttpResponseRedirect")
+    @patch("exp.views.study.reverse")
+    def test_post_first_lab(
+        self, mock_reverse, mock_http_response_redirect, mock_get_object, mock_request
+    ):
+        mock_has_perm = MagicMock(side_effect=[False, True])
+        mock_labs_only = MagicMock(return_value=(sentinel.lab,))
+        mock_redirect_to = mock_reverse(
+            "exp:study-edit", kwargs={"pk": mock_get_object().clone().pk}
+        )
+        mock_response = mock_http_response_redirect(mock_redirect_to)
+
+        mock_request.user.has_perm = mock_has_perm
+        mock_request.user.labs.only = mock_labs_only
+
+        clone_study_view = CloneStudyView()
+
+        self.assertEqual(clone_study_view.post(), mock_response)
+        mock_request.user.labs.only.assert_called_with("id")
+        mock_get_object().clone().creator.has_perm.assert_called_with(
+            LabPermission.CREATE_LAB_ASSOCIATED_STUDY.codename, obj=sentinel.lab
+        )
+
+
+class ChangeStudyStatusViewTestCase(TestCase):
+    def test_model(self):
+        change_study_status_view = ChangeStudyStatusView()
+        self.assertIs(change_study_status_view.model, Study)
+
+    def test_permissions(self):
+        self.assertTrue(
+            issubclass(ChangeStudyStatusView, ExperimenterLoginRequiredMixin),
+            "ChangeStudyStatusView must have ExperimenterLoginRequiredMixin",
+        )
+        self.assertTrue(
+            issubclass(ChangeStudyStatusView, UserPassesTestMixin),
+            "ChangeStudyStatusView must have UserPassesTestMixin",
+        )
+
+    @patch.object(ChangeStudyStatusView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    def test_user_can_change_study_status(
+        self, mock_get_object: Mock, mock_request: Mock
+    ):
+        mock_is_researcher = PropertyMock(return_value=True)
+
+        type(mock_request.user).is_researcher = mock_is_researcher
+        mock_request.user.has_study_perms = MagicMock(return_value=True)
+
+        change_study_status_view = ChangeStudyStatusView()
+
+        self.assertIs(change_study_status_view.user_can_change_study_status(), True)
+        mock_is_researcher.assert_called_with()
+        mock_request.user.has_study_perms.assert_called_with(
+            StudyPermission.CHANGE_STUDY_STATUS, mock_get_object()
+        )
+
+    def test_test_func(self):
+        change_study_status_view = ChangeStudyStatusView()
+        self.assertEqual(
+            change_study_status_view.test_func,
+            change_study_status_view.user_can_change_study_status,
+            "CloneStudyView.test_func must be set to CloneStudyView.user_can_change_study_status",
+        )
+
+    @patch.object(SingleObjectMixin, "get_object")
+    @patch("exp.views.study.HttpResponseRedirect")
+    @patch("exp.views.study.reverse")
+    def test_post(
+        self,
+        mock_reverse: Mock,
+        mock_http_response_redirect: Mock,
+        mock_get_object: Mock,
+    ):
+        change_study_status_view = ChangeStudyStatusView()
+
+        change_study_status_view.update_trigger = MagicMock(return_value=True)
+
+        self.assertEqual(change_study_status_view.post(), mock_http_response_redirect())
+        mock_http_response_redirect.assert_called_with()
+        mock_reverse.assert_called_with(
+            "exp:study-detail", kwargs={"pk": mock_get_object().pk}
+        )
+        change_study_status_view.update_trigger.assert_called_with()
+
+    @patch.object(ChangeStudyStatusView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    @patch("exp.views.study.HttpResponseRedirect")
+    @patch("exp.views.study.reverse")
+    @patch("exp.views.study.messages")
+    def test_post_exception(
+        self,
+        mock_messages: Mock,
+        mock_reverse: Mock,
+        mock_http_response_redirect: Mock,
+        mock_get_object: Mock,
+        mock_request: Mock,
+    ):
+        change_study_status_view = ChangeStudyStatusView()
+        change_study_status_view.update_trigger = MagicMock(
+            side_effect=Exception(sentinel.error_message)
+        )
+        self.assertEqual(change_study_status_view.post(), mock_http_response_redirect())
+        mock_messages.error.assert_called_with(
+            mock_request, f"TRANSITION ERROR: {sentinel.error_message}"
+        )
+        mock_reverse.assert_called_with(
+            "exp:study-detail", kwargs={"pk": mock_get_object().pk}
+        )
+
+    @patch.object(ChangeStudyStatusView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    @patch("exp.views.study.messages")
+    def test_update_trigger(
+        self, mock_messages: Mock, mock_get_object: Mock, mock_request: Mock
+    ):
+        mock_request.POST.get = MagicMock(return_value="trigger_attr")
+        mock_request.POST.keys = MagicMock(return_value=("comments-text",))
+
+        change_study_status_view = ChangeStudyStatusView()
+
+        self.assertEqual(change_study_status_view.update_trigger(), mock_get_object())
+        mock_request.POST.get.assert_called_with("trigger")
+        mock_request.POST.keys.assert_called_with()
+        mock_messages.success.assert_called_with(
+            mock_request, f"Study {mock_get_object().name} {mock_get_object().state}."
+        )
+        mock_get_object().save.assert_called_with()
+        mock_get_object().trigger_attr.assert_called_with(user=mock_request.user)
+
+    @patch.object(ChangeStudyStatusView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    @patch("exp.views.study.messages")
+    def test_update_trigger_trigger_is_none(
+        self, mock_messages: Mock, mock_get_object: Mock, mock_request: Mock
+    ):
+        mock_request.POST.get = MagicMock(return_value=None)
+
+        change_study_status_view = ChangeStudyStatusView()
+
+        self.assertEqual(change_study_status_view.update_trigger(), mock_get_object())
+        mock_messages.success.assert_called_with(
+            mock_request, f"Study {mock_get_object().name} {mock_get_object().state}."
+        )
+        mock_get_object().save.assert_not_called()
+        mock_get_object().trigger_attr.assert_not_called()
+
+    @patch.object(ChangeStudyStatusView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    def test_update_trigger_object_no_attr(
+        self, mock_get_object: Mock, mock_request: Mock
+    ):
+        mock_request.POST.get = MagicMock(return_value="trigger_attr")
+        del mock_get_object().trigger_attr
+
+        change_study_status_view = ChangeStudyStatusView()
+
+        self.assertEqual(change_study_status_view.update_trigger(), mock_get_object())
+        mock_get_object().save.assert_not_called()
+        mock_request.POST.keys.assert_not_called()
+
+
+class ManageResearcherPermissionsViewTestCase(TestCase):
+    def test_model(self) -> None:
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertIs(manage_researcher_permissions_view.model, Study)
+
+    def test_permissions(self) -> None:
+        self.assertTrue(
+            issubclass(ManageResearcherPermissionsView, ExperimenterLoginRequiredMixin),
+            "ManageResearcherPermissionsView must have ExperimenterLoginRequiredMixin",
+        )
+        self.assertTrue(
+            issubclass(ManageResearcherPermissionsView, UserPassesTestMixin),
+            "ManageResearcherPermissionsView must have UserPassesTestMixin",
+        )
+
+    @patch.object(ManageResearcherPermissionsView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    def test_user_can_change_study_permissions(
+        self, mock_get_object: Mock, mock_request: Mock,
+    ) -> None:
+        mock_request.user.has_study_perms = MagicMock(return_value=True)
+        mock_is_researcher = PropertyMock(return_value=True)
+        type(mock_request.user).is_researcher = mock_is_researcher
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+
+        self.assertIs(
+            manage_researcher_permissions_view.user_can_change_study_permissions(), True
+        )
+        mock_request.user.has_study_perms.assert_called_once_with(
+            StudyPermission.MANAGE_STUDY_RESEARCHERS, mock_get_object()
+        )
+        mock_is_researcher.assert_called_with()
+
+    def test_test_func(self):
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertEqual(
+            manage_researcher_permissions_view.test_func,
+            manage_researcher_permissions_view.user_can_change_study_permissions,
+            "ManageResearcherPermissionsView.test_func must be set to ManageResearcherPermissionsView.user_can_change_study_permissions",
+        )
+
+    @patch.object(SingleObjectMixin, "get_object")
+    @patch(
+        "exp.views.study.ManageResearcherPermissionsView.manage_researcher_permissions"
+    )
+    @patch("exp.views.study.HttpResponseRedirect")
+    @patch("exp.views.study.reverse")
+    def test_post(
+        self,
+        mock_reverse: Mock,
+        mock_https_response_redirect: Mock,
+        mock_manage_researcher_permissions: Mock,
+        mock_get_object: Mock,
+    ):
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertEqual(
+            manage_researcher_permissions_view.post(), mock_https_response_redirect()
+        )
+        mock_https_response_redirect.assert_called_with()
+        mock_reverse.assert_called_once_with(
+            "exp:study-detail", kwargs={"pk": mock_get_object().pk}
+        )
+        mock_manage_researcher_permissions.assert_called_once_with()
+
+    @patch.object(SingleObjectMixin, "get_object")
+    @patch(
+        "exp.views.study.ManageResearcherPermissionsView.manage_researcher_permissions"
+    )
+    @patch("exp.views.study.HttpResponseForbidden")
+    @patch("exp.views.study.reverse")
+    def test_post_assertion_error(
+        self,
+        mock_reverse: Mock,
+        mock_https_response_forbidden: Mock,
+        mock_manage_researcher_permissions: Mock,
+        mock_get_object: Mock,
+    ):
+        mock_manage_researcher_permissions.side_effect = [AssertionError()]
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertEqual(
+            manage_researcher_permissions_view.post(), mock_https_response_forbidden()
+        )
+
+    @patch("exp.views.study.send_mail")
+    @patch.object(SingleObjectMixin, "get_object")
+    def test_send_study_email(self, mock_get_object: Mock, mock_send_mail: Mock):
+        mock_user = MagicMock()
+        mock_permission = MagicMock()
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        manage_researcher_permissions_view.send_study_email(mock_user, mock_permission)
+        mock_send_mail.delay.assert_called_with(
+            "notify_researcher_of_study_permissions",
+            f"New access granted for study {mock_get_object().name}",
+            mock_user.username,
+            from_email=mock_get_object().lab.contact_email,
+            permission=mock_permission,
+            study_name=mock_get_object().name,
+            study_id=mock_get_object().id,
+            lab_name=mock_get_object().lab.name,
+            researcher_name=mock_user.get_short_name(),
+        )
+
+    @patch("exp.views.study.ManageResearcherPermissionsView.remove_user")
+    @patch("exp.views.study.ManageResearcherPermissionsView.add_user")
+    @patch("exp.views.study.ManageResearcherPermissionsView.update_user")
+    @patch.object(ManageResearcherPermissionsView, "request", create=True)
+    @patch.object(SingleObjectMixin, "get_object")
+    def test_manage_researcher_permissions(
+        self,
+        mock_get_object: Mock,
+        mock_request: Mock,
+        mock_update_user: Mock,
+        mock_add_user: Mock,
+        mock_remove_user: Mock,
+    ) -> None:
+
+        mock_request.POST.get = MagicMock(
+            side_effect=[sentinel.add_user_id, sentinel.remove_user_id, "update_user",]
+        )
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        manage_researcher_permissions_view.manage_researcher_permissions()
+        mock_update_user.assert_called_once_with(mock_get_object())
+        mock_add_user.assert_called_once_with(mock_get_object(), sentinel.add_user_id)
+        mock_remove_user.assert_called_once_with(
+            mock_get_object(), sentinel.remove_user_id
+        )
+
+    @patch("exp.views.study.messages")
+    @patch.object(ManageResearcherPermissionsView, "send_study_email")
+    @patch("accounts.models.User.objects")
+    @patch.object(ManageResearcherPermissionsView, "request", create=True)
+    def test_update_user(
+        self,
+        mock_request: Mock,
+        mock_user_objects: Mock,
+        mock_send_study_email: Mock,
+        mock_messages: None,
+    ):
+        user_group = "study_preview"
+
+        mock_update_user = MagicMock(name="update_user")
+        mock_study_group = MagicMock(name="study_group")
+        mock_study = MagicMock(name="study")
+
+        mock_request.POST.get.side_effect = [sentinel.user_update_id, user_group]
+        mock_user_objects.get.side_effect = [mock_update_user]
+
+        mock_update_user.groups.all.return_value = [mock_study.admin_group]
+        mock_study.all_study_groups.return_value = [mock_study_group]
+        mock_study.admin_group.user_set.count.return_value = 2
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+
+        self.assertIsNone(manage_researcher_permissions_view.update_user(mock_study))
+
+        mock_update_user.groups.all.assert_called_once_with()
+        mock_study.admin_group.user_set.count.assert_called_once_with()
+        mock_messages.error.assert_not_called()
+        mock_study.all_study_groups.assert_called_once_with()
+        mock_study_group.user_set.remove.assert_called_once_with(mock_update_user)
+        mock_update_user.groups.add.assert_called_once_with(mock_study.preview_group)
+        mock_send_study_email.assert_called_once_with(mock_update_user, user_group)
+
+    @patch.object(ManageResearcherPermissionsView, "user_only_admin", return_value=True)
+    @patch("exp.views.study.messages")
+    @patch.object(ManageResearcherPermissionsView, "send_study_email")
+    @patch("accounts.models.User.objects")
+    @patch.object(ManageResearcherPermissionsView, "request", create=True)
+    def test_update_user_not_enough_admins(
+        self,
+        mock_request: Mock,
+        mock_user_objects: Mock,
+        mock_send_study_email: Mock,
+        mock_messages: Mock,
+        mock_user_only_admin: Mock,
+    ):
+
+        user_group = "study_preview"
+
+        mock_update_user = MagicMock(name="update_user")
+        mock_study_group = MagicMock(name="study_group")
+        mock_study = MagicMock(name="study")
+
+        mock_request.POST.get.side_effect = [sentinel.user_update_id, user_group]
+
+        mock_user_objects.get.return_value = mock_update_user
+        mock_study.all_study_groups.return_value = [mock_study_group]
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+
+        self.assertIsNone(manage_researcher_permissions_view.update_user(mock_study))
+
+        mock_messages.error.assert_called_once_with(
+            mock_request,
+            "Could not change permissions for this researcher. There must be at least one study admin.",
+            extra_tags="user_removed",
+        )
+        mock_study.all_study_groups.assert_called_once_with()
+        mock_study_group.user_set.remove.assert_called_once_with(mock_update_user)
+        mock_update_user.groups.add.assert_called_once_with(mock_study.preview_group)
+        mock_send_study_email.assert_called_once_with(mock_update_user, user_group)
+        mock_user_only_admin.assert_called_once_with(mock_study, mock_update_user)
+
+    @patch.object(
+        ManageResearcherPermissionsView, "user_only_admin", return_value=False
+    )
+    @patch("exp.views.study.messages")
+    @patch.object(ManageResearcherPermissionsView, "send_study_email")
+    @patch("accounts.models.User.objects")
+    @patch.object(ManageResearcherPermissionsView, "request", create=True)
+    def test_update_user_already_one_admin(
+        self,
+        mock_request: Mock,
+        mock_user_objects: Mock,
+        mock_send_study_email: Mock,
+        mock_messages: Mock,
+        mock_user_only_admin: Mock,
+    ):
+        user_group = "study_admin"
+
+        mock_study = MagicMock(name="study")
+        mock_update_user = MagicMock(name="update_user")
+        mock_study_group = MagicMock(name="study_group")
+
+        mock_study.all_study_groups.return_value = [mock_study_group]
+        mock_user_objects.get.return_value = mock_update_user
+
+        mock_request.POST.get.side_effect = [sentinel.user_update_id, user_group]
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+
+        self.assertIsNone(manage_researcher_permissions_view.update_user(mock_study))
+
+        mock_messages.error.assert_not_called()
+        mock_study.all_study_groups.assert_called_once_with()
+        mock_study_group.user_set.remove.assert_called_once_with(mock_update_user)
+        mock_update_user.groups.add.assert_called_once_with(mock_study.admin_group)
+        mock_send_study_email.assert_called_once_with(mock_update_user, user_group)
+        mock_user_only_admin.assert_called_once_with(mock_study, mock_update_user)
+
+    @patch("exp.views.study.messages")
+    @patch.object(ManageResearcherPermissionsView, "send_study_email")
+    @patch.object(ManageResearcherPermissionsView, "request", create=True)
+    @patch("accounts.models.User.objects")
+    def test_add_user(
+        self,
+        mock_user_objects: Mock,
+        mock_request: Mock,
+        mock_send_study_email: Mock,
+        mock_messages: Mock,
+    ):
+        mock_study = MagicMock(name="study")
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertIsNone(
+            manage_researcher_permissions_view.add_user(
+                mock_study, sentinel.add_user_id
+            )
+        )
+        mock_user_objects.get().groups.add.assert_called_once_with(
+            mock_study.preview_group
+        )
+        mock_messages.success.assert_called_once_with(
+            mock_request,
+            f"{mock_user_objects.get().get_short_name()} given {mock_study.name} Preview Permissions.",
+            extra_tags="user_added",
+        )
+        mock_send_study_email.assert_called_once_with(
+            mock_user_objects.get(), "study_preview"
+        )
+
+    @patch("exp.views.study.messages")
+    @patch.object(ManageResearcherPermissionsView, "request", create=True)
+    @patch.object(
+        ManageResearcherPermissionsView, "user_only_admin", return_value=False
+    )
+    @patch("accounts.models.User.objects")
+    def test_remove_user(
+        self,
+        mock_user_objects: Mock,
+        mock_user_only_admin: Mock,
+        mock_request: Mock,
+        mock_messages: Mock,
+    ):
+        mock_study = MagicMock(name="study")
+        mock_study_group = MagicMock(name="study_group")
+        mock_study.all_study_groups.return_value = [mock_study_group]
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertIsNone(
+            manage_researcher_permissions_view.remove_user(
+                mock_study, sentinel.remove_user_id
+            )
+        )
+        mock_messages.error.assert_not_called()
+        mock_user_only_admin.assert_called_once_with(
+            mock_study, mock_user_objects.get()
+        )
+        mock_study_group.user_set.remove.assert_called_once_with(
+            mock_user_objects.get()
+        )
+        mock_messages.success.assert_called_once_with(
+            mock_request,
+            f"{mock_user_objects.get().get_short_name()} removed from {mock_study.name}.",
+            extra_tags="user_removed",
+        )
+
+    @patch("exp.views.study.messages")
+    @patch.object(ManageResearcherPermissionsView, "request", create=True)
+    @patch.object(ManageResearcherPermissionsView, "user_only_admin", return_value=True)
+    @patch("accounts.models.User.objects")
+    def test_remove_user_one_admin(
+        self,
+        mock_user_objects: Mock,
+        mock_user_only_admin: Mock,
+        mock_request: Mock,
+        mock_messages: Mock,
+    ):
+        mock_study = MagicMock(name="study")
+        mock_study_group = MagicMock(name="study_group")
+        mock_study.all_study_groups.return_value = [mock_study_group]
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertIsNone(
+            manage_researcher_permissions_view.remove_user(
+                mock_study, sentinel.remove_user_id
+            )
+        )
+
+        mock_user_only_admin.assert_called_once_with(
+            mock_study, mock_user_objects.get()
+        )
+        mock_study_group.user_set.remove.assert_not_called()
+        mock_messages.error.assert_called_once_with(
+            mock_request,
+            "Could not delete this researcher. There must be at least one study admin.",
+            extra_tags="user_removed",
+        )
+
+    def test_user_only_admin_user_not_admin(self):
+        mock_study = MagicMock()
+        mock_user = MagicMock()
+
+        mock_user.groups.all.return_value = []
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertFalse(
+            manage_researcher_permissions_view.user_only_admin(mock_study, mock_user)
+        )
+        mock_user.groups.all.assert_called_once_with()
+
+    def test_user_only_admin_user_no_other_admins(self):
+        mock_study = MagicMock()
+        mock_user = MagicMock()
+
+        mock_user.groups.all.return_value = [mock_study.admin_group]
+        mock_study.admin_group.user_set.count.return_value = 1
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertTrue(
+            manage_researcher_permissions_view.user_only_admin(mock_study, mock_user)
+        )
+        mock_user.groups.all.assert_called_once_with()
+
+    def test_only_one_admin_user_other_admins(self):
+        mock_study = MagicMock()
+        mock_user = MagicMock()
+
+        mock_user.groups.all.return_value = [mock_study.admin_group]
+        mock_study.admin_group.user_set.count.return_value = 2
+
+        manage_researcher_permissions_view = ManageResearcherPermissionsView()
+        self.assertFalse(
+            manage_researcher_permissions_view.user_only_admin(mock_study, mock_user)
+        )
+        mock_user.groups.all.assert_called_once_with()
+
+
 # TODO: StudyCreateView
 # - check user has to be in a lab with perms to create study to get
 # TODO: StudyUpdateView
@@ -516,10 +1153,6 @@ class StudyViewsTestCase(TestCase):
 # TODO: StudyListView
 # - check can get as researcher only
 # - check you see exactly studies you have view details perms for
-# TODO: StudyDetailView
-# - check can get as researcher only
-# - check correct links are shown given perms
-# - [postpone checks of POST which will be refactored]
 # TODO: StudyPreviewProxyView
 # - add checks analogous to preview detail view
 # - check for correct redirect

--- a/exp/urls.py
+++ b/exp/urls.py
@@ -14,11 +14,6 @@ Including another URLconf
     2. Import the include() function: from django.conf.urls import url, include
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from exp.views.study import (
-    ChangeStudyStatusView,
-    CloneStudyView,
-    ManageResearcherPermissionsView,
-)
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
@@ -62,6 +57,11 @@ from exp.views import (
     StudyResponseVideoAttachment,
     StudySingleResponseDownload,
     StudyUpdateView,
+)
+from exp.views.study import (
+    ChangeStudyStatusView,
+    CloneStudyView,
+    ManageResearcherPermissionsView,
 )
 
 app_name = "exp"

--- a/exp/urls.py
+++ b/exp/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 from exp.views.study import (
     ChangeStudyStatusView,
     CloneStudyView,
+    ManageResearcherPermissionsView,
 )
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
@@ -88,7 +89,6 @@ urlpatterns = [
         name="study-participant-analytics",
     ),
     path("studies/create/", StudyCreateView.as_view(), name="study-create"),
-    ########################### So I can find these in this file... I will remove them.
     path("studies/<int:pk>/", StudyDetailView.as_view(), name="study-detail"),
     path("studies/<int:pk>/clone-study", CloneStudyView.as_view(), name="clone-study"),
     path(
@@ -96,7 +96,11 @@ urlpatterns = [
         ChangeStudyStatusView.as_view(),
         name="change-study-status",
     ),
-    ###########################
+    path(
+        "studies/<int:pk>/manage-researcher-permissions",
+        ManageResearcherPermissionsView.as_view(),
+        name="manage-researcher-permissions",
+    ),
     path(
         "studies/<int:pk>/contact/",
         StudyParticipantContactView.as_view(),

--- a/exp/urls.py
+++ b/exp/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     2. Import the include() function: from django.conf.urls import url, include
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
+from exp.views.study import CloneStudyView
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
@@ -84,7 +85,10 @@ urlpatterns = [
         name="study-participant-analytics",
     ),
     path("studies/create/", StudyCreateView.as_view(), name="study-create"),
+    ########################### So I can find these in this file... I will remove them.
     path("studies/<int:pk>/", StudyDetailView.as_view(), name="study-detail"),
+    path("studies/<int:pk>/clone-study", CloneStudyView.as_view(), name="clone-study"),
+    ###########################
     path(
         "studies/<int:pk>/contact/",
         StudyParticipantContactView.as_view(),

--- a/exp/urls.py
+++ b/exp/urls.py
@@ -14,7 +14,10 @@ Including another URLconf
     2. Import the include() function: from django.conf.urls import url, include
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from exp.views.study import CloneStudyView
+from exp.views.study import (
+    ChangeStudyStatusView,
+    CloneStudyView,
+)
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
@@ -88,6 +91,11 @@ urlpatterns = [
     ########################### So I can find these in this file... I will remove them.
     path("studies/<int:pk>/", StudyDetailView.as_view(), name="study-detail"),
     path("studies/<int:pk>/clone-study", CloneStudyView.as_view(), name="clone-study"),
+    path(
+        "studies/<int:pk>/change-study-status",
+        ChangeStudyStatusView.as_view(),
+        name="change-study-status",
+    ),
     ###########################
     path(
         "studies/<int:pk>/contact/",

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -596,18 +596,9 @@ class ManageResearcherPermissionsView(StudyDetailView):
             bool: Returns false if user does not have permission.
         """
         user = self.request.user
-        method = self.request.method
-        study = self.get_object()
-
-        if not user.is_researcher:
-            return False
-
-        if method == "POST":
-            return user.has_study_perms(StudyPermission.MANAGE_STUDY_RESEARCHERS, study)
-        else:
-            # If we're not one of the two allowed methods this should be caught
-            # earlier
-            return False
+        return user.is_researcher and user.has_study_perms(
+            StudyPermission.MANAGE_STUDY_RESEARCHERS, self.get_object()
+        )
 
     # Make PyCharm happy - otherwise we'd just override
     # UserPassesTestMixin.get_test_func()
@@ -635,18 +626,9 @@ class ChangeStudyStatusView(StudyDetailView):
             bool: Returns false if user does not have permission.
         """
         user = self.request.user
-        method = self.request.method
-        study = self.get_object()
-
-        if not user.is_researcher:
-            return False
-
-        if method == "POST":
-            return user.has_study_perms(StudyPermission.CHANGE_STUDY_STATUS, study)
-        else:
-            # If we're not one of the two allowed methods this should be caught
-            # earlier
-            return False
+        return user.is_researcher and user.has_study_perms(
+            StudyPermission.CHANGE_STUDY_STATUS, self.get_object()
+        )
 
     # Make PyCharm happy - otherwise we'd just override
     # UserPassesTestMixin.get_test_func()
@@ -693,18 +675,7 @@ class CloneStudyView(StudyDetailView):
             bool: Returns false if user does not have permission.
         """
         user = self.request.user
-        method = self.request.method
-        study = self.get_object()
-
-        if not user.is_researcher:
-            return False
-
-        if method == "POST":
-            return user.can_create_study()
-        else:
-            # If we're not one of the two allowed methods this should be caught
-            # earlier
-            return False
+        return user.is_researcher and user.can_create_study()
 
     test_func = user_can_clone_study
 

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -589,7 +589,7 @@ class StudyDetailView(
 
 
 class ManageResearcherPermissionsView(StudyDetailView):
-    def user_can_see_or_edit_study_details(self):
+    def user_can_change_study_permissions(self):
         """Checks if user has permission to update researcher permissions.
 
         Returns:
@@ -611,7 +611,7 @@ class ManageResearcherPermissionsView(StudyDetailView):
 
     # Make PyCharm happy - otherwise we'd just override
     # UserPassesTestMixin.get_test_func()
-    test_func = user_can_see_or_edit_study_details
+    test_func = user_can_change_study_permissions
 
     def post(self, *args, **kwargs):
         """Updates user permissions on form submission.
@@ -628,7 +628,7 @@ class ManageResearcherPermissionsView(StudyDetailView):
 
 
 class ChangeStudyStatusView(StudyDetailView):
-    def user_can_see_or_edit_study_details(self):
+    def user_can_change_study_status(self):
         """Checks that the user has permission to change study status.
 
         Returns:
@@ -650,7 +650,7 @@ class ChangeStudyStatusView(StudyDetailView):
 
     # Make PyCharm happy - otherwise we'd just override
     # UserPassesTestMixin.get_test_func()
-    test_func = user_can_see_or_edit_study_details
+    test_func = user_can_change_study_status
 
     def post(self, *args, **kwargs):
         """Update study status on form submission.
@@ -686,7 +686,7 @@ class ChangeStudyStatusView(StudyDetailView):
 
 
 class CloneStudyView(StudyDetailView):
-    def user_can_see_or_edit_study_details(self):
+    def user_can_clone_study(self):
         """Checks if user has permissions to clone study.
 
         Returns:
@@ -706,7 +706,7 @@ class CloneStudyView(StudyDetailView):
             # earlier
             return False
 
-    test_func = user_can_see_or_edit_study_details
+    test_func = user_can_clone_study
 
     def post(self, *args, **kwargs):
         """Clone study on form submission. 

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -480,7 +480,15 @@ class StudyDetailView(
         return self.paginated_queryset(researchers_result, page, 10)
 
 
-class ManageResearcherPermissionsView(StudyDetailView):
+class ManageResearcherPermissionsView(
+    ExperimenterLoginRequiredMixin,
+    UserPassesTestMixin,
+    PaginatorMixin,
+    SingleObjectFetchProtocol[Study],
+    generic.DetailView,
+):
+    model = Study
+
     def user_can_change_study_permissions(self):
         """Checks if user has permission to update researcher permissions.
 
@@ -601,7 +609,15 @@ class ManageResearcherPermissionsView(StudyDetailView):
             )
 
 
-class ChangeStudyStatusView(StudyDetailView):
+class ChangeStudyStatusView(
+    ExperimenterLoginRequiredMixin,
+    UserPassesTestMixin,
+    PaginatorMixin,
+    SingleObjectFetchProtocol[Study],
+    generic.DetailView,
+):
+    model = Study
+
     def user_can_change_study_status(self):
         """Checks that the user has permission to change study status.
 
@@ -650,7 +666,15 @@ class ChangeStudyStatusView(StudyDetailView):
         return object
 
 
-class CloneStudyView(StudyDetailView):
+class CloneStudyView(
+    ExperimenterLoginRequiredMixin,
+    UserPassesTestMixin,
+    PaginatorMixin,
+    SingleObjectFetchProtocol[Study],
+    generic.DetailView,
+):
+    model = Study
+
     def user_can_clone_study(self):
         """Checks if user has permissions to clone study.
 

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -481,11 +481,7 @@ class StudyDetailView(
 
 
 class ManageResearcherPermissionsView(
-    ExperimenterLoginRequiredMixin,
-    UserPassesTestMixin,
-    PaginatorMixin,
-    SingleObjectFetchProtocol[Study],
-    generic.DetailView,
+    ExperimenterLoginRequiredMixin, UserPassesTestMixin, generic.DetailView,
 ):
     model = Study
 
@@ -610,11 +606,7 @@ class ManageResearcherPermissionsView(
 
 
 class ChangeStudyStatusView(
-    ExperimenterLoginRequiredMixin,
-    UserPassesTestMixin,
-    PaginatorMixin,
-    SingleObjectFetchProtocol[Study],
-    generic.DetailView,
+    ExperimenterLoginRequiredMixin, UserPassesTestMixin, generic.DetailView,
 ):
     model = Study
 
@@ -667,11 +659,7 @@ class ChangeStudyStatusView(
 
 
 class CloneStudyView(
-    ExperimenterLoginRequiredMixin,
-    UserPassesTestMixin,
-    PaginatorMixin,
-    SingleObjectFetchProtocol[Study],
-    generic.DetailView,
+    ExperimenterLoginRequiredMixin, UserPassesTestMixin, generic.DetailView,
 ):
     model = Study
 

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -346,8 +346,8 @@ class StudyDetailView(
     generic.DetailView,
 ):
     """
-    StudyDetailView shows information about a study. Can view basic metadata about a study,
-    view study logs, manage study researchers, and change a study's state.
+    StudyDetailView shows information about a study. It can view basic metadata about a study and
+    view study logs.
     """
 
     model = Study
@@ -355,7 +355,7 @@ class StudyDetailView(
     raise_exception = True
 
     def user_can_see_or_edit_study_details(self):
-        """Checks based on method, with fallback to umbrella lab perms.
+        """Checks if user has permission to view study details.
 
         Returns:
             A boolean indicating whether or not the user should be able to see
@@ -378,18 +378,6 @@ class StudyDetailView(
     # Make PyCharm happy - otherwise we'd just override
     # UserPassesTestMixin.get_test_func()
     test_func = user_can_see_or_edit_study_details
-
-    def post(self, *args, **kwargs):
-        """
-        Post method can:
-         - update the trigger if the state of the study has changed
-         - clone study and redirect to the clone
-         - add, remove, or update permissions for a researcher
-        TODO: these should be broken out into three separate views!
-        """
-        return HttpResponseRedirect(
-            reverse("exp:study-detail", kwargs=dict(pk=self.get_object().pk))
-        )
 
     def manage_researcher_permissions(self):
         """
@@ -602,11 +590,10 @@ class StudyDetailView(
 
 class ManageResearcherPermissionsView(StudyDetailView):
     def user_can_see_or_edit_study_details(self):
-        """Checks based on method, with fallback to umbrella lab perms.
+        """Checks if user has permission to update researcher permissions.
 
         Returns:
-            A boolean indicating whether or not the user should be able to see
-            this view.
+            bool: Returns false if user does not have permission.
         """
         user = self.request.user
         method = self.request.method
@@ -627,12 +614,8 @@ class ManageResearcherPermissionsView(StudyDetailView):
     test_func = user_can_see_or_edit_study_details
 
     def post(self, *args, **kwargs):
-        """
-        Post method can:
-         - update the trigger if the state of the study has changed
-         - clone study and redirect to the clone
-         - add, remove, or update permissions for a researcher
-        TODO: these should be broken out into three separate views!
+        """Updates user permissions on form submission.
+
         """
         try:
             self.manage_researcher_permissions()
@@ -646,11 +629,10 @@ class ManageResearcherPermissionsView(StudyDetailView):
 
 class ChangeStudyStatusView(StudyDetailView):
     def user_can_see_or_edit_study_details(self):
-        """Checks based on method, with fallback to umbrella lab perms.
+        """Checks that the user has permission to change study status.
 
         Returns:
-            A boolean indicating whether or not the user should be able to see
-            this view.
+            bool: Returns false if user does not have permission.
         """
         user = self.request.user
         method = self.request.method
@@ -671,12 +653,8 @@ class ChangeStudyStatusView(StudyDetailView):
     test_func = user_can_see_or_edit_study_details
 
     def post(self, *args, **kwargs):
-        """
-        Post method can:
-         - update the trigger if the state of the study has changed
-         - clone study and redirect to the clone
-         - add, remove, or update permissions for a researcher
-        TODO: these should be broken out into three separate views!
+        """Update study status on form submission.
+
         """
         try:
             update_trigger(self)
@@ -690,11 +668,10 @@ class ChangeStudyStatusView(StudyDetailView):
 
 class CloneStudyView(StudyDetailView):
     def user_can_see_or_edit_study_details(self):
-        """Checks based on method, with fallback to umbrella lab perms.
+        """Checks if user has permissions to clone study.
 
         Returns:
-            A boolean indicating whether or not the user should be able to see
-            this view.
+            bool: Returns false if user does not have permission.
         """
         user = self.request.user
         method = self.request.method
@@ -713,12 +690,8 @@ class CloneStudyView(StudyDetailView):
     test_func = user_can_see_or_edit_study_details
 
     def post(self, *args, **kwargs):
-        """
-        Post method can:
-         - update the trigger if the state of the study has changed
-         - clone study and redirect to the clone
-         - add, remove, or update permissions for a researcher
-        TODO: these should be broken out into three separate views!
+        """Clone study on form submission. 
+
         """
         orig_study = self.get_object()
         clone = orig_study.clone()

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -380,8 +380,6 @@ class StudyDetailView(
                 return user.has_study_perms(
                     StudyPermission.MANAGE_STUDY_RESEARCHERS, study
                 )
-            if "trigger" in self.request.POST:
-                return user.has_study_perms(StudyPermission.CHANGE_STUDY_STATUS, study)
         else:
             # If we're not one of the two allowed methods this should be caught
             # earlier
@@ -634,6 +632,50 @@ class StudyDetailView(
         """Builds paginated search results for researchers."""
         page = self.request.GET.get("page")
         return self.paginated_queryset(researchers_result, page, 10)
+
+
+class ChangeStudyStatusView(StudyDetailView):
+    def user_can_see_or_edit_study_details(self):
+        """Checks based on method, with fallback to umbrella lab perms.
+
+        Returns:
+            A boolean indicating whether or not the user should be able to see
+            this view.
+        """
+        user = self.request.user
+        method = self.request.method
+        study = self.get_object()
+
+        if not user.is_researcher:
+            return False
+
+        if method == "POST":
+            return user.has_study_perms(StudyPermission.CHANGE_STUDY_STATUS, study)
+        else:
+            # If we're not one of the two allowed methods this should be caught
+            # earlier
+            return False
+
+    # Make PyCharm happy - otherwise we'd just override
+    # UserPassesTestMixin.get_test_func()
+    test_func = user_can_see_or_edit_study_details
+
+    def post(self, *args, **kwargs):
+        """
+        Post method can:
+         - update the trigger if the state of the study has changed
+         - clone study and redirect to the clone
+         - add, remove, or update permissions for a researcher
+        TODO: these should be broken out into three separate views!
+        """
+        try:
+            update_trigger(self)
+        except Exception as e:
+            messages.error(self.request, f"TRANSITION ERROR: {e}")
+
+        return HttpResponseRedirect(
+            reverse("exp:study-detail", kwargs=dict(pk=self.get_object().pk))
+        )
 
 
 class CloneStudyView(StudyDetailView):

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -550,7 +550,7 @@
         </div>
     </div>
     {#  MODALS #}
-    <form class="modal fade" id="study-state-modal" method="POST">{% csrf_token %}
+    <form class="modal fade" id="study-state-modal" action="{% url 'exp:change-study-status' study.id %}" method="POST">{% csrf_token %}
         <input type="hidden" name="trigger"/>
         <div class="modal-content">
             <div class="modal-header">

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -302,7 +302,7 @@
                         {% if can_create_study %}
                             {#  Here we have a hidden clone form so we can maintain dropdown styling. #}
                             {#  TODO: actually use this form to let the user clone the study in a specific lab. #}
-                            <form id="cloneForm" method="POST" style="display:none;">{% csrf_token %}
+                            <form id="cloneForm" action="{% url 'exp:clone-study' study.id %}" method="POST" style="display:none;">{% csrf_token %}
                                 <input type="hidden" name="clone_study" value="{{ study.id }}"/>
                             </form>
                             <a type="button" class="btn btn-default" role="button" onclick="cloneStudy()">

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -406,7 +406,7 @@
                                                         </div>
                                                         <div class="col-xs-3">
                                                             <form method="POST"
-                                                                  action="./#manage-researchers">{% csrf_token %}
+                                                                  action="{% url 'exp:manage-researcher-permissions' study.id %}">{% csrf_token %}
                                                                 <input type="hidden" name="add_user"
                                                                        value="{{ user.id }}"/>
                                                                 <button aria-label="Add researcher to study"
@@ -473,7 +473,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="col-sm-2 researcher-delete">
-                                                    <form method="POST" action="./#manage-researchers">{% csrf_token %}
+                                                    <form method="POST" action="{% url 'exp:manage-researcher-permissions' study.id %}">{% csrf_token %}
                                                         <input type="hidden" name="remove_user"
                                                                value="{{ researcher.user.id }}"/>
                                                         <button aria-label="Remove researcher from study" type="submit"

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -463,7 +463,7 @@
                                                         <a href="#" data-name="update_user"
                                                            class="researcher_permissions"
                                                            data-type="select"
-                                                           data-url="{% url 'exp:study-detail' pk=study.id %}"
+                                                           data-url="{% url 'exp:manage-researcher-permissions' study.id %}"
                                                            data-params="{csrfmiddlewaretoken:'{{ csrf_token }}'}"
                                                            data-id="{{ researcher.user.get_short_name }}"
                                                            data-pk="{{ researcher.user.id }}"


### PR DESCRIPTION
Break up `StudyDetailView` into three views: Managing Researcher Permissions, Changing Study Status, and Cloning Study.

Closes #518 

Tests:
```
poetry run ./manage.py test \
    exp.tests.test_study_views.CloneStudyViewTestCase \
    exp.tests.test_study_views.ChangeStudyStatusViewTestCase \
    exp.tests.test_study_views.ManageResearcherPermissionsViewTestCase
```

