### PR TITLE
Set a db password in the example env file

### DIFF
--- a/env_dist
+++ b/env_dist
@@ -59,7 +59,7 @@ RABBITMQ_VHOST=/
 # you can log in using DB_PASSWORD.
 DB_NAME=lookit
 DB_HOST=127.0.0.1
-DB_PASSWORD=" "
+DB_PASSWORD=postgres
 DB_PORT=5432
 DB_USER=postgres
 


### PR DESCRIPTION
Historically, there's been a empty string as the password for the DB in the local environment.  This PR set the password to the normal default of "postgres" for the local environment.  Small change, but necessary for docker compose script.  Also, less confusing.  