### PR TITLE
Fix bug when changing permissions ui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
     - stage: Build & Test
       script:
         - bash -c 'until pg_isready; do sleep 1; done'
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - docker pull $DOCKER_IMAGE_URL:$TRAVIS_COMMIT || docker pull $DOCKER_IMAGE_URL:$DOCKER_BRANCH || true
         - docker build
             --cache-from $DOCKER_IMAGE_URL:$TRAVIS_COMMIT --cache-from $DOCKER_IMAGE_URL:$DOCKER_BRANCH


### PR DESCRIPTION
When a permission was changed and the user was the only admin the view would throw an assertion error.  This error was caught in the post method of the `StudyDetailView`.  I removed the assert in a recent issue, this caused the last admin on a project to have their permission group changed without error.  

To fix this issue, I changed it from a try/catch to a boolean response.  If there's an error on the `manage_researcher_permissions` method then it should return False and then a 403 error will be given.  