### PR TITLE
Update logic for filter "hide studies we've done"

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -3,7 +3,7 @@ from hashlib import sha1
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, signals
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.dispatch import receiver
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, reverse
@@ -293,12 +293,8 @@ class StudiesListView(generic.ListView, PaginatorMixin, FormView):
         return reverse("web:studies-list")
 
     def studies_without_completed_consent_frame(self, studies, child):
-        return [
-            r.study
-            for r in Response.objects.filter(
-                study__in=studies, child=child, completed_consent_frame=False
-            ).distinct("study_id")
-        ]
+        query = Q(child=child, completed_consent_frame=True)
+        return [s for s in studies if s.responses.filter(query).count() == 0]
 
     def set_eligible_children_per_study(self, studies):
         user = self.request.user

--- a/web/views.py
+++ b/web/views.py
@@ -260,7 +260,9 @@ class StudiesListView(generic.ListView, PaginatorMixin, FormView):
                 child = Child.objects.get(pk=child_value, user=user)
 
                 if hide_studies_we_have_done_value:
-                    studies = self.completed_consent_frame(studies, child)
+                    studies = self.studies_without_completed_consent_frame(
+                        studies, child
+                    )
 
                 studies = [
                     s for s in studies if get_child_eligibility_for_study(child, s)
@@ -290,11 +292,11 @@ class StudiesListView(generic.ListView, PaginatorMixin, FormView):
     def get_success_url(self):
         return reverse("web:studies-list")
 
-    def completed_consent_frame(self, studies, child):
+    def studies_without_completed_consent_frame(self, studies, child):
         return [
             r.study
             for r in Response.objects.filter(
-                study__in=studies, child=child, completed_consent_frame=True
+                study__in=studies, child=child, completed_consent_frame=False
             ).distinct("study_id")
         ]
 


### PR DESCRIPTION
This PR fixes a bug that was introduced with the recent update to the studies list page filter.  This update should now correctly only display studies that have responses where the field `completed_consent_frame` is False.  