### PR TITLE
Add integity to JS files hosted by us

### DIFF
--- a/exp/templates/exp/base.html
+++ b/exp/templates/exp/base.html
@@ -19,7 +19,7 @@
     {% if request.user.is_superuser %}
     <style>
       body {
-          background: url('{% static 'exp/img/su-mode.svg' %}') repeat transparent;
+          background: url('{% static "exp/img/su-mode.svg" %}') repeat transparent;
           background-size: 400px 400px;
       }
     </style>
@@ -30,9 +30,9 @@
         <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
     {% endblock %}
     <link href="{% static 'exp/css/bootstrap-editable.css' %}" rel="stylesheet"/>
-    <script src="{% static 'exp/js/bootstrap-editable.min.js' %}"></script>
-    <script src="{% static 'exp/js/clipboard.min.js' %}"></script>
-    <script defer src="{% static 'js/fontawesome-all.js' %}" integrity="sha384-z9ZOvGHHo21RqN5De4rfJMoAxYpaVoiYhuJXPyVmSs8yn20IE3PmBM534CffwSJI"></script>
+    <script src="{% static 'exp/js/bootstrap-editable.min.js' %}" integrity="sha384-U+oyyQtlZ0gWSjCW7DGnSUxmWwo0EtGjKPOG7i8WjkZkErNgccKPLFOlbYwYTPud"></script>
+    <script src="{% static 'exp/js/clipboard.min.js' %}" integrity="sha384-yfYgXC4debH24R+YufOxRYpRWQzZ9Vy/u7bClZYCobaimHiUK+g6msjpjx2ta0Bx"></script>
+    <script defer src="{% static 'js/fontawesome-all.js' %}" integrity="sha384-s9KfTj2cVSa5Yc4gOd2/VyMCQCfFHwEoDAiVHgW2xDOlO/U9UcFQ0KXijfnM7qq8"></script>
     {% google_tag_manager %}
   </head>
   <body>

--- a/studies/templates/studies/study_participant_analytics.html
+++ b/studies/templates/studies/study_participant_analytics.html
@@ -5,28 +5,22 @@
 
 {% block head %}
     {{ block.super }}
-    <script src="{% static 'js/jquery-ui.min.js' %}" integrity="sha256-KM512VNnjElC30ehFwehXjx1YCHPiQkOPmqnrWtpccM="></script>
-
-    <link rel="stylesheet"
-          href="{% static 'css/bootstrap-select.min.css' %}">
-    <script src="{% static 'js/bootstrap-select.min.js' %}"></script>
-
-    <script src="{% static 'studies/js/d3.min.js' %}" integrity="sha256-Xb6SSzhH3wEPC4Vy3W70Lqh9Y3Du/3KxPqI2JHQSpTw="></script>
+    <script src="{% static 'js/jquery-ui.min.js' %}" integrity="sha384-S3zIKOq/nelLqr0KAhub+iP5nyS201AUUfFxfEyKp9cM02cIiVixkZe+g3a10Rav"></script>
+    <link rel="stylesheet" href="{% static 'css/bootstrap-select.min.css' %}">
+    <script src="{% static 'js/bootstrap-select.min.js' %}" integrity="sha384-8fu9aU0rBHyWhoS96J+3YorJqJZsUp8c3IkInX6NKYi/K/jmG98rDibD+JgkI+fZ"></script>
+    <script src="{% static 'studies/js/d3.min.js' %}" integrity="sha384-M06Cb6r/Yrkprjr7ngOrJlzgekrkkdmGZDES/SUnkUpUol0/qjsaQWQfLzq0mcfg"></script>
     <link rel="stylesheet" href="{% static 'studies/css/metricsgraphics.min.css' %}" />
-    <script src="{% static 'studies/js/metricsgraphics.min.js' %}" integrity="sha256-QFwUntQpro6H+h/btQ+8nVVDqeZnVQSuqsTTUGz2o44="></script>
+    <script src="{% static 'studies/js/metricsgraphics.min.js' %}" integrity="sha384-1tg+Caggw2MOJb5XdqvPWuAdItLy/pYh+OKAUeUp2u3LcAjTuqEUraUNX7wVUgGO"></script>
     {# Moment #}
-    <script type="text/javascript" src="{% static 'js/moment.min.js' %}"></script>
-
+    <script type="text/javascript" src="{% static 'js/moment.min.js' %}" integrity="sha384-pUJlcb0s5ZVM8ujEW3wr2qTVRBbcLEIvcEVEhk9GUd65R3z4uPx9NlB52/4+R3b3"></script>
     {# PivotTable.js #}
-    <script src="{% static 'studies/js/pivot.min.js' %}"></script>
+    <script src="{% static 'studies/js/pivot.min.js' %}" integrity="sha384-vsrhldvbRmpeg/gDxKwKmuOkfVLi4qEzv3pJl9ZCSmfKs6yY01JqFU0m8KzWUYnP"></script>
     <link rel="stylesheet" href="{% static 'studies/css/pivot.min.css' %}" />
-
     {# Google Charts (for PivotTable js rendering) #}
-    <script type="text/javascript" src="{% static 'studies/js/google-charts-loader.js' %}"></script>
-    <script src="{% static 'studies/js/gchart_renderers.min.js' %}"></script>
-
+    <script type="text/javascript" src="{% static 'studies/js/google-charts-loader.js' %}" integrity="sha384-W3/GXTpOFBFHX6YMpQmBB7044yTj4DIU5X4mPmT4CzPttnIIx6Z63qSYzor5FLD8"></script>
+    <script src="{% static 'studies/js/gchart_renderers.min.js' %}" integrity="sha384-MGue9XkTSfyc/uIW6x6YGXpPzZ7rPbs7YOA5kjhf5pALg11XA7rpxifZ+kZgkEkB"></script>
     <!-- Datepicker -->
-    <script type="text/javascript" src="{% static 'js/daterangepicker.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/daterangepicker.min.js' %}" integrity="sha384-ty7j9l9dyFJXResSJqxWIltBRwUxu77rLFQK18vubTvNC+6NUMAeu/xri9AU0WqK"></script>
     <link rel="stylesheet" type="text/css" href="{% static 'css/daterangepicker.min.css' %}"/>
 
     {% comment %}

--- a/studies/templates/studies/study_participant_contact.html
+++ b/studies/templates/studies/study_participant_contact.html
@@ -14,17 +14,16 @@
     <link href="{% static 'exp/css/summernote.min.css' %}" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{% static 'css/daterangepicker.min.css' %}"/>
     <!-- Moment -->
-    <script type="text/javascript" src="{% static 'js/moment.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/moment.min.js' %}" integrity="sha384-pUJlcb0s5ZVM8ujEW3wr2qTVRBbcLEIvcEVEhk9GUd65R3z4uPx9NlB52/4+R3b3"></script>
     <!-- Datatables -->
     <script type="text/javascript"
-            src="{% static 'exp/js/datatables.min.js' %}"></script>
+            src="{% static 'exp/js/datatables.min.js' %}" integrity="sha384-A731IT4Y5cwczV+LdDgi3PAWsaSSCxorR9wOZo+oYfR35xVe51t9A/fAK1kQLDBC"></script>
     <!-- Bootstrap Select -->
-    <script src="{% static 'js/bootstrap-select.min.js' %}"></script>
+    <script src="{% static 'js/bootstrap-select.min.js' %}" integrity="sha384-8fu9aU0rBHyWhoS96J+3YorJqJZsUp8c3IkInX6NKYi/K/jmG98rDibD+JgkI+fZ"></script>
     <!-- Summernote -->
-    <script type="text/javascript"
-            src="{% static 'exp/js/summernote.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'exp/js/summernote.min.js' %}" integrity="sha384-6DIICtAGseoEwUySTKiK/vQcEGp0pWlj8EhiaY7LCQOIei0pugca4VXG9+TKWbOX"></script>
     <!-- Datepicker -->
-    <script type="text/javascript" src="{% static 'js/daterangepicker.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/daterangepicker.min.js' %}" integrity="sha384-ty7j9l9dyFJXResSJqxWIltBRwUxu77rLFQK18vubTvNC+6NUMAeu/xri9AU0WqK"></script>
 {% endblock %}
 
 {% block title %}Contact Participants{% endblock %}

--- a/studies/templates/studies/study_participant_eligibility.html
+++ b/studies/templates/studies/study_participant_eligibility.html
@@ -6,10 +6,8 @@
 {% block head %}
     {{ block.super }}
     {# NoUI Slider #}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/14.0.2/nouislider.min.js"
-            integrity="sha256-VG+4f1Hm2q4e+DTEOaiZKlWjJm5W4yqnXNvKkWBYA20=" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/14.0.2/nouislider.min.css"
-          integrity="sha256-6pa9Ln4B/FyHlxOYaXuwpET9xH0e21iX0SPLg9P5Ro0=" crossorigin="anonymous"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/14.0.2/nouislider.min.js" integrity="sha256-VG+4f1Hm2q4e+DTEOaiZKlWjJm5W4yqnXNvKkWBYA20=" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/14.0.2/nouislider.min.css" integrity="sha256-6pa9Ln4B/FyHlxOYaXuwpET9xH0e21iX0SPLg9P5Ro0=" crossorigin="anonymous"/>
 
     {# Bootstrap Toggle -- keeping here in case it is needed later #}
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -17,10 +17,10 @@
   {% bootstrap_css %}
   {% bootstrap_javascript jquery=True %}
   <link href="{% static 'css/lato-font.css' %}" rel="stylesheet">
-  <script src="{% static 'js/jquery-ui.min.js' %}"></script>
-  <script defer src="{% static 'js/fontawesome-all.js' %}" integrity="sha384-z9ZOvGHHo21RqN5De4rfJMoAxYpaVoiYhuJXPyVmSs8yn20IE3PmBM534CffwSJI"></script>
+  <script src="{% static 'js/jquery-ui.min.js' %}" integrity="sha384-S3zIKOq/nelLqr0KAhub+iP5nyS201AUUfFxfEyKp9cM02cIiVixkZe+g3a10Rav"></script>
+  <script defer src="{% static 'js/fontawesome-all.js' %}" integrity="sha384-s9KfTj2cVSa5Yc4gOd2/VyMCQCfFHwEoDAiVHgW2xDOlO/U9UcFQ0KXijfnM7qq8"></script>
   <link rel="stylesheet" href="{% static 'css/jquery-ui.min.css' %}" />
-  <script src="{% static 'js/moment.min.js' %}"></script>
+  <script src="{% static 'js/moment.min.js' %}" integrity="sha384-pUJlcb0s5ZVM8ujEW3wr2qTVRBbcLEIvcEVEhk9GUd65R3z4uPx9NlB52/4+R3b3"></script>
   <link type="text/css" rel="stylesheet" href="{% static 'base.css' %}" />
   {% block head %}
   {% endblock %}


### PR DESCRIPTION
When I added "fix end of file" to pre-commit, I ended up accidentally changing the files hash.  Some files, specifically the ones used to provide icons, was referenced with the incorrect hash.  This hash is represented as `integrity` in the HTML.  

This PR brings up a few issues that should be addressed:

1. We have no UI testing.
2. Static files are all over the place and should be moved under a single parent directory.
3. All static files referenced in any heading should in a single base file. 

I am going to create issue for the latter two points above. 