### PR TITLE
Fix study links with locale

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -452,7 +452,8 @@ class StudyDetailView(
             comments_text.append(study.comments)
 
         # if study is submitted, see if there are any declarations to display
-        if study.state == "submitted":
+        declarations_exist = study.comments_extra.get("declarations")
+        if study.state == "submitted" and declarations_exist:
 
             declarations_state = ", ".join(
                 DECLARATIONS["submit"][k]

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -452,8 +452,7 @@ class StudyDetailView(
             comments_text.append(study.comments)
 
         # if study is submitted, see if there are any declarations to display
-        declarations_exist = study.comments_extra.get("declarations")
-        if study.state == "submitted" and declarations_exist:
+        if study.state == "submitted":
 
             declarations_state = ", ".join(
                 DECLARATIONS["submit"][k]

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -452,10 +452,7 @@ class StudyDetailView(
             comments_text.append(study.comments)
 
         # if study is submitted, see if there are any declarations to display
-        declarations_exist = False
-        if study.comments_extra and study.comments_extra.get("declarations"):
-            declarations_exist = True
-
+        declarations_exist = study.comments_extra.get("declarations")
         if study.state == "submitted" and declarations_exist:
 
             declarations_state = ", ".join(

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -452,7 +452,10 @@ class StudyDetailView(
             comments_text.append(study.comments)
 
         # if study is submitted, see if there are any declarations to display
-        declarations_exist = study.comments_extra.get("declarations")
+        declarations_exist = False
+        if study.comments_extra and study.comments_extra.get("declarations"):
+            declarations_exist = True
+
         if study.state == "submitted" and declarations_exist:
 
             declarations_state = ", ".join(

--- a/web/views.py
+++ b/web/views.py
@@ -625,14 +625,10 @@ class ExperimentAssetsProxyView(LoginRequiredMixin, ProxyView):
         # Check if locale (language code) is present in the URL.
         # If so, we need to re-write the request path without the locale
         # so that it points to a working study asset URL.
-        locale_pattern = (
-            rf"/(?P<locale>[a-zA-Z-].+)/studies/{uuid}/(?P<rest>.*)$"
-        )
+        locale_pattern = rf"/(?P<locale>[a-zA-Z-].+)/studies/{uuid}/(?P<rest>.*)$"
         path_match = re.match(locale_pattern, request.path)
         if path_match:
-            path_no_locale = (
-                rf"/studies/{uuid}/{path_match.group('rest')}"
-            )
+            path_no_locale = rf"/studies/{uuid}/{path_match.group('rest')}"
             request.path = path_no_locale
             request.path_info = path_no_locale
             request.META["PATH_INFO"] = path_no_locale


### PR DESCRIPTION
This is an attempt at #973 and #1000. This is just for testing on staging, since I'm not able to test this locally.

After my last attempt to fix this issue on develop (#1016), I found that, when the URL contains a locale, clicking the study link _does_ load the ember study, but then it produces a 'Page not found' error before making some of the requests that originate from the study JS (specifically the vendor.js file, I think). The requests that aren't made are those starting with `/api/v1/`.

Normal sequence of requests (i.e. no locale in the URL) are shown below. Requests with the red box around them are absent when there's a locale in the Lookit site URL:

<img width="1485" alt="staging_no_locale_first_request_after_404" src="https://user-images.githubusercontent.com/9041788/187319029-98ac6387-e92b-4f1c-801a-c07077b9d984.png">

Page content and requests with a locale in the Lookit site URL:

<img width="1485" alt="staging_ember_request_locale_404" src="https://user-images.githubusercontent.com/9041788/187319068-1f5ef1a4-5fed-41a4-9976-a2f80a1ad3cb.png">

So the problem might be with the creation of paths to the study asset files? 

I'm going to merge this without review so that I can test ASAP. But please feel free to provide thoughts/feedback anyway.

BTW I added the fix for the study declarations key error (totally separate issue), just because this was causing problems for me. Happy to fix the error in some other way, I just needed a temporary solution. 