### PR TITLE
Summary char limit - fixes #1075

### DIFF
--- a/studies/forms.py
+++ b/studies/forms.py
@@ -339,7 +339,7 @@ class StudyForm(ModelForm):
             "lab": "Which lab this study will be affiliated with",
             "image": "This is the image participants will see when browsing studies. Please make sure that your image file dimensions are square and the size is less than 1 MB.",
             "exit_url": "Specify the page where you want to send your participants after they've completed the study. (The 'Past studies' page on Lookit is a good default option.)",
-            "preview_summary": "This is the text participants will see when browsing studies. Please keep your description under 100 words.",
+            "preview_summary": "This is the text participants will see when browsing studies. The limit is 300 characters.",
             "short_description": "Describe what happens during your study here. This should give families a concrete idea of what they will be doing - e.g., reading a story together and answering questions, watching a short video, playing a game about numbers. If you are running a scheduled study, make sure to include a description of how they will sign up and access the study session.",
             "purpose": "Explain the purpose of your study here. This should address what question this study answers AND why that is an interesting or important question, in layperson-friendly terms.",
             "contact_info": "This should give the name of the PI for your study, and an email address where the PI or study staff can be reached with questions. Format: PIs Name (contact: youremail@lab.edu)",

--- a/studies/models.py
+++ b/studies/models.py
@@ -296,7 +296,7 @@ class Study(models.Model):
     priority = models.IntegerField(
         validators=[MinValueValidator(1), MaxValueValidator(99)], default=99
     )
-    preview_summary = models.CharField(max_length=500, default="")
+    preview_summary = models.CharField(max_length=300, default="")
     short_description = models.TextField()
     purpose = models.TextField()
     criteria = models.TextField()


### PR DESCRIPTION
As discussed in #1075, this PR is to reduce the text input limit for study preview summaries from 500 to 300 characters.

Here is what the new limit looks like (test study):

<img width="1187" alt="Screenshot 2023-02-14 at 1 56 07 PM" src="https://user-images.githubusercontent.com/9041788/218875752-dc3b47a8-aebe-4f5b-852d-4678bef6bc82.png">

The text input field will now stop accepting characters after 300. The limit is also indicated via the preview summary help text:

<img width="936" alt="Screenshot 2023-02-14 at 2 03 39 PM" src="https://user-images.githubusercontent.com/9041788/218875835-fa46e841-42c7-448e-b8d2-06b37e809e2e.png">

This will not change anything for existing studies that already have a preview summary between 300 and 500 characters. However, if the researcher edits the study and tries to save it, they will get a form validation error and banner message:

<img width="1031" alt="Screenshot 2023-02-14 at 2 21 19 PM" src="https://user-images.githubusercontent.com/9041788/218878119-d2e35f08-1010-4816-8ddb-a901aebed96e.png">
<img width="942" alt="Screenshot 2023-02-14 at 2 21 41 PM" src="https://user-images.githubusercontent.com/9041788/218878125-d8547e86-109a-492a-af3f-81e7fd2544d4.png">
