### PR TITLE
Remove exit url from study detail

### DIFF
--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -189,8 +189,6 @@
                                 <p>
                                     <span class="pr-md"><label
                                             class='pr-xs'> Duration: </label> {{ study.duration }} </span>
-                                    <span><label
-                                            class='pr-xs'> Exit URL: </label> {{ study.exit_url | default:"None specified" }} </span>
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
This PR remove the exit url field from the study detail view. 

Closes  #836