### PR TITLE
Removed css that justify aligned text

### DIFF
--- a/web/templates/frontpages/scientists.html
+++ b/web/templates/frontpages/scientists.html
@@ -17,10 +17,6 @@
         text-align: center;
     }
 
-    .scientists-row p {
-        text-align: justify;
-    }
-
     ul.affiliate-list {
         columns: 3;
     }


### PR DESCRIPTION
Removed CSS that justified Scientist's Bio info on the scientist page. 

Closes #704