### PR TITLE
Blank noopener links

### DIFF
--- a/exp/templates/exp/_navigation.html
+++ b/exp/templates/exp/_navigation.html
@@ -33,7 +33,7 @@
             Help <span class="caret"></span>
           </a>
           <ul class="dropdown-menu">
-            <li><a href="https://lookit.readthedocs.io/" target="_blank">Docs</a></li>
+            <li><a href="https://lookit.readthedocs.io/" target="_blank" rel="noopener">Docs</a></li>
           </ul>
         </li>
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -385,9 +385,9 @@ sqlparse = ">=0.2.0"
 
 [[package]]
 name = "django-dynamic-fixture"
-version = "3.1.1"
+version = "3.1.2"
 description = "A full library to create dynamic model instances for testing purposes."
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -1451,7 +1451,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "3.8.3"
-content-hash = "1de8401211da23c28cf215a74493d71cb233677487f211eae3057babbbb16dda"
+content-hash = "11ca285e814ff02f2c3e9486994e2f91d06c22b5470d5bca59fb798ad682017d"
 
 [metadata.files]
 amqp = [
@@ -1672,7 +1672,7 @@ django-debug-toolbar = [
     {file = "django_debug_toolbar-2.2.1-py3-none-any.whl", hash = "sha256:7feaee934608f5cdd95432154be832fe30fda6c1249018191e2c27bc0b6a965e"},
 ]
 django-dynamic-fixture = [
-    {file = "django-dynamic-fixture-3.1.1.tar.gz", hash = "sha256:90d9d68ec373dce97a4a9ba3ec6a39cf10918e9c222fdf231074cfb668d14ea2"},
+    {file = "django-dynamic-fixture-3.1.2.tar.gz", hash = "sha256:08cf0dadb91a1058ef7bf2486e5df2a93571f4517a7de1b806d1a6ee6d78b078"},
 ]
 django-extensions = [
     {file = "django-extensions-2.2.9.tar.gz", hash = "sha256:2f81b618ba4d1b0e58603e25012e5c74f88a4b706e0022a3b21f24f0322a6ce6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ django-bootstrap3 = "^15.0.0"
 django-celery-beat = "2.0.0"
 django-cors-headers = "3.4.0"
 django-countries = "7.2.1"
-django-dynamic-fixture = "3.1.1"
 django-extensions = "2.2.9"
 django-filter = "2.3.0"
 django-guardian = "2.3.0"
@@ -65,6 +64,7 @@ pre-commit = "2.9.2"
 pyinstrument = "3.1.3"
 pyopenssl = "19.1.0"
 python_dotenv = "0.18.0"
+django-dynamic-fixture = "^3.1.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -279,7 +279,7 @@
                     <div class="col-xs-3"> 
                         <div class="pull-right btn-group-vertical study-action-buttons">
                         {% if "read_study__responses(is_preview=True)" in study_perms %}
-                            <a type="button" class="btn btn-default" href="{% url 'exp:preview-detail' uuid=study.uuid %}" target="_blank">
+                            <a type="button" class="btn btn-default" href="{% url 'exp:preview-detail' uuid=study.uuid %}" target="_blank" rel="noopener">
                                 {% bootstrap_icon "play-circle" %} Preview Study
                             </a>
                         {% endif %}

--- a/studies/templates/studies/study_edit.html
+++ b/studies/templates/studies/study_edit.html
@@ -63,7 +63,7 @@
             <div class="col-lg-10 col-lg-offset-1">
                 <div class="panel panel-default mt-xl">
                     <div class="panel-heading">
-                        <h1 class="panel-title">Study Editor <a class="btn btn-default btn-sm pull-right" href="{% url 'exp:preview-detail' uuid=study.uuid %}" target="_blank"
+                        <h1 class="panel-title">Study Editor <a class="btn btn-default btn-sm pull-right" href="{% url 'exp:preview-detail' uuid=study.uuid %}" target="_blank" rel="noopener"
                                 id="preview-button" >
                             {% bootstrap_icon "play-circle" %} Preview Study
                         </a></h1>

--- a/web/templates/flatpages/default.html
+++ b/web/templates/flatpages/default.html
@@ -61,8 +61,8 @@
                         <li><a href="https://accessibility.mit.edu/">{% trans "Accessibility" %}</a></li>
 						<li><a href="/contact_us/">{% trans "Contact us" %}</a></li>
 						<li>{% trans "Connect" %}:
-						<a href="https://www.facebook.com/lookit.mit.edu" target="_blank"><i class="fa fa-facebook fa-lg social-link"></i> </a>
-						<a href="https://www.instagram.com/babiesoflookit/" target="_blank"><i class="fa fa-instagram fa-lg social-link"></i> </a>
+						<a href="https://www.facebook.com/lookit.mit.edu" target="_blank" rel="noopener"><i class="fa fa-facebook fa-lg social-link"></i> </a>
+						<a href="https://www.instagram.com/babiesoflookit/" target="_blank" rel="noopener"><i class="fa fa-instagram fa-lg social-link"></i> </a>
 						</li>
 						</ul>
 					</div>


### PR DESCRIPTION
This PR resolves an issue found by sonarcloud.io.  It was report a few times, but is the same issue for each instance.  I just added `rel="noopener"` to any `a` tags that had an `href` to an outside link. 

### Sonarcloud issues
- https://sonarcloud.io/project/security_hotspots?id=lookit_lookit-api&hotspots=AXy8kd_losUr7kBuIq65
- https://sonarcloud.io/project/security_hotspots?id=lookit_lookit-api&hotspots=AXy8kd9VosUr7kBuIq6e
- https://sonarcloud.io/project/security_hotspots?id=lookit_lookit-api&hotspots=AXy8kd8iosUr7kBuIq6D
- https://sonarcloud.io/project/security_hotspots?id=lookit_lookit-api&hotspots=AXy8keDposUr7kBuIq8J
- https://sonarcloud.io/project/security_hotspots?id=lookit_lookit-api&hotspots=AXy8keDposUr7kBuIq8L
