### PR TITLE
redirect to ember server if running in local env

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 from django.db.models.functions import Lower
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.http.response import HttpResponse
-from django.shortcuts import get_object_or_404, reverse
+from django.shortcuts import get_object_or_404, redirect, reverse
 from django.views import generic
 from django.views.generic.detail import SingleObjectMixin
 from revproxy.views import ProxyView
@@ -947,9 +947,13 @@ class PreviewProxyView(ResearcherLoginRequiredMixin, UserPassesTestMixin, ProxyV
                 request.path_info = path_no_locale
                 request.META["PATH_INFO"] = path_no_locale
 
-            path = f"{study_uuid}/index.html"
-
-            return super().dispatch(request, path)
+            if settings.DEBUG and settings.ENVIRONMENT == "develop":
+                """If we're in a local environment, then redirect shortcut to switch to the ember server"""
+                debug_path = rf"{settings.EXPERIMENT_BASE_URL}{request.path_info}"
+                return redirect(debug_path)
+            else:
+                path = f"{study_uuid}/index.html"
+                return super().dispatch(request, path)
 
 
 # UTILITY FUNCTIONS

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -935,10 +935,9 @@ class PreviewProxyView(ResearcherLoginRequiredMixin, UserPassesTestMixin, ProxyV
             response = create_external_response(study, child_uuid, preview=True)
             return HttpResponseRedirect(get_external_url(study, response))
         else:
-            """Check if locale (language code) is present in the URL.
-            If so, we need to re-write the request path without the locale
-            so that it points to a working study URL.
-            """
+            # Check if locale (language code) is present in the URL.
+            # If so, we need to re-write the request path without the locale
+            # so that it points to a working study URL.
             locale_pattern = rf"/(?P<locale>[a-zA-Z-].+)/exp/studies/{study_uuid}/{child_uuid}/preview/(?P<rest>.*?)"
             path_match = re.match(locale_pattern, request.path)
             if path_match:
@@ -948,7 +947,7 @@ class PreviewProxyView(ResearcherLoginRequiredMixin, UserPassesTestMixin, ProxyV
                 request.META["PATH_INFO"] = path_no_locale
 
             if settings.DEBUG and settings.ENVIRONMENT == "develop":
-                """If we're in a local environment, then redirect shortcut to switch to the ember server"""
+                # If we're in a local environment, then redirect shortcut to switch to the ember server
                 debug_path = rf"{settings.EXPERIMENT_BASE_URL}{request.path_info}"
                 return redirect(debug_path)
             else:

--- a/web/views.py
+++ b/web/views.py
@@ -679,6 +679,10 @@ class ExperimentProxyView(LoginRequiredMixin, UserPassesTestMixin, ProxyView):
             request.path_info = path_no_locale
             request.META["PATH_INFO"] = path_no_locale
 
-        path = f"{study_uuid}/index.html"
-
-        return super().dispatch(request, path)
+        if settings.DEBUG and settings.ENVIRONMENT == "develop":
+            """If we're in a local environment, then redirect shortcut to switch to the ember server"""
+            debug_path = rf"{settings.EXPERIMENT_BASE_URL}{request.path_info}"
+            return redirect(debug_path)
+        else:
+            path = f"{study_uuid}/index.html"
+            return super().dispatch(request, path)

--- a/web/views.py
+++ b/web/views.py
@@ -663,10 +663,9 @@ class ExperimentProxyView(LoginRequiredMixin, UserPassesTestMixin, ProxyView):
         study_uuid = kwargs.get("uuid", None)
         child_uuid = kwargs.get("child_id", None)
 
-        """Check if locale (language code) is present in the URL. 
-        If so, we need to re-write the request path without the locale 
-        so that it points to a working study URL.
-        """
+        # Check if locale (language code) is present in the URL.
+        # If so, we need to re-write the request path without the locale
+        # so that it points to a working study URL.
         locale_pattern = (
             rf"/(?P<locale>[a-zA-Z-].+)/studies/{study_uuid}/{child_uuid}/(?P<rest>.*?)"
         )
@@ -680,7 +679,7 @@ class ExperimentProxyView(LoginRequiredMixin, UserPassesTestMixin, ProxyView):
             request.META["PATH_INFO"] = path_no_locale
 
         if settings.DEBUG and settings.ENVIRONMENT == "develop":
-            """If we're in a local environment, then redirect shortcut to switch to the ember server"""
+            # If we're in a local environment, then redirect shortcut to switch to the ember server
             debug_path = rf"{settings.EXPERIMENT_BASE_URL}{request.path_info}"
             return redirect(debug_path)
         else:


### PR DESCRIPTION
## Description
This fixes the MaxRetries error that occurs when running or previewing a study in the local environment. The redirect will switch the request over to the local ember server, so that the developer doesn't have to manually change the port in the browser's address bar. 

https://user-images.githubusercontent.com/9041788/184457166-6d548866-0b16-4393-8daa-6fc84ebbf1c8.mov

Note that the way that the lookit-api and ember tasks interact is still very different on local vs remote environments. This doesn't change that, it just makes local development more convenient by by-passing an error page.

## Implementation Note
I think we could just check `DEBUG` rather than both `DEBUG` and `ENVIRONMENT` in this line: 
```python
if settings.DEBUG and settings.ENVIRONMENT == "develop":
```
as is currently done here, for example: https://github.com/lookit/lookit-api/blob/e95445a48d9d39a41905769a5854cde4cedbd001/project/urls.py#L56
but I wanted to err on the safe side.