### PR TITLE
Use model properties for conditionals within view

### DIFF
--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -64,7 +64,7 @@
                                     {% for response in study.responses.all %}
                                     {% with videos=response.videos.all %}
                                     <div class="media">
-                                        {% if is_lookit_study %}
+                                        {% if study.show_videos %}
                                         <div class="media-left media-top">
                                             {% if videos.0.download_url %}
                                             <video controls class="media-object" width="200">
@@ -87,7 +87,7 @@
                                                 <dd>{{ response.child.given_name }}</dd>
                                                 <dt>{% trans "Date" %}</dt>
                                                 <dd>{{ response.date_created }}</dd>
-                                                {% if is_lookit_study %}
+                                                {% if study.show_consent %}
                                                 <dt>{% trans "Consent status" %}</dt>
                                                 <dd>
                                                     {% if response.most_recent_ruling == 'accepted' %}
@@ -125,7 +125,7 @@
                     {% empty %}
                     <div class="panel-default">
                         <div class="panel-body">
-                            {% if is_lookit_study %}
+                            {% if study.study_type.is_ember_frame_player %}
                             <em> {% trans "You have not yet participated in any Lookit studies." %} </em>
                             {% else %}
                             <em> {% trans "You have not yet participated in any external studies." %} </em>

--- a/web/views.py
+++ b/web/views.py
@@ -467,14 +467,6 @@ class StudiesHistoryView(LoginRequiredMixin, generic.ListView, FormView):
 
         return kwargs
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["is_lookit_study"] = (
-            self.request.session.get("past_studies_tabs", "0")
-            == PastStudiesFormTabChoices.lookit_studies.value[0]
-        )
-        return context
-
 
 class StudyDetailView(generic.DetailView):
     """


### PR DESCRIPTION
The pattern used to show (or not show) different sections of the history view needed updating to use a pattern introduced in a recent PR (#826). This pattern is extended to this view.   