### PR TITLE
Add compilemessages to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ RUN apt-get update \
     && python /tmp/get-poetry.py  \
     && source "$HOME/.poetry/env" \
     && poetry config virtualenvs.create false \
-    && poetry install --no-dev
+    && poetry install --no-dev \
+    && python manage.py compilemessages


### PR DESCRIPTION
The previous way of generating translation files (*.mo) wasn't working.  This issue needs to be investigated, but in the mean time, we'll generate the files upon building the docker image.  