### PR TITLE
Show external and scheduled in study edit form

### DIFF
--- a/exp/views/mixins.py
+++ b/exp/views/mixins.py
@@ -175,10 +175,18 @@ def is_valid_ember_frame_player(metadata):
 
     errors = []
 
-    if not requests.get(player_repo_url).ok:
-        errors.append(f"Frameplayer repo url {player_repo_url} does not work.")
-    if not requests.get(f"{player_repo_url}/commit/{frameplayer_commit_sha}").ok:
-        errors.append(f"Frameplayer commit {frameplayer_commit_sha} does not exist.")
+    if not player_repo_url:
+        errors.append("Frameplayer repo url is not set.")
+    else:
+        if not player_repo_url or not requests.get(player_repo_url).ok:
+            errors.append(f"Frameplayer repo url {player_repo_url} does not work.")
+        if (
+            not player_repo_url
+            or not requests.get(f"{player_repo_url}/commit/{frameplayer_commit_sha}").ok
+        ):
+            errors.append(
+                f"Frameplayer commit {frameplayer_commit_sha} does not exist."
+            )
 
     return errors
 

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -353,6 +353,17 @@ class StudyEditForm(StudyForm):
             )
             self.fields["lab"].disabled = True
 
+    def clean_external(self):
+        study = self.instance
+        external = self.cleaned_data["external"]
+
+        if (not external and study.study_type.is_external) or (
+            external and study.study_type.is_ember_frame_player
+        ):
+            raise forms.ValidationError("Attempt to change study type not allowed.")
+
+        return external
+
 
 class StudyCreateForm(StudyForm):
     """Form for creating a new study"""

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -323,6 +323,7 @@ class StudyEditForm(StudyForm):
     def __init__(self, user=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["external"].disabled = True
+        self.fields["scheduled"].disabled = True
         self.fields["structure"].help_text = PROTOCOL_HELP_TEXT_EDIT
         # Restrict ability to edit study lab based on user permissions
         can_change_lab = user.has_study_perms(

--- a/studies/templates/studies/_study_fields.html
+++ b/studies/templates/studies/_study_fields.html
@@ -88,7 +88,6 @@
                 .querySelector('#id_use_generator')
                 .closest('.form-group').classList.add('hidden')
             document.querySelector('#type-metadata-2').classList.remove('hidden')
-            document.querySelector('#id_scheduled').disabled = false
         }
 
     function setFramePlayer() {
@@ -106,11 +105,17 @@
                 .forEach(e => e.disabled=true)
             document.querySelector('#id_use_generator').closest('.form-group').classList.remove('hidden')
             document.querySelector('#type-metadata-2').classList.add('hidden')
-            document.querySelector('#id_scheduled').disabled = true
         }
 
     function updateStudyType (externalCheckbox) {
         externalCheckbox.checked ? setExternal() : setFramePlayer()
+        updateScheduled()
+    }
+
+    function updateScheduled(){
+        const external = document.querySelector('#id_external')
+        const scheduled = document.querySelector('#id_scheduled')
+        scheduled.disabled = external.disabled || !external.checked
     }
 
     function updateScheduling (scheduledCheckBox) {            

--- a/studies/templates/studies/_study_fields.html
+++ b/studies/templates/studies/_study_fields.html
@@ -110,12 +110,6 @@
         }
 
     function updateStudyType (externalCheckbox) {
-        // Hide external and scheduled fields when external is disabled
-        if (document.querySelector('#id_external').disabled){
-                document
-                    .querySelectorAll('#id_external, #id_scheduled')
-                    .forEach(e=> e.closest('.form-group').classList.add('hidden'))
-        }
         externalCheckbox.checked ? setExternal() : setFramePlayer()
     }
 


### PR DESCRIPTION
This PR is to show the "External" and "Scheduled" on the Study Edit Form.  

Closes #861

<img width="1105" alt="Screen Shot 2021-11-10 at 11 15 27 AM" src="https://user-images.githubusercontent.com/44074998/141150590-62b9ed86-7481-4618-992b-013b759a0e11.png">
<img width="1105" alt="Screen Shot 2021-11-10 at 11 15 31 AM" src="https://user-images.githubusercontent.com/44074998/141150597-8652f11e-c67e-4666-a739-850aaef53fcb.png">
<img width="1105" alt="Screen Shot 2021-11-10 at 11 15 37 AM" src="https://user-images.githubusercontent.com/44074998/141150605-fb36fe2c-b3b3-4bb1-b5ce-c14787467005.png">
<img width="1105" alt="Screen Shot 2021-11-10 at 11 15 40 AM" src="https://user-images.githubusercontent.com/44074998/141150607-bc327e6c-9fea-440d-9f53-aea6b69456c9.png">


