### PR TITLE
Move add child button

### DIFF
--- a/web/templates/web/child-add.html
+++ b/web/templates/web/child-add.html
@@ -1,0 +1,100 @@
+{% extends 'web/base.html' %}
+{% load bootstrap3 %}
+{% block title %}Children{% endblock %}
+{% load i18n %}
+
+{% block flash %}
+  {% if form.non_field_errors %}
+  <div class="alert alert-danger" role="alert">
+      {{ form.non_field_errors }}
+  </div>
+  {% endif %}
+{% endblock %}
+{% block content %}
+    <script>
+        $(document).ready(function() {
+            $('.datepicker').datepicker({
+               changeMonth: true,
+               changeYear: true,
+               showButtonPanel: true,
+               maxDate: 0,
+               yearRange: "1900:+nn"
+            })
+            .on('change', function () {
+               var age = getAge(this);
+               if (document.getElementById('age_calc')) {
+                   document.getElementById('age_calc').innerHTML = `Age: ${age}`;
+               } else {
+                   var x = document.createElement("p");
+                   x.setAttribute("id", "age_calc");
+                   x.setAttribute("class", "age_format")
+                   var t = document.createTextNode(`Age: ${age}`);
+                   x.appendChild(t);
+                   document.getElementsByClassName("form-group")[1].insertBefore(x,document.getElementById("id_birthday"));
+               }
+           });
+        });
+        function getAge(dateValue) {
+            if (dateValue.value === '') {
+                return '{% trans "Empty birthday" %} '  
+            }
+            var years = moment().diff(new Date(dateValue.value), 'years');
+            if (years === 0) {
+                var months = moment().diff(new Date(dateValue.value), 'months');
+                if (months === 0) {
+                    var days = moment().diff(new Date(dateValue.value), 'days');
+                    return days === 1 ? days + '{% trans " day" %}': days + '{% trans " days" %}';
+                }
+                return months === 1 ? months + '{% trans " month" %}': months + '{% trans " months" %}';
+            } else {
+                return years === 1 ? years + '{% trans " year" %}': years + '{% trans " years" %}';
+            }
+        }
+
+        function toggleAddChildForm() {
+            form = $(document.getElementById('add-child-form')).toggle();
+        }
+        $(function() {
+           $("#toggleAddChildButton").click(function () {
+              $(this).text(function(i, text){
+                  return text === '{% trans "Add Child" %}' ? '{% trans "Hide Form" %}' : '{% trans "Add Child" %}';
+              })
+           });
+        })
+    </script>
+    {% bootstrap_messages %}
+    <div class="container">
+        <div class="row account-edit">
+            <div class="col-md-4 mb-lg">
+                 {% include 'accounts/_account-navigation.html' with current_page="children-list" %}
+            </div>
+            <div class="col-md-8">
+                <div id="add-child-form" style="display:{% if form_hidden %} none {% else %} inline {% endif %}">
+                    <div class="panel-heading">
+                      <h1 class="panel-title">
+                          {% trans "Add Child" %}
+                      </h1>
+                    </div>
+                    <div class="panel panel-default">
+                      <div class="panel-body">
+                          <div class="panel-body">
+                            <form method="POST" action="">
+                                {% csrf_token %}
+                                {% bootstrap_form form %}
+                                {% buttons %}
+                              <div class="pull-right">
+                                  <a class="btn btn-default" href="{% url 'web:children-list' %}"> {% trans "Cancel" %} </a>
+                                  <button type="submit" class="btn btn-success">
+                                     {% bootstrap_icon "plus" %} {% trans "Add Child" %}
+                                  </button>
+                              </div>
+                              {% endbuttons %}
+                            </form>
+                        </div>
+                    </div>
+                  </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/web/templates/web/children-list.html
+++ b/web/templates/web/children-list.html
@@ -70,9 +70,7 @@
                  {% include 'accounts/_account-navigation.html' with current_page="children-list" %}
             </div>
             <div class="col-md-8">
-                <div class="pull-right">
-                    <button id="toggleAddChildButton" onclick="toggleAddChildForm()"class="btn btn-primary">{% if form_hidden %}{% trans "Add Child" %}{% else %} {% trans "Hide Form" %} {% endif %}</button>
-                </div>
+                
                 <div id="add-child-form" style="display:{% if form_hidden %} none {% else %} inline {% endif %}">
                     <div class="panel-heading">
                       <h1 class="panel-title">
@@ -125,6 +123,15 @@
                             <p><em> {% trans "No child profiles registered!" %} </em></p>
                         {% endif %}
                     </div>
+                </div>
+                <div class="row">
+                    <button id="toggleAddChildButton" onclick="toggleAddChildForm()" class="btn btn-primary pull-right">
+                        {% if form_hidden %}
+                            {% trans "Add Child" %}
+                        {% else %}
+                            {% trans "Hide Form" %}
+                        {% endif %}
+                    </button>
                 </div>
             </div>
         </div>

--- a/web/templates/web/children-list.html
+++ b/web/templates/web/children-list.html
@@ -3,102 +3,18 @@
 {% block title %}Children{% endblock %}
 {% load i18n %}
 
-{% block flash %}
-  {% if form.non_field_errors %}
-  <div class="alert alert-danger" role="alert">
-      {{ form.non_field_errors }}
-  </div>
-  {% endif %}
-{% endblock %}
-{% block content %}
-    <script>
-        
-        $(document).ready(function() {
-            $('.datepicker').datepicker({
-               changeMonth: true,
-               changeYear: true,
-               showButtonPanel: true,
-               maxDate: 0,
-               yearRange: "1900:+nn"
-            })
-            .on('change', function () {
-               var age = getAge(this);
-               if (document.getElementById('age_calc')) {
-                   document.getElementById('age_calc').innerHTML = `Age: ${age}`;
-               } else {
-                   var x = document.createElement("p");
-                   x.setAttribute("id", "age_calc");
-                   x.setAttribute("class", "age_format")
-                   var t = document.createTextNode(`Age: ${age}`);
-                   x.appendChild(t);
-                   document.getElementsByClassName("form-group")[1].insertBefore(x,document.getElementById("id_birthday"));
-               }
-           });
-        });
-        function getAge(dateValue) {
-            if (dateValue.value === '') {
-                return '{% trans "Empty birthday" %} '  
-            }
-            var years = moment().diff(new Date(dateValue.value), 'years');
-            if (years === 0) {
-                var months = moment().diff(new Date(dateValue.value), 'months');
-                if (months === 0) {
-                    var days = moment().diff(new Date(dateValue.value), 'days');
-                    return days === 1 ? days + '{% trans " day" %}': days + '{% trans " days" %}';
-                }
-                return months === 1 ? months + '{% trans " month" %}': months + '{% trans " months" %}';
-            } else {
-                return years === 1 ? years + '{% trans " year" %}': years + '{% trans " years" %}';
-            }
-        }
-
-        function toggleAddChildForm() {
-            form = $(document.getElementById('add-child-form')).toggle();
-        }
-        $(function() {
-           $("#toggleAddChildButton").click(function () {
-              $(this).text(function(i, text){
-                  return text === '{% trans "Add Child" %}' ? '{% trans "Hide Form" %}' : '{% trans "Add Child" %}';
-              })
-           });
-        })
-    </script>
+{% block content %}   
     {% bootstrap_messages %}
     <div class="container">
         <div class="row account-edit">
             <div class="col-md-4 mb-lg">
-                 {% include 'accounts/_account-navigation.html' with current_page="children-list" %}
+                {% include 'accounts/_account-navigation.html' with current_page="children-list" %}
             </div>
             <div class="col-md-8">
-                
-                <div id="add-child-form" style="display:{% if form_hidden %} none {% else %} inline {% endif %}">
-                    <div class="panel-heading">
-                      <h1 class="panel-title">
-                          {% trans "Add Child" %}
-                      </h1>
-                    </div>
-                    <div class="panel panel-default">
-                      <div class="panel-body">
-                          <div class="panel-body">
-                            <form method="POST" action="">{% csrf_token %}
-                              {% bootstrap_form form %}
-                              {% buttons %}
-                              <div class="pull-right">
-                                  <a class="btn btn-default" href="{% url 'web:children-list' %}"> {% trans "Cancel" %} </a>
-                                  <button type="submit" class="btn btn-success">
-                                     {% bootstrap_icon "plus" %} {% trans "Add Child" %}
-                                  </button>
-                              </div>
-                              {% endbuttons %}
-                            </form>
-                        </div>
-                    </div>
-                  </div>
-                </div>
                 <div class="row">
                     <div class="col-xs-12">
                         <h2><label> {% trans "Children" %} </label></h2>
-                        {% if objects %}
+                        {% if children %}
                             <div class="table-responsive">
                                 <table class="table">
                                   <thead>
@@ -109,7 +25,7 @@
                                     </tr>
                                   </thead>
                                   <tbody>
-                                      {% for child in objects %}
+                                      {% for child in children %}
                                           <tr>
                                             <td>{{ child.given_name }}</td>
                                             <td>{{ child.birthday }}</td>
@@ -125,13 +41,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <button id="toggleAddChildButton" onclick="toggleAddChildForm()" class="btn btn-primary pull-right">
-                        {% if form_hidden %}
-                            {% trans "Add Child" %}
-                        {% else %}
-                            {% trans "Hide Form" %}
-                        {% endif %}
-                    </button>
+                    <a class="btn btn-primary pull-right" href="{% url 'web:child-add' %}">Add Child</a
                 </div>
             </div>
         </div>

--- a/web/urls.py
+++ b/web/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
         name="demographic-data-update",
     ),
     path("account/children/", views.ChildrenListView.as_view(), name="children-list"),
+    path("account/add-child/", views.ChildAddView.as_view(), name="child-add"),
     path(
         "account/children/<uuid:uuid>/",
         views.ChildUpdateView.as_view(),

--- a/web/views.py
+++ b/web/views.py
@@ -194,14 +194,12 @@ class DemographicDataUpdateView(LoginRequiredMixin, generic.CreateView):
         return context
 
 
-class ChildrenListView(LoginRequiredMixin, generic.CreateView):
+class ChildrenListView(LoginRequiredMixin, generic.TemplateView):
     """
     Allows user to view a list of current children and add children
     """
 
     template_name = "web/children-list.html"
-    model = Child
-    form_class = forms.ChildForm
 
     def get_context_data(self, **kwargs):
         """
@@ -209,18 +207,16 @@ class ChildrenListView(LoginRequiredMixin, generic.CreateView):
         to the context_dict.  Also add info to hide the Add Child form on page load.
         """
         context = super().get_context_data(**kwargs)
-        children = Child.objects.filter(deleted=False, user=self.request.user)
-        context["objects"] = children
-        context["form_hidden"] = kwargs.get("form_hidden", True)
+        context["children"] = Child.objects.filter(
+            deleted=False, user=self.request.user
+        )
         return context
 
-    def form_invalid(self, form):
-        """
-        If form invalid, add child form needs to be open when page reloads.
-        """
-        return self.render_to_response(
-            self.get_context_data(form=form, form_hidden=False)
-        )
+
+class ChildAddView(LoginRequiredMixin, generic.CreateView):
+    template_name = "web/child-add.html"
+    model = Child
+    form_class = forms.ChildForm
 
     def form_valid(self, form):
         """


### PR DESCRIPTION
On children list view, moved `add child` button to bottom of list.  Decided that the add child form was odd and overly complex.  Moved the add child form to its own view.

![add_child](https://user-images.githubusercontent.com/44074998/160890134-9d193f1a-34eb-4bb5-87d1-8ea8945375b3.gif)
 
Closes  #951