### PR TITLE
Remove locale from study links by manually setting language

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -928,9 +928,9 @@ class PreviewProxyView(ResearcherLoginRequiredMixin, UserPassesTestMixin, ProxyV
         path replacement manually. Great! Just wonderful.
         """
 
-        """Manually set the language code to the default language, which isn't prefixed in URLs, 
-        to stop the locale middleware from adding a language/locale prefix back into the study URL 
-        after the request has been dispatched"""
+        # Manually set the language code to the default language, which isn't prefixed in URLs,
+        # to stop the locale middleware from adding a language/locale prefix back into the study URL
+        # after the request has been dispatched
         translation.activate(settings.LANGUAGE_CODE)
         request.LANGUAGE_CODE = settings.LANGUAGE_CODE
 
@@ -942,10 +942,9 @@ class PreviewProxyView(ResearcherLoginRequiredMixin, UserPassesTestMixin, ProxyV
             response = create_external_response(study, child_uuid, preview=True)
             return HttpResponseRedirect(get_external_url(study, response))
         else:
-            """Check if locale (language code) is present in the URL.
-            If so, we need to re-write the request path without the locale
-            so that it points to a working study URL.
-            """
+            # Check if locale (language code) is present in the URL.
+            # If so, we need to re-write the request path without the locale
+            # so that it points to a working study URL.
             locale_pattern = rf"/(?P<locale>[a-zA-Z-].+)/exp/studies/{study_uuid}/{child_uuid}/preview/(?P<rest>.*?)"
             path_match = re.match(locale_pattern, request.path)
             if path_match:

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -11,6 +11,7 @@ from django.db.models.functions import Lower
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.http.response import HttpResponse
 from django.shortcuts import get_object_or_404, reverse
+from django.utils import translation
 from django.views import generic
 from django.views.generic.detail import SingleObjectMixin
 from revproxy.views import ProxyView
@@ -926,6 +927,12 @@ class PreviewProxyView(ResearcherLoginRequiredMixin, UserPassesTestMixin, ProxyV
         Also, the redirect functionality in revproxy is broken so we have to patch
         path replacement manually. Great! Just wonderful.
         """
+
+        """Manually set the language code to the default language, which isn't prefixed in URLs, 
+        to stop the locale middleware from adding a language/locale prefix back into the study URL 
+        after the request has been dispatched"""
+        translation.activate(settings.LANGUAGE_CODE)
+        request.LANGUAGE_CODE = settings.LANGUAGE_CODE
 
         study_uuid = kwargs.get("uuid", None)
         child_uuid = kwargs.get("child_id", None)

--- a/web/views.py
+++ b/web/views.py
@@ -661,19 +661,18 @@ class ExperimentProxyView(LoginRequiredMixin, UserPassesTestMixin, ProxyView):
         path replacement manually.
         """
 
-        """Manually set the language code to the default language, which isn't prefixed in URLs, 
-        to stop the locale middleware from adding a language/locale prefix back into the study URL 
-        after the request has been dispatched"""
+        # Manually set the language code to the default language, which isn't prefixed in URLs,
+        # to stop the locale middleware from adding a language/locale prefix back into the study URL
+        # after the request has been dispatched
         translation.activate(settings.LANGUAGE_CODE)
         request.LANGUAGE_CODE = settings.LANGUAGE_CODE
 
         study_uuid = kwargs.get("uuid", None)
         child_uuid = kwargs.get("child_id", None)
 
-        """Check if locale (language code) is present in the URL. 
-        If so, we need to re-write the request path without the locale 
-        so that it points to a working study URL.
-        """
+        # Check if locale (language code) is present in the URL.
+        # If so, we need to re-write the request path without the locale
+        # so that it points to a working study URL.
         locale_pattern = (
             rf"/(?P<locale>[a-zA-Z-].+)/studies/{study_uuid}/{child_uuid}/(?P<rest>.*?)"
         )

--- a/web/views.py
+++ b/web/views.py
@@ -13,6 +13,7 @@ from django.db.models.query_utils import Q
 from django.dispatch import receiver
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, reverse
+from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from django.views.generic.edit import FormView
@@ -659,6 +660,12 @@ class ExperimentProxyView(LoginRequiredMixin, UserPassesTestMixin, ProxyView):
         """The redirect functionality in revproxy is broken so we have to patch
         path replacement manually.
         """
+
+        """Manually set the language code to the default language, which isn't prefixed in URLs, 
+        to stop the locale middleware from adding a language/locale prefix back into the study URL 
+        after the request has been dispatched"""
+        translation.activate(settings.LANGUAGE_CODE)
+        request.LANGUAGE_CODE = settings.LANGUAGE_CODE
 
         study_uuid = kwargs.get("uuid", None)
         child_uuid = kwargs.get("child_id", None)


### PR DESCRIPTION
## Background
This is to address the issue of broken study links when the user starts the session from the Lookit website that contains a locale code in the path: #973, #1000.

I tried manually removing the locale from the request path for study sessions in this PR: #1008. This does change the request path correclty, but when testing on the staging server, it didn't work: the locale is added back into the path. 

I think the Locale Middleware is altering the request _after_ it's been modified by the ProxyView dispatch methods ([see here](https://docs.djangoproject.com/en/4.1/topics/http/middleware/)). If so then the fix will probably need to involve Django's translation tools and/or the Locale Middleware.

## Current change
This PR is to see if it's possible to remove the locale from the study session URLs by manually setting the request's language code and [activating](https://docs.djangoproject.com/en/4.1/ref/utils/#django.utils.translation.activate) the default translation language.

If this works, then I will try removing the earlier modifications to the request path from #1008.

If this doesn't work, then the next step might be trying to figure out how to make URL pattern exceptions with [`i18n_patterns`](https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#language-prefix-in-url-patterns). I haven't been able to figure that out yet and I'm not sure if it's possible. It does look like it's possible to re-write/customize the `i18n_patterns` function: https://stackoverflow.com/a/54786316.