### PR TITLE
No longer remove search form values from session

### DIFF
--- a/web/static/base.css
+++ b/web/static/base.css
@@ -243,10 +243,6 @@ button.account-row {
     background-color: #f8f8f8;
 }
 
-.panel.study-list .right {
-    border-left: 1px solid #ddd;
-}
-
 .panel.study-list h1 {
     font-size: x-large;
     font-weight: bold;
@@ -263,10 +259,6 @@ button.account-row {
     font-size: large;
     font-weight: normal;
     margin-top: 0px;
-}
-
-.panel.study-list .description {
-    padding-left: 15px;
 }
 
 .panel.study-list .left .study-criteria {

--- a/web/tests.py
+++ b/web/tests.py
@@ -598,7 +598,7 @@ class StudiesListViewTestCase(TestCase):
         mock_form_class().fields.__iter__.assert_called_once_with()
 
         self.assertIn(sentinel.field, kwargs)
-        self.assertNotIn(sentinel.field, mock_request.session)
+        self.assertIn(sentinel.field, mock_request.session)
 
     def test_get_success_url(self):
         view = StudiesListView()

--- a/web/views.py
+++ b/web/views.py
@@ -279,10 +279,9 @@ class StudiesListView(generic.ListView, PaginatorMixin, FormView):
     def get_initial(self):
         kwargs = super().get_initial()
 
-        # When field values are retrieved from session to populate form, they are removed from session
         for field in self.form_class().fields:
             if field in self.request.session:
-                kwargs[field] = self.request.session.pop(field)
+                kwargs[field] = self.request.session.get(field)
 
         return kwargs
 


### PR DESCRIPTION
Two issues came out of the recent push to master:

1.  The css looked a bit odd, mainly the border between the left and right sections on the studies list cards.  I removed this border and some unnecessary padding. 
2. The filter was removed when a user changes pages.  This made for an odd experience.  The solution was to no remove the filter values from session and the user will have to press the clear button if they want the for cleared.  The browser's reload button will no longer clear the filter form.  