### PR TITLE
Show study link on external studies

### DIFF
--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -270,7 +270,7 @@
                                 </p>
                             </div>
                             <div class="col-xs-12">
-                                {% if study.built %}
+                                {% if study.built or study.study_type.is_external %}
                                     <span>
                                         <label>Study link:</label>
                                     </span>


### PR DESCRIPTION
Update the conditional in the template to show the study link when the study type is external.

Closes #970

<img width="1067" alt="Screen Shot 2022-07-12 at 9 23 26 AM" src="https://user-images.githubusercontent.com/44074998/178500345-916e1e52-02f4-4dbe-b9aa-81418ca1b042.png">
