### PR TITLE
Add rabbitmq host to web service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ serve:
 	docker compose pull && docker compose up --build
 
 clean:
-	rm -rf ./data
 	docker rm -f lookit-api-web lookit-api-db lookit-api-broker lookit-api-worker
+	docker image rm lookit-api_worker lookit-api_web
 
 migrate:
 	docker compose run --rm web poetry run ./manage.py migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     container_name: lookit-api-db
     volumes:
       - ./data:/var/lib/postgresql/data
+    ports:
+     - "5432:5432"
     environment:
       - POSTGRES_DB=lookit
       - POSTGRES_USER=postgres
@@ -28,6 +30,7 @@ services:
       - .env
     environment:
       - DB_HOST=db
+      - RABBITMQ_HOST=broker
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
This PR covers 4 very small changes:

- Add the RabbitMQ host to the web service within the docker compose script.
- No longer deletes the database on `clean` make target. 
- Removes the docker images on `clean` make target.
- Exposes the database port to host machine so that we can use a database IDE. 