### PR TITLE
Install without using poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,18 @@
 name = "lookit-api"
 version = "0.1.0"
 description = ""
-authors = [""]
+authors = ["MIT <mit@mit.com>"]
+
+packages = [
+    { include = "accounts" },
+    { include = "api" },
+    { include = "exp" },
+    { include = "project" },
+    { include = "studies" },
+    { include = "web" },
+]
+
+include = ['build/*', "ember_build/**/*", "locale/**/*"]
 
 [tool.poetry.dependencies]
 python = "3.8.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "lookit-api"
 version = "0.1.0"
 description = ""
-authors = ["MIT <mit@mit.com>"]
+authors = ["MIT <lookit@mit.edu>"]
 
 packages = [
     { include = "accounts" },


### PR DESCRIPTION
This is an attempt to be able to install our application without poetry.  

Todos:

1. Test that this application can be ran by uwsgi when installed into virtualenv.
2. Is it possible to install using `pip install .` with Poetry not installed?

Closes #689