### PR TITLE
Change h2 to h1 for page titles

### DIFF
--- a/exp/templates/exp/support.html
+++ b/exp/templates/exp/support.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="container">
-<h2>How Researchers can Support Lookit</h2>
+<h1>How Researchers can Support Lookit</h1>
 
 <p>
 Lookit is free for labs to use, but like any open source software project, it's not free to run! 

--- a/web/templates/frontpages/faq.html
+++ b/web/templates/frontpages/faq.html
@@ -8,7 +8,7 @@
 <div class="main">
     <div class="lookit-row lookit-page-title">
         <div class="container">
-            <h2>{% trans "Frequently Asked Questions"%}</h2>
+            <h1>{% trans "Frequently Asked Questions"%}</h1>
         </div>
     </div>
     <div class="lookit-row faq-row">

--- a/web/templates/frontpages/resources.html
+++ b/web/templates/frontpages/resources.html
@@ -10,7 +10,7 @@
             <div class="main">
                 <div class="lookit-row lookit-page-title">
                     <div class="container">
-                        <h2>Resources</h2>
+                        <h1>Resources</h1>
                     </div>
                 </div>
                 <div class="lookit-row resources-row">

--- a/web/templates/frontpages/scientists.html
+++ b/web/templates/frontpages/scientists.html
@@ -24,7 +24,7 @@
 <div class="main">
     <div class="lookit-row lookit-page-title">
         <div class="container">
-            <h2>{% trans "Meet the Lookit team"%}</h2>
+            <h1>{% trans "Meet the Lookit team"%}</h1>
         </div>
     </div>
     <div class="lookit-row scientists-row">


### PR DESCRIPTION
Page titles should be wrapped in h1 tags.  

Closes #719