### PR TITLE
Remove roles from faq page

### DIFF
--- a/web/templates/frontpages/faq.html
+++ b/web/templates/frontpages/faq.html
@@ -14,9 +14,9 @@
     <div class="lookit-row faq-row">
         <div class="container">
             <h3>{% trans "Participation"%}</h3>
-            <div class="panel-group" id="accordion" role="tablist">
+            <div class="panel-group" id="accordion">
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse1">{% trans "What is a 'study' about cognitive development?"%}</a></h4>
                     </div>
                     <div id="collapse1" class="panel-collapse collapse" >
@@ -36,7 +36,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse20">{% trans "Why participate in developmental research?"%}</a></h4>
                     </div>
                     <div id="collapse20" class="panel-collapse collapse">
@@ -55,7 +55,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse2">{% trans "What happens when my child participates in a research study?"%}</a></h4>
                     </div>
                     <div id="collapse2" class="panel-collapse collapse">
@@ -78,7 +78,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse0">{% trans "Who creates the studies?"%}</a></h4>
                     </div>
                     <div id="collapse0" class="panel-collapse collapse" >
@@ -93,7 +93,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse21">{% trans "Who will my child and I meet when we do a study involving a scheduled video chat?"%}</a></h4>
                     </div>
                     <div id="collapse21" class="panel-collapse collapse" >
@@ -107,7 +107,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse7">{% trans "Why are you running studies online instead of in person?"%}</a></h4>
                     </div>
                     <div id="collapse7" class="panel-collapse collapse">
@@ -134,7 +134,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading collapsed" role="tab">
+                    <div class="panel-heading collapsed">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse3">{% trans "How do we provide consent to participate?"%}</a></h4>
                     </div>
                     <div id="collapse3" class="panel-collapse collapse">
@@ -154,7 +154,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse4">{% trans "How is our information kept secure and confidential?"%}</a></h4>
                     </div>
                     <div id="collapse4" class="panel-collapse collapse">
@@ -172,7 +172,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse5">{% trans "Who will see our video?"%}</a></h4>
                     </div>
                     <div id="collapse5" class="panel-collapse collapse">
@@ -195,7 +195,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse6">{% trans "What information do researchers use from our video?"%}</a></h4>
                     </div>
                     <div id="collapse6" class="panel-collapse collapse">
@@ -246,7 +246,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse9">{% trans "My child wasn't paying attention, or we were interrupted. Can we try the study again?"%}</a></h4>
                     </div>
                     <div id="collapse9" class="panel-collapse collapse">
@@ -258,7 +258,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse10">{% trans "My child is outside the age range. Can he/she still participate in this study?"%}</a></h4>
                     </div>
                     <div id="collapse10" class="panel-collapse collapse" >
@@ -270,7 +270,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse11">{% trans "My child was born prematurely. Should we use his/her adjusted age?"%}</a></h4>
                     </div>
                     <div id="collapse11" class="panel-collapse collapse">
@@ -282,7 +282,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse12">{% trans "Our family speaks a language other than English at home. Can my child participate?"%}</a></h4>
                     </div>
                     <div id="collapse12" class="panel-collapse collapse">
@@ -294,7 +294,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse13">{% trans "My child has been diagnosed with a developmental disorder or has special needs. Can he/she still participate?"%}</a></h4>
                     </div>
                     <div id="collapse13" class="panel-collapse collapse">
@@ -309,7 +309,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading collapsed" role="tab">
+                    <div class="panel-heading collapsed">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse14">{% trans "I have multiple children in the age range for a study. Can they participate together?"%}</a></h4>
                     </div>
                     <div id="collapse14" class="panel-collapse collapse">
@@ -321,7 +321,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse15">{% trans "But I've heard that young children should avoid 'screen time.'"%}</a></h4>
                     </div>
                     <div id="collapse15" class="panel-collapse collapse">
@@ -336,7 +336,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse16">{% trans "Will we be paid for our participation?"%}</a></h4>
                     </div>
                     <div id="collapse16" class="panel-collapse collapse">
@@ -348,7 +348,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading collapsed" role="tab">
+                    <div class="panel-heading collapsed">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse17">{% trans "Can I learn the results of the research my child does?"%}</a></h4>
                     </div>
                     <div id="collapse17" class="panel-collapse collapse">
@@ -366,7 +366,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading collapsed" role="tab">
+                    <div class="panel-heading collapsed">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse23">{% trans "I love this. How do I share this site?"%}</a></h4>
                     </div>
                     <div id="collapse23" class="panel-collapse collapse">
@@ -381,7 +381,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading collapsed" role="tab">
+                    <div class="panel-heading collapsed">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse24">{% trans "What is the Parent Researcher Collaborative (PaRC)?"%}</a></h4>
                     </div>
                     <div id="collapse24" class="panel-collapse collapse">
@@ -397,7 +397,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading collapsed" role="tab">
+                    <div class="panel-heading collapsed">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse25">{% trans "How can I contact you?"%}</a></h4>
                     </div>
                     <div id="collapse25" class="panel-collapse collapse">
@@ -414,9 +414,9 @@
                 </div>
             </div>
             <h3>{% trans "Technical"%}</h3>
-            <div class="panel-group" role="tablist">
+            <div class="panel-group">
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse18">{% trans "What browsers are supported?"%}</a></h4>
                     </div>
                     <div id="collapse18" class="panel-collapse collapse">
@@ -428,7 +428,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse19">{% trans "Can we do a study on my phone or tablet?"%}</a></h4>
                     </div>
                     <div id="collapse19" class="panel-collapse collapse">
@@ -445,7 +445,7 @@
                     
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse26">{% trans "My study isn't working, what can I do?"%}</a></h4>
                     </div>
                     <div id="collapse26" class="panel-collapse collapse">
@@ -462,7 +462,7 @@
                     
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse27">{% trans "What security measures do you implement?"%}</a></h4>
                     </div>
                     <div id="collapse27" class="panel-collapse collapse">
@@ -479,9 +479,9 @@
                 </div>
             </div>
             <h3>{% trans "For Researchers"%}</h3>
-            <div class="panel-group" role="tablist">
+            <div class="panel-group">
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse29">{% trans "How can I list my study?"%}</a></h4>
                     </div>
                     <div id="collapse29" class="panel-collapse collapse">
@@ -497,7 +497,7 @@
                     </div>
                 </div>
                 <div class="panel panel-default">
-                    <div class="panel-heading" role="tab">
+                    <div class="panel-heading">
                         <h4 class="panel-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapse30">{% trans "Where can I discuss best practices for online research with other researchers?"%}</a></h4>
                     </div>
                     <div id="collapse30" class="panel-collapse collapse">


### PR DESCRIPTION
Remove roles containing "tab" or "tablist".  The FAQ page is the only page I found that has these roles. 

Closes #721