### PR TITLE
Update age range in search filter

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -445,9 +445,9 @@ class ChildUpdateForm(forms.ModelForm):
 CHILD_CHOICES = [
     ("", "Find studies for..."),
     ("0,1", "babies (under 1)"),
-    ("1,2", "toddlers (1-2)"),
-    ("3,4", "preschoolers (3-4)"),
-    ("5,17", "school-age kids (5-17)"),
+    ("1,3", "toddlers (1-2)"),
+    ("3,5", "preschoolers (3-4)"),
+    ("5,18", "school-age kids (5-17)"),
     ("18,999", "adults (18+)"),
 ]
 


### PR DESCRIPTION
Update age range in search filter to cover all ages throughout childhood.  For example, before the age range "1 - 2" and "3 - 4" doesn't include the entire year "2".  This has been fixed by changing age range "1 - 2" to actually cover until age "3".  This has been update will all age ranges.  