### PR TITLE
Cleared search form will no longer select checkbox

### DIFF
--- a/web/templates/web/studies-list.html
+++ b/web/templates/web/studies-list.html
@@ -103,8 +103,6 @@
     </div>
 </div>
 
- 
-
 <script>
     $(function() {       
         const $form = $('form');
@@ -120,9 +118,8 @@
         })
 
         function resetForm(callbackFn){
-
             $form.find('input:text').attr('value', '')
-            $checkbox.attr('checked', true);
+            $checkbox.attr('checked', false);
             $dropdownSelected.removeAttr('selected');    
             callbackFn()
         }


### PR DESCRIPTION
Fixes a bug where the checkbox in the search bar would be selected when the clear button is pressed.  

Note:  This bug shines a light on the fact that we don't have a Splinter/Ghost Inspector/Selenium test suite.