### PR TITLE
Generalize view conditionals

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -505,6 +505,34 @@ class Study(models.Model):
     def expressed_interest_count(self):
         return self.responses.count()
 
+    @property
+    def show_videos(self):
+        return self.study_type.is_ember_frame_player
+
+    @property
+    def show_frame_data(self):
+        return self.study_type.is_ember_frame_player
+
+    @property
+    def show_consent(self):
+        return self.study_type.is_ember_frame_player
+
+    @property
+    def show_responses(self):
+        return self.study_type.is_ember_frame_player
+
+    @property
+    def show_build_experiment_runner(self):
+        return self.study_type.is_ember_frame_player
+
+    @property
+    def show_expressed_interest(self):
+        return self.study_type.is_external
+
+    @property
+    def show_scheduled(self):
+        return self.study_type.is_external and self.metadata["scheduled"]
+
     # WORKFLOW CALLBACKS
 
     def clone(self):

--- a/studies/templates/studies/_all_json_and_csv_data.html
+++ b/studies/templates/studies/_all_json_and_csv_data.html
@@ -142,7 +142,7 @@
                 
                     <hr>
                 
-                    {% if not study.study_type.is_external %}
+                    {% if study.show_frame_data %}
                     <div class="row">
                         <div class="col-md-7 col-sm-6">
                             Frame data

--- a/studies/templates/studies/_response_nav_tabs.html
+++ b/studies/templates/studies/_response_nav_tabs.html
@@ -16,7 +16,7 @@
             Demographic <span class="hidden-xs"> Snapshots </span>
         </a>
     </li>
-    {% if not study.study_type.is_external %}
+    {% if study.show_videos %}
     <li {% if active == 'attachments' %} class="active" {% endif %}>
         <a href="{% url 'exp:study-attachments' study.id %}">
             Videos

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -298,7 +298,7 @@
                                 <i class="fas fa-mail-bulk" aria-hidden="true"></i> Message Participants
                             </a>
                         {%  endif %}
-                        {% if not study.study_type.is_external %}
+                        {% if study.show_consent%}
                         {% if "edit_study__responses__consent_rulings" in study_perms or "edit_study__responses__consent_rulings(is_preview=True)" in study_perms %}
                             <a type="button" class="btn btn-default"
                                href="{% url 'exp:study-responses-consent-manager' pk=study.id %}?{% query_transform request sort='-date_created' %}">
@@ -360,7 +360,7 @@
                                 <em>{{comments|linebreaks}}</em>
                             </li>
                             {% endif %}
-                            {% if not study.study_type.is_external %}
+                            {% if study.show_build_experiment_runner %}
                             <li class="list-group-item list-group-item-{{ build_ui_tag }}">
                                 <div class="row">
                                     <div class="col-xs-9">

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -163,18 +163,22 @@
                         Edited:</strong> {{ study.date_modified|date:"M d, Y" }}
                 </div>
 
-                {% if study.study_type.is_external %}
+                {% if study.show_expressed_interest %}
                 <div class="col-sm-3">
                     <div><strong>Exp<span class="hidden-sm hidden-md">ressed</span> Interest:
                         </strong> {{ study.expressed_interest_count}}</div>
                 </div>
-                {% else %}
+                {% endif %}
+
+                {% if study.show_responses %}
                 <div class="col-sm-3">
                     <div><strong> Compl<span class="hidden-sm hidden-md">eted</span> Responses:
                         </strong> {{ study.completed_responses_count }}</div>
                     <div><strong> Inc<span class="hidden-sm hidden-md">omplete</span> Responses:
                         </strong> {{ study.incomplete_responses_count }}</div>
                 </div>
+                {% endif %}
+                {% if study.show_consent %}
                 <div class="col-sm-3">
                     <div><strong>App<span class="hidden-sm hidden-md">roved </span> Consent:
                         </strong> {{ study.valid_consent_count }}</div>

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -189,7 +189,7 @@
                 </section>
             </div>
 
-            {% if not study.study_type.is_external %}
+            {% if study.show_videos%}
             <section class="mt-md well">
                 <h4> Videos </h4>
                 {% for response in response_data %}

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -152,7 +152,7 @@
                             <a id="participate-button" class="btn btn-lg btn-default" href="{% url 'exp:study-detail' object.pk %}">{% trans "Build experiment runner to preview" %}</a>
                             {% else %}
                             <button type="submit" disabled class="btn-lg btn-primary" id="participate-button">
-                                {% if object.study_type.is_external and object.metadata.scheduled %}
+                                {% if object.show_scheduled %}
                                 {% trans "Schedule a time to participate" %}
                                 {% elif preview_mode %}
                                 {% trans "Preview" %}


### PR DESCRIPTION
The view was littered with `study.study_type.is_external` and this lead the confusion.  Moving to a more generalized pattern where properties on the model determines if "something" should be show is more extendable when we need to incorporate a new experiment runner. 