### PR TITLE
Clarify help text for entering lab custom URL slug

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -82,7 +82,7 @@ class Lab(models.Model):
         verbose_name="Custom URL Slug",
         help_text="A unique URL ending (slug) for the webpage that will show any discoverable, active studies for this lab. "
         "For example, entering \"my-lab-name\" in this box will produce the custom URL \"https://lookit.mit.edu/studies/my-lab-name\" "
-        "for this lab. Slugs can contain letters, numbers, underscores, and/or hyphens.",
+        "for this lab. Slugs should not contain spaces and can contain letters, numbers, underscores, and/or hyphens.",
     )
     institution = models.CharField(max_length=255, blank=True)
     principal_investigator_name = models.CharField(max_length=255, blank=False)

--- a/studies/models.py
+++ b/studies/models.py
@@ -80,8 +80,9 @@ class Lab(models.Model):
         null=True,
         default=None,
         verbose_name="Custom URL",
-        help_text="A unique URL ending (slug) that will show discoverable, active studies for this lab "
-        "only, e.g. entering 'my-lab-name' will give you the custom URL https://lookit.mit.edu/studies/my-lab-name",
+        help_text="A unique URL ending (slug) for the webpage that will show any discoverable, active studies for this lab. "
+        "For example, entering \"my-lab-name\" in this box will produce the custom URL \"https://lookit.mit.edu/studies/my-lab-name\" "
+        "for this lab. Slugs can contain letters, numbers, underscores, and/or hyphens.",
     )
     institution = models.CharField(max_length=255, blank=True)
     principal_investigator_name = models.CharField(max_length=255, blank=False)

--- a/studies/models.py
+++ b/studies/models.py
@@ -80,8 +80,8 @@ class Lab(models.Model):
         null=True,
         default=None,
         verbose_name="Custom URL",
-        help_text="A unique URL (slug) that will show discoverable, active studies for this lab "
-        "only, e.g. https://lookit.mit.edu/studies/my-lab-name",
+        help_text="A unique URL ending (slug) that will show discoverable, active studies for this lab "
+        "only, e.g. entering 'my-lab-name' will give you the custom URL https://lookit.mit.edu/studies/my-lab-name",
     )
     institution = models.CharField(max_length=255, blank=True)
     principal_investigator_name = models.CharField(max_length=255, blank=False)

--- a/studies/models.py
+++ b/studies/models.py
@@ -79,7 +79,7 @@ class Lab(models.Model):
         unique=True,
         null=True,
         default=None,
-        verbose_name="Custom URL",
+        verbose_name="Custom URL Slug",
         help_text="A unique URL ending (slug) for the webpage that will show any discoverable, active studies for this lab. "
         "For example, entering \"my-lab-name\" in this box will produce the custom URL \"https://lookit.mit.edu/studies/my-lab-name\" "
         "for this lab. Slugs can contain letters, numbers, underscores, and/or hyphens.",


### PR DESCRIPTION
~~This fixes an issue reported in lookit-docs, but that is actually related to the help text shown on the form for creating a new lab~~ (Edit: I transferred the issue from lookit-docs to lookit-api)

Fixes #1094

This change is intended to clarify that the researcher should just enter the slug (URL ending) that they want, not the full URL.

<img width="961" alt="Screenshot 2023-02-07 at 1 31 39 PM" src="https://user-images.githubusercontent.com/9041788/217370933-6dd88d81-d6b7-4a32-85c9-bf6b6504daac.png">
