### PR TITLE
Add child hash id to response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,6 @@ local-certs:
 	mkdir -p certs 
 	mkcert -install
 	cd certs && mkcert local_lookit.mit.edu
+
+test:
+	docker compose run --rm web poetry run ./manage.py test --failfast

--- a/accounts/tests/test_utils.py
+++ b/accounts/tests/test_utils.py
@@ -1,0 +1,35 @@
+from uuid import UUID
+
+from django.test import TestCase
+from django_dynamic_fixture import G
+
+from accounts.models import Child
+from accounts.utils import hash_child_id, hash_child_id_from_model, hash_id
+from studies.models import Response, Study
+
+
+class AuthenticationTestCase(TestCase):
+    def setUp(self):
+        self.id1 = UUID("26edcab0-b578-49e4-9ef3-6f9e5ee32642")
+        self.id2 = UUID("c39fc4e9-0084-4efb-9db1-ea596c946108")
+        self.salt = UUID("88b9d333-852d-42a2-8352-3027354ee136")
+        self.length = 6
+
+    def test_hash_id(self):
+        """Confirm that hash id return a consistant hash value."""
+        self.assertEqual(hash_id(self.id1, self.id2, self.salt, self.length), "2Y7W5d")
+
+    def test_hash_child_id_from_model(self):
+        """Compare hash_child_id to the refactored hash_child_id_from_model."""
+        resp_dict = {
+            "child__uuid": self.id1,
+            "study__uuid": self.id2,
+            "study__salt": self.salt,
+            "study__hash_digits": self.length,
+        }
+
+        child_model = G(Child, uuid=self.id1)
+        study_model = G(Study, uuid=self.id2, salt=self.salt, hash_digits=self.length)
+        resp_model = G(Response, child=child_model, study=study_model)
+
+        self.assertEqual(hash_child_id(resp_dict), hash_child_id_from_model(resp_model))

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -3,6 +3,8 @@ import hashlib
 
 from django.utils.text import slugify
 
+from studies.models import Response
+
 
 def build_org_group_name(org_name, group):
     """
@@ -38,6 +40,12 @@ def hash_child_id(resp):
         resp["study__uuid"],
         resp["study__salt"],
         resp["study__hash_digits"],
+    )
+
+
+def hash_child_id_from_model(resp: Response):
+    return hash_id(
+        resp.child.uuid, resp.study.uuid, resp.study.salt, resp.study.hash_digits
     )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   db:
     image: postgres:9.6
     container_name: lookit-api-db
+    command: postgres -c stats_temp_directory=/tmp
     volumes:
       - ./data:/var/lib/postgresql/data
     ports:

--- a/studies/serializers.py
+++ b/studies/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework_json_api import serializers
 
 from accounts.models import Child
+from accounts.utils import hash_child_id_from_model
 from api.serializers import (
     PatchedHyperlinkedRelatedField,
     PatchedResourceRelatedField,
@@ -107,6 +108,7 @@ class ResponseSerializer(UuidHyperlinkedModelSerializer):
         related_link_url_kwarg="uuid",
         required=False,
     )
+    hash_child_id = serializers.SerializerMethodField("get_hash_child_id")
 
     class Meta:
         model = Response
@@ -126,7 +128,11 @@ class ResponseSerializer(UuidHyperlinkedModelSerializer):
             "is_preview",
             "pk",
             "withdrawn",
+            "hash_child_id",
         )
+
+    def get_hash_child_id(self, obj):
+        return hash_child_id_from_model(obj)
 
 
 class ResponseWriteableSerializer(UuidResourceModelSerializer):


### PR DESCRIPTION
### Summary
To provide the child hashed id, we needed to first generate it and then inject it into the response API.  To inject the field in the API we're using `SerializerMethodField`.  The function to generate the hashed id, required the Response model object to be in a dictionary form that I was unable to recreate.  To complete this task a bit more quickly, I just wrong a parallel function to the existing one and a unit test to verify that they work the same.  

### Off Topic Work
I am continually working on the docker compose script.  The latest change was to define a temp directory within the container.  This was to remove a warning.

### Additional Reading
- http://www.tomchristie.com/rest-framework-2-docs/api-guide/fields#serializermethodfield