### PR TITLE
edit criteria placeholder text in study create/edit form - #997

### DIFF
--- a/studies/forms.py
+++ b/studies/forms.py
@@ -311,7 +311,7 @@ class StudyForm(ModelForm):
             "compensation_description": Textarea(attrs={"rows": 2}),
             "exit_url": Textarea(attrs={"rows": 1}),
             "criteria": Textarea(
-                attrs={"rows": 1, "placeholder": "For 4-year-olds who love dinosaurs"}
+                attrs={"rows": 1, "placeholder": "For 4- to 6-year-olds"}
             ),
             "duration": Textarea(attrs={"rows": 1, "placeholder": "15 minutes"}),
             "contact_info": Textarea(


### PR DESCRIPTION
Fixes #997

This PR changes the placeholder text in the study edit form 'Participant Eligibility Description' to remove the '...who love dinosaurs' part. 

I also added an age range to make it a little clearer to researchers why this field exists (i.e. to translate the actual study criteria that might be in a non-intuitive form, such as an age range in days, into a more human readable version).

<img width="923" alt="Screenshot 2023-02-03 at 5 06 51 PM" src="https://user-images.githubusercontent.com/9041788/216737552-cb038c64-082f-4fef-bdcf-90df06cba1c5.png">
