### PR TITLE
Schuduled box editable

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -10,7 +10,13 @@ WORKDIR /code
 
 COPY pyproject.toml poetry.lock /code/
 
-RUN apt-get clean \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends locales \
+    && echo "LC_ALL=en_US.UTF-8" >> /etc/environment \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && echo "LANG=en_US.UTF-8" > /etc/locale.conf \
+    && locale-gen en_US.UTF-8 \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sSL https://install.python-poetry.org | python3 - \
     && poetry install

--- a/exp/tests/test_study_forms.py
+++ b/exp/tests/test_study_forms.py
@@ -424,6 +424,14 @@ class StudyFormTestCase(TestCase):
         self.assertNotIn(self.other_lab, edit_form.fields["lab"].queryset)
         self.assertNotIn("lab", edit_form.errors)
 
+    def test_scheduled_checkbox_enabled(self):
+        """Checking that the Study Edit Form's sheduled field is always enabled.  JavaScript will disable this field when study is internal."""
+        data = model_to_dict(self.study)
+        structure_text = '{"frames": {"frame-a": {}, "frame-b": {}}, "sequence": ["frame-a", "frame-b"]}'
+        data["structure"] = structure_text
+        form = StudyEditForm(data=data, instance=self.study, user=self.study_designer)
+        self.assertFalse(form.fields["scheduled"].disabled)
+
 
 class StudyMixinsTestCase(TestCase):
     @parameterized.expand(

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -329,7 +329,6 @@ class StudyEditForm(StudyForm):
     def __init__(self, user=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["external"].disabled = True
-        self.fields["scheduled"].disabled = True
         self.fields["structure"].help_text = PROTOCOL_HELP_TEXT_EDIT
         # Restrict ability to edit study lab based on user permissions
         can_change_lab = user.has_study_perms(

--- a/studies/templates/studies/_study_fields.html
+++ b/studies/templates/studies/_study_fields.html
@@ -114,7 +114,7 @@
     function updateScheduled(){
         const external = document.querySelector('#id_external')
         const scheduled = document.querySelector('#id_scheduled')
-        scheduled.disabled = external.disabled || !external.checked
+        scheduled.disabled = !external.checked
     }
 
     function updateScheduling (scheduledCheckBox) {            

--- a/web/templates/web/studies-list.html
+++ b/web/templates/web/studies-list.html
@@ -95,12 +95,14 @@
     </div>
     <div class="panel-default">
         <div class="panel-body">
-        {% trans 'Looking for more ways to contribute to research from home? Check out <a href="https://childrenhelpingscience.com/"
-    target="_blank"
-    rel="noreferrer noopener">Children Helping Science</a> for even more studies!' %}
+            {% trans 'Looking for more ways to contribute to research from home? Check out' %}
+            <a href="https://childrenhelpingscience.com/"
+               target="_blank"
+               rel="noreferrer noopener">
+            {% trans 'Children Helping Science' %} </a> {% trans 'for even more studies!' %}
+        </div>
     </div>
-</div>
-<script>
+    <script>
     $(function () {
         const $form = $('form');
         const $hideStudiesCheckbox = $form.find('input:checkbox[name=hide_studies_we_have_done]')
@@ -150,5 +152,5 @@
     });
 
 
-</script>
+    </script>
 {% endblock content %}


### PR DESCRIPTION
This PR will allow external studies' `scheduled` checkbox to be changed after save.  

Closes #927

![edit-scheduled](https://user-images.githubusercontent.com/44074998/175327869-4d3b21b3-d749-4f84-b4f7-962c58645704.gif)



