### PR TITLE
Add check-yaml to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,8 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict
       - id: check-ast
+      - id: check-yaml

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -62,7 +62,7 @@ steps:
     'GIT_TAG=$TAG_NAME',
     '--network=cloudbuild',
     '--file',
-    'dev.Dockerfile'
+    'dev.Dockerfile',
     '.'
   ]
 
@@ -99,7 +99,7 @@ steps:
     '--env',
     'TAG_NAME=$TAG_NAME',
     '--env',
-    'POETRY_INSTALL_ARG="--no-dev"'
+    'POETRY_INSTALL_ARG="--no-dev"',
     'gcr.io/$PROJECT_ID/lookit-orchestrator',
   ]
 


### PR DESCRIPTION
I made some format errors in `cloudbuild.yaml` in a recent PR (#731).  These mistakes could have been caught if pre-commit was linting yaml files.  

This PR adds yaml linting to pre-commit and fixes the found mistakes.  