### PR TITLE
Use study name as alt text for study thumbnail

### DIFF
--- a/studies/templates/studies/_image_display.html
+++ b/studies/templates/studies/_image_display.html
@@ -8,7 +8,7 @@
 
 <p class="image-block">
     {% if object.image %}
-        <img class="study-detail-thumbnail" alt="study detail thumbnail" onerror="imgError(this)" src="{{ object.image.url }}" width="100%">
+        <img class="study-detail-thumbnail" alt="{{ object.name }}" onerror="imgError(this)" src="{{ object.image.url }}" width="100%">
     {% endif %}
     <div style="display:none;" class="study-list-placeholder" id="image-placeholder">
           <i aria-hidden="true" class="fas fa-picture {% if large %} fa-5x {% endif %}"></i>

--- a/web/templates/web/studies-list.html
+++ b/web/templates/web/studies-list.html
@@ -77,7 +77,7 @@
         </div>
         <div class="row">
             <div class="col-md-3 left">
-                <img src="{{study.image.url}}" class="img-responsive img-rounded" alt="Responsive image">
+                <img src="{{study.image.url}}" class="img-responsive img-rounded" alt="{{ study.name }}">
                 <div class="study-criteria">
                     <small>
                         <p>{{study.criteria}}</p>


### PR DESCRIPTION
Replace existing alt text for study thumbnails.  Instead, use the study name (or title) as the alt text for these thumbnails. 

Closes #716