### PR TITLE
Small updates to study announcement email template

### DIFF
--- a/studies/templates/emails/study_announcement.html
+++ b/studies/templates/emails/study_announcement.html
@@ -30,7 +30,12 @@
 </li>
 </ul>
 <p>
-    You and your child can participate any time you want by going to
+    {% if study.show_scheduled %}
+        You can schedule a time to participate with your child
+    {% else %}
+        You and your child can participate any time you want
+    {% endif %}
+    by going to
     <a href="{{ base_url }}{% url 'web:study-detail' uuid=study.uuid %}">"{{ study.name }}"</a> on Lookit.
 If you have any questions, please reply to this email to reach the {{ study.lab.name }} at
 {{ study.lab.contact_email }}.
@@ -39,3 +44,5 @@ If you have any questions, please reply to this email to reach the {{ study.lab.
     Thanks for contributing to the science of how kids learn - we hope to see you soon!
 </p>
 -- the Lookit team
+<br />
+<a href="{{ base_url }}{% url 'web:email-preferences' %}">Update your email preferences</a>

--- a/studies/templates/emails/study_announcement.txt
+++ b/studies/templates/emails/study_announcement.txt
@@ -12,8 +12,11 @@ Why: {{ study.purpose }}
 
 Compensation: {{ study.compensation_description|default:"This is a volunteer-based study." }}
 
-You and your child can participate any time you want by going to "{{ study.name }}" on Lookit ({{ base_url }}{% url 'web:study-detail' uuid=study.uuid %}). If you have any questions, please reply to this email to reach the {{ study.lab.name }} at {{ study.lab.contact_email }}.
+{% if study.show_scheduled %}You can schedule a time to participate with your child{% else %}You and your child can participate any time you want{% endif %} by going to "{{ study.name }}" on Lookit ({{ base_url }}{% url 'web:study-detail' uuid=study.uuid %}). If you have any questions, please reply to this email to reach the {{ study.lab.name }} at {{ study.lab.contact_email }}.
 
 Thanks for contributing to the science of how kids learn - we hope to see you soon!
 
 -- the Lookit team
+
+
+Update your email preferences here: {{ base_url }}{% url 'web:email-preferences' %}


### PR DESCRIPTION
I got an email announcement recently for Azira (our youngest, now 6mo!) and noticed a few things I figured would be simpler to just make a PR for than an issue - 

* add link to email preferences (like for custom email)
* adjust language based on whether study is scheduled

Obviously feel free to ignore if this is more trouble to test than it's worth! I did NOT test the email formatting & links because I don't still have a dev environment properly set up. 