### PR TITLE
Fixed small bug with study detail view

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -492,7 +492,7 @@ class StudyDetailView(generic.DetailView):
                 child_uuid = request.POST["child_id"]
                 if study.study_type.is_external:
                     child = Child.objects.get(uuid=child_uuid)
-                    response, _ = Response.objects.get_or_create(
+                    response, _created = Response.objects.get_or_create(
                         study=study,
                         child=child,
                         study_type=study.study_type,


### PR DESCRIPTION
Found a small bug in the StudyDetailView that was breaking on error.  Basically, the underscore is overloaded within Django.  It both means a variable that isn't going to be accessed and the function to translate text.  