### PR TITLE
update str method for ConsentRuling

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -1314,9 +1314,4 @@ class ConsentRuling(models.Model):
         index_together = (("response", "action"), ("response", "arbiter"))
 
     def __str__(self):
-
-        if self.arbiter:
-            arbitor_name = self.arbiter.get_short_name()
-        else:
-            arbitor_name = None
-        return f"<{arbitor_name}: {self.action} {self.response} @ {self.created_at:%c}>"
+        return f"<{self.arbiter.get_short_name()}: {self.action} {self.response} @ {self.created_at:%c}>"


### PR DESCRIPTION
Removed some unnecessary code from the ConstentRuling model.  The `__str__` method was handling a case were the arbiter might not be present, this should never happen. 