### PR TITLE
Fix study links with locale - use redirect

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -11,7 +11,6 @@ from django.db.models.functions import Lower
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.http.response import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, reverse
-from django.utils import translation
 from django.views import generic
 from django.views.generic.detail import SingleObjectMixin
 from revproxy.views import ProxyView
@@ -952,12 +951,6 @@ class PreviewProxyView(ResearcherLoginRequiredMixin, UserPassesTestMixin, ProxyV
         Also, the redirect functionality in revproxy is broken so we have to patch
         path replacement manually. Great! Just wonderful.
         """
-
-        # Manually set the language code to the default language, which isn't prefixed in URLs,
-        # to stop the locale middleware from adding a language/locale prefix back into the study URL
-        # after the request has been dispatched
-        translation.activate(settings.LANGUAGE_CODE)
-        request.LANGUAGE_CODE = settings.LANGUAGE_CODE
 
         study_uuid = kwargs.get("uuid", None)
         child_uuid = kwargs.get("child_id", None)

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -452,7 +452,8 @@ class StudyDetailView(
             comments_text.append(study.comments)
 
         # if study is submitted, see if there are any declarations to display
-        if study.state == "submitted":
+        declarations_exist = study.comments_extra.get("declarations")
+        if study.state == "submitted" and declarations_exist:
 
             declarations_state = ", ".join(
                 DECLARATIONS["submit"][k]

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -452,8 +452,7 @@ class StudyDetailView(
             comments_text.append(study.comments)
 
         # if study is submitted, see if there are any declarations to display
-        declarations_exist = study.comments_extra.get("declarations")
-        if study.state == "submitted" and declarations_exist:
+        if study.state == "submitted":
 
             declarations_state = ", ".join(
                 DECLARATIONS["submit"][k]

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -979,7 +979,7 @@ class PreviewProxyView(ResearcherLoginRequiredMixin, UserPassesTestMixin, ProxyV
 
         path = f"{study_uuid}/index.html"
         return super().dispatch(request, path)
-            
+
 
 # UTILITY FUNCTIONS
 def get_permitted_triggers(view_instance, triggers):

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -452,10 +452,7 @@ class StudyDetailView(
             comments_text.append(study.comments)
 
         # if study is submitted, see if there are any declarations to display
-        declarations_exist = False
-        if study.comments_extra and study.comments_extra.get("declarations"):
-            declarations_exist = True
-
+        declarations_exist = study.comments_extra.get("declarations")
         if study.state == "submitted" and declarations_exist:
 
             declarations_state = ", ".join(

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -452,7 +452,10 @@ class StudyDetailView(
             comments_text.append(study.comments)
 
         # if study is submitted, see if there are any declarations to display
-        declarations_exist = study.comments_extra.get("declarations")
+        declarations_exist = False
+        if study.comments_extra and study.comments_extra.get("declarations"):
+            declarations_exist = True
+
         if study.state == "submitted" and declarations_exist:
 
             declarations_state = ", ".join(

--- a/web/views.py
+++ b/web/views.py
@@ -13,7 +13,6 @@ from django.db.models.query_utils import Q
 from django.dispatch import receiver
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, reverse
-from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from django.views.generic.edit import FormView
@@ -612,12 +611,6 @@ class ExperimentAssetsProxyView(LoginRequiredMixin, ProxyView):
     def dispatch(self, request, *args, **kwargs):
         """Bypass presence of child ID."""
 
-        # Manually set the language code to the default language, which isn't prefixed in URLs,
-        # to stop the locale middleware from adding a language/locale prefix back into the study assets URLs
-        # after the request has been dispatched
-        translation.activate(settings.LANGUAGE_CODE)
-        request.LANGUAGE_CODE = settings.LANGUAGE_CODE
-
         uuid = kwargs.pop("uuid")
         asset_path = kwargs.pop("path")
         path = f"{uuid}/{asset_path}"
@@ -679,12 +672,6 @@ class ExperimentProxyView(LoginRequiredMixin, UserPassesTestMixin, ProxyView):
         """The redirect functionality in revproxy is broken so we have to patch
         path replacement manually.
         """
-
-        # Manually set the language code to the default language, which isn't prefixed in URLs,
-        # to stop the locale middleware from adding a language/locale prefix back into the study URL
-        # after the request has been dispatched
-        translation.activate(settings.LANGUAGE_CODE)
-        request.LANGUAGE_CODE = settings.LANGUAGE_CODE
 
         study_uuid = kwargs.get("uuid", None)
         child_uuid = kwargs.get("child_id", None)

--- a/web/views.py
+++ b/web/views.py
@@ -615,17 +615,6 @@ class ExperimentAssetsProxyView(LoginRequiredMixin, ProxyView):
         asset_path = kwargs.pop("path")
         path = f"{uuid}/{asset_path}"
 
-        # Check if locale (language code) is present in the URL.
-        # If so, we need to re-write the request path without the locale
-        # so that it points to a working study asset URL.
-        locale_pattern = rf"/(?P<locale>[a-zA-Z-].+)/studies/{uuid}/(?P<rest>.*)$"
-        path_match = re.match(locale_pattern, request.path)
-        if path_match:
-            path_no_locale = rf"/studies/{uuid}/{path_match.group('rest')}"
-            request.path = path_no_locale
-            request.path_info = path_no_locale
-            request.META["PATH_INFO"] = path_no_locale
-
         return super().dispatch(request, path, *args, **kwargs)
 
 

--- a/web/views.py
+++ b/web/views.py
@@ -625,14 +625,10 @@ class ExperimentAssetsProxyView(LoginRequiredMixin, ProxyView):
         # Check if locale (language code) is present in the URL.
         # If so, we need to re-write the request path without the locale
         # so that it points to a working study asset URL.
-        locale_pattern = (
-            rf"/(?P<locale>[a-zA-Z-].+)/studies/{uuid}/(?P<rest>.*)$"
-        )
+        locale_pattern = rf"/(?P<locale>[a-zA-Z-].+)/studies/{uuid}/(?P<rest>.*)$"
         path_match = re.match(locale_pattern, request.path)
         if path_match:
-            path_no_locale = (
-                rf"/studies/{uuid}/{path_match.group('rest')}"
-            )
+            path_no_locale = rf"/studies/{uuid}/{path_match.group('rest')}"
             request.path = path_no_locale
             request.path_info = path_no_locale
             request.META["PATH_INFO"] = path_no_locale

--- a/web/views.py
+++ b/web/views.py
@@ -692,22 +692,19 @@ class ExperimentProxyView(LoginRequiredMixin, UserPassesTestMixin, ProxyView):
         # Check if locale (language code) is present in the URL.
         # If so, we need to re-write the request path without the locale
         # so that it points to a working study URL.
-        locale_pattern = (
-            rf"/(?P<locale>[a-zA-Z-].+)/studies/{study_uuid}/{child_uuid}/(?P<rest>.*?)"
-        )
-        path_match = re.match(locale_pattern, request.path)
+        path = request.path
+        locale_pattern = rf"/(?P<locale>[a-zA-Z-].+)/studies/{study_uuid}/{child_uuid}/(?P<rest>.*?)"
+        path_match = re.match(locale_pattern, path)
         if path_match:
-            path_no_locale = (
-                rf"/studies/{study_uuid}/{child_uuid}/{path_match.group('rest')}"
-            )
-            request.path = path_no_locale
-            request.path_info = path_no_locale
-            request.META["PATH_INFO"] = path_no_locale
+            path = f"/studies/{study_uuid}/{child_uuid}/{path_match.group('rest')}"
+            url = request.build_absolute_uri(path)
+            # Using redirect instead of super().dispatch here to get around locale/translation middleware
+            return redirect(url)
 
         if settings.DEBUG and settings.ENVIRONMENT == "develop":
             # If we're in a local environment, then redirect shortcut to switch to the ember server
-            debug_path = rf"{settings.EXPERIMENT_BASE_URL}{request.path_info}"
-            return redirect(debug_path)
-        else:
-            path = f"{study_uuid}/index.html"
-            return super().dispatch(request, path)
+            url = f"{settings.EXPERIMENT_BASE_URL}{path}"
+            return redirect(url)
+
+        path = f"{study_uuid}/index.html"
+        return super().dispatch(request, path)

--- a/web/views.py
+++ b/web/views.py
@@ -669,7 +669,9 @@ class ExperimentProxyView(LoginRequiredMixin, UserPassesTestMixin, ProxyView):
         # If so, we need to re-write the request path without the locale
         # so that it points to a working study URL.
         path = request.path
-        locale_pattern = rf"/(?P<locale>[a-zA-Z-].+)/studies/{study_uuid}/{child_uuid}/(?P<rest>.*?)"
+        locale_pattern = (
+            rf"/(?P<locale>[a-zA-Z-].+)/studies/{study_uuid}/{child_uuid}/(?P<rest>.*?)"
+        )
         path_match = re.match(locale_pattern, path)
         if path_match:
             path = f"/studies/{study_uuid}/{child_uuid}/{path_match.group('rest')}"


### PR DESCRIPTION
This is another attempt at fixing #973 and #1000 (but merging should not automatically close those issues).

This PR is to try using `redirect` instead of `super().dispatch` to process the modified URL. This redirect approach is working locally (with and without local, for both preview and real sessions). 
I've also: 
(1) refactored this logic slightly to e.g. remove unnecessary code, such as `else` statements, and improve/clarify variables
(2) removed the manual language activation and setting the request's LANGUAGE_CODE value, since these things were added to test but did not seem to fix the problem.

I have not modified the requests/paths in `ExperimentAssetsProxyView`. It may turn out that the same approach is needed here (i.e. check for locale, remove it, and redirect).

I'll merge this without review so that I can test ASAP on staging.