### PR TITLE
Ensure soft deleted children aren't shown unnecessarily

### DIFF
--- a/exp/tests/test_analytics_views.py
+++ b/exp/tests/test_analytics_views.py
@@ -1,3 +1,56 @@
+from unittest.mock import patch
+
+from django.test.testcases import TestCase
+
+from exp.views.analytics import StudyParticipantAnalyticsView
+
+
+class StudyParticipantAnalyticsViewTestCase(TestCase):
+    @patch.object(StudyParticipantAnalyticsView, "request", create=True)
+    @patch("accounts.models.Child.objects")
+    def test_get_context_data_deleted_children_perms_true(
+        self, mock_child_objects, mock_request,
+    ):
+        mock_request.user.has_perm.return_value = True
+
+        view = StudyParticipantAnalyticsView()
+        view.get_context_data()
+
+        print(mock_child_objects)
+
+        mock_child_objects.filter.assert_called_once_with(
+            user__is_researcher=False, deleted=False
+        )
+        mock_request.user.has_perm.assert_called_with(
+            "accounts.can_view_all_children_in_analytics"
+        )
+
+    @patch.object(StudyParticipantAnalyticsView, "request", create=True)
+    @patch("exp.views.analytics.get_annotated_responses_qs")
+    @patch("accounts.models.Child.objects")
+    def test_get_context_data_deleted_children_perms_false(
+        self, mock_child_objects, mock_get_annotated_responses_qs, mock_request
+    ):
+        mock_request.user.has_perm.return_value = False
+
+        view = StudyParticipantAnalyticsView()
+        view.get_context_data()
+
+        mock_child_objects.filter.assert_called_once_with(
+            deleted=False,
+            user__is_researcher=False,
+            id__in=mock_get_annotated_responses_qs()
+            .filter()
+            .select_related()
+            .values()
+            .values_list()
+            .distinct(),
+        )
+        mock_request.user.has_perm.assert_called_with(
+            "accounts.can_view_all_children_in_analytics"
+        )
+
+
 # TODO: StudyParticipantAnalyticsView
 # - check can get iff self.request.user.has_perm("accounts.can_view_analytics")
 #             and self.request.user.is_researcher

--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -28,6 +28,7 @@ from exp.views.study import (
     CloneStudyView,
     ManageResearcherPermissionsView,
     StudyDetailView,
+    StudyPreviewDetailView,
 )
 from studies.models import Lab, Study, StudyType
 from studies.permissions import LabPermission, StudyPermission
@@ -1222,6 +1223,15 @@ class StudyDetailViewTestCase(TestCase):
             StudyPermission.READ_STUDY_DETAILS, mock_get_object()
         )
         mock_is_researcher.assert_called_with()
+
+
+class StudyPreviewDetailViewTestCase(TestCase):
+    @patch.object(StudyPreviewDetailView, "request", create=True)
+    def test_get_context_data_not_deleted_children(self, mock_request):
+        with patch.object(StudyPreviewDetailView, "object", create=True):
+            study_preview_detail_view = StudyPreviewDetailView()
+            study_preview_detail_view.get_context_data()
+            mock_request.user.children.filter.assert_called_once_with(deleted=False)
 
 
 # TODO: StudyCreateView

--- a/exp/tests/test_user_views.py
+++ b/exp/tests/test_user_views.py
@@ -1,3 +1,29 @@
+from unittest.mock import patch
+
+from django.test.testcases import TestCase
+from django.views.generic.base import ContextMixin
+
+from exp.views.user import ParticipantDetailView
+
+
+class ParticipantDetailViewTestCase(TestCase):
+    @patch.object(ParticipantDetailView, "valid_responses")
+    @patch.object(ContextMixin, "get_context_data")
+    def test_get_context_data_all_children(
+        self, mock_super_get_context_data, mock_valid_responses,
+    ):
+        with patch.object(ParticipantDetailView, "object", create=True), patch.object(
+            ParticipantDetailView, "get_study_info"
+        ):
+            participant_detail_view = ParticipantDetailView()
+            participant_detail_view.get_context_data()
+            mock_user = mock_super_get_context_data()["user"]
+            # verify that all, even soft deleted, children are queried.
+            mock_user.children.filter.assert_called_once_with(
+                id__in=mock_valid_responses().values_list()
+            )
+
+
 # TODO: ParticipantListView
 # - check can only see as researcher
 # - check that participant w/ consent frame completed but no consent approved does not show up

--- a/exp/views/analytics.py
+++ b/exp/views/analytics.py
@@ -108,10 +108,13 @@ class StudyParticipantAnalyticsView(
         )
 
         if self.request.user.has_perm("accounts.can_view_all_children_in_analytics"):
-            children_queryset = Child.objects.filter(user__is_researcher=False)
+            children_queryset = Child.objects.filter(
+                user__is_researcher=False, deleted=False
+            )
             ctx["can_view_all_children"] = True
         else:
             children_queryset = Child.objects.filter(
+                deleted=False,
                 user__is_researcher=False,
                 id__in=annotated_responses.values_list(
                     "child_id", flat=True

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -315,6 +315,24 @@ class TestAnnouncementEmailFunctionality(TestCase):
             )
         )
 
+    def test_potential_message_targets_deleted_children(self):
+        user = User(is_active=True)
+        user.save()
+
+        child = Child(user=user)
+        child.save()
+
+        self.assertTrue(
+            any(m.child_id == child.id for m in potential_message_targets())
+        )
+
+        child.deleted = True
+        child.save()
+
+        self.assertFalse(
+            any(m.child_id == child.id for m in potential_message_targets())
+        )
+
     def test_target_creation_e2e(self):
         targets = list(acquire_potential_announcement_email_targets())
 

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -138,7 +138,7 @@
                         {% if not request.user.is_authenticated %}
                             <a class="btn btn-lg btn-default" href="{% url 'login' %}">{% trans "Log in to participate" %}</a>
                         {% elif not children %}
-                            <a class="btn btn-lg btn-default" href="{% url 'web:children-list' %}">{% trans "Add child profile to " %} {% if preview_mode %} {% trans "preview" %} {% else %} {% trans "participate" %} {% endif %} %}</a>
+                            <a class="btn btn-lg btn-default" href="{% url 'web:children-list' %}">{% trans "Add child profile to " %} {% if preview_mode %} {% trans "preview" %} {% else %} {% trans "participate" %} {% endif %}</a>
                         {% elif not has_demographic %}
                             <a class="btn btn-lg btn-default" href="{% url 'web:demographic-data-update' %}">{% trans "Complete demographic survey to " %} {% if preview_mode %} {% trans "preview" %} {% else %} {% trans "participate" %} {% endif %}" %}</a>
                         {% else %}

--- a/web/views.py
+++ b/web/views.py
@@ -84,7 +84,7 @@ class DemographicDataUpdateView(LoginRequiredMixin, generic.CreateView):
         return demographic_data
 
     def get_success_url(self):
-        if self.request.user.children.exists():
+        if self.request.user.children.filter(deleted=False).exists():
             return reverse("web:studies-list")
         else:
             return reverse("web:children-list")


### PR DESCRIPTION
Added tests to verify that specific views aren't showing children that were "deleted".   In one case, There's a test that verifies that even "deleted" children are shown. 

Close #666 

 WIP: Still working through list of tasks.  Just wanted to get this off my laptop for the weekend. 