### PR TITLE
Add autocomplete attribute to form element

### DIFF
--- a/web/templates/registration/login.html
+++ b/web/templates/registration/login.html
@@ -19,7 +19,7 @@
                     <h3 class="panel-title">{% trans "Login" %}</h3>
                 </div>
                 <div class="panel-body">
-                    <form action="" method="post" class="form">
+                    <form action="" method="post" class="form" autocomplete="off">
                         {% csrf_token %}
                         {% bootstrap_form form %}
                         {% buttons %}


### PR DESCRIPTION
Per the LMG document, added `autocomplete=off` to the login form element.  

Closes #1085