### PR TITLE
Google Tag Manager

### DIFF
--- a/env_dist
+++ b/env_dist
@@ -75,3 +75,6 @@ EMAIL_FROM_ADDRESS=lookit.robot@some.domain
 # SENDGRID_API_KEY=SG.KEY-HERE
 # SSL_CERT_FILE=/path/to/cacert.pem
 # REQUESTS_CA_BUNDLE=/path/to/cacert.pem
+
+# Google tag manager.  You will have to goto https://tagmanager.google.com/ to find the ID.
+GOOGLE_TAG_MANAGER_ID=

--- a/exp/templates/exp/base.html
+++ b/exp/templates/exp/base.html
@@ -35,9 +35,10 @@
     <script src="{% static 'exp/js/bootstrap-editable.min.js' %}"></script>
     <script src="{% static 'exp/js/clipboard.min.js' %}"></script>
     <script defer src="{% static 'js/fontawesome-all.js' %}" integrity="sha384-z9ZOvGHHo21RqN5De4rfJMoAxYpaVoiYhuJXPyVmSs8yn20IE3PmBM534CffwSJI"></script>
-    {% google_analytics %}
+    {% google_tag_manager_head %}
   </head>
   <body>
+    {% google_tag_manager_body %}
     <div class="container-fluid">
       <header class="row">
           {% block header %}

--- a/web/templates/403.html
+++ b/web/templates/403.html
@@ -4,9 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <title>403 Forbidden</title>
-    {% google_analytics %}
+    {% google_tag_manager_head %}
 </head>
 <body>
+    {% google_tag_manager_body %}
     <h1>403 Forbidden</h1>
     <p>{{ exception }}</p>
 </body>

--- a/web/templates/flatpages/default.html
+++ b/web/templates/flatpages/default.html
@@ -19,9 +19,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.full.min.js"></script>
     <link type="text/css" rel="stylesheet" href="{% static "base.css" %}" />
     <script src="https://use.fontawesome.com/41c082d3c2.js"></script>
-    {% google_analytics %}
+    {% google_tag_manager_head %}
   </head>
   <body>
+    {% google_tag_manager_body %}
     <div class="container-fluid">
       {% bootstrap_messages %}
       <header class="row">

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -22,13 +22,13 @@
     <link rel="stylesheet" href="{% static 'css/jquery-ui.min.css' %}" />
     <script src="{% static 'js/moment.min.js' %}"></script>
     <link type="text/css" rel="stylesheet" href="{% static "base.css" %}" />
-    {% google_analytics %}
+    {% google_tag_manager_head %}
     {% block head %}
     {% endblock %}
 
   </head>
   <body>
-
+    {% google_tag_manager_body %}
     <div class="container-fluid">
       <header class="row">
           {% block header %}

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 from typing import Text
 
@@ -5,9 +6,18 @@ from django import template
 from django.utils.safestring import mark_safe
 
 from accounts.queries import get_child_eligibility
-from project import settings
+from project.settings import DEBUG
 
 register = template.Library()
+
+GOOGLE_TAG_MANAGER_ID = os.environ.get("GOOGLE_TAG_MANAGER_ID", "")
+
+
+def format(text: Text) -> Text:
+    if not DEBUG and GOOGLE_TAG_MANAGER_ID:
+        return mark_safe(textwrap.dedent(text))
+    else:
+        return ""
 
 
 @register.simple_tag
@@ -16,19 +26,23 @@ def child_is_valid_for_study_criteria_expression(child, study):
 
 
 @register.simple_tag
-def google_analytics() -> Text:
-    if not settings.DEBUG:
-        ga_js = textwrap.dedent(
-            """
-                <script async src="https://www.googletagmanager.com/gtag/js?id=UA-163886699-1"></script>
-                <script>
-                window.dataLayer = window.dataLayer || [];
-                function gtag(){dataLayer.push(arguments);}
-                gtag('js', new Date());
-                gtag('config', 'UA-163886699-1');
-                </script>
-            """
-        )
-        return mark_safe(ga_js)
-    else:
-        return ""
+def google_tag_manager_head() -> Text:
+    return format(
+        f"""
+    <script>(function(w,d,s,l,i){{w[l]=w[l]||[];w[l].push({{'gtm.start':
+    new Date().getTime(),event:'gtm.js'}});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    }})(window,document,'script','dataLayer','{GOOGLE_TAG_MANAGER_ID}');</script>
+    """
+    )
+
+
+@register.simple_tag
+def google_tag_manager_body() -> Text:
+    return format(
+        f"""
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={GOOGLE_TAG_MANAGER_ID}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    """
+    )


### PR DESCRIPTION
This PR adds the correct Google Tag Manager code to our HTML templates.  

Open Question:

There are two bits of code.  The first is the normal javascript variant, while the second is a `noscript` version that will trigger when some is running without JS.  Should we leave out the `noscript`?