### PR TITLE
Move node version to 12 for EFP

### DIFF
--- a/ember_build/Dockerfile
+++ b/ember_build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:12-slim
 
 # For GOSU details see https://github.com/tianon/gosu/blob/master/INSTALL.md
 RUN set -eux; \


### PR DESCRIPTION
The docker file for building experiments is held in this repo.  We needed the version of node increased from 10 to 12 to support AWS SDK.  