### PR TITLE
Bootstrap 5 studies history bug fix

### DIFF
--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -3,6 +3,7 @@
 {% load bootstrap_icons %}
 {% load i18n %}
 {% load static %}
+{% load web_extras %}
 {% block title %}
     {% trans "Past Studies" %}
 {% endblock title %}
@@ -130,9 +131,9 @@
     </div>
 {% empty %}
     <div class="m-3">
-        {% if study.study_type.is_ember_frame_player %}
+        {% if form.past_studies_tabs|studies_tab_selected == "0" %}
             <em>{% trans "You have not yet participated in any Lookit studies." %}</em>
-        {% else %}
+        {% elif form.past_studies_tabs|studies_tab_selected == "1" %}
             <em>{% trans "You have not yet participated in any external studies." %}</em>
         {% endif %}
     </div>

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -165,3 +165,9 @@ def studies_tab_text(tabs):
                 return _(
                     'You and your child can participate in these studies by scheduling a time to meet with a researcher (usually over video conferencing). Choose a study and then click "Participate" to sign up for a study session in the future.'
                 )
+
+@register.filter(name='studies_tab_selected')
+def studies_tab_selected(value):
+    for tab in value:
+        if tab.data["selected"]:
+            return tab.data["value"]

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -166,7 +166,8 @@ def studies_tab_text(tabs):
                     'You and your child can participate in these studies by scheduling a time to meet with a researcher (usually over video conferencing). Choose a study and then click "Participate" to sign up for a study session in the future.'
                 )
 
-@register.filter(name='studies_tab_selected')
+
+@register.filter(name="studies_tab_selected")
 def studies_tab_selected(value):
     for tab in value:
         if tab.data["selected"]:


### PR DESCRIPTION
This fixes a bug on `bootstrap-5` in the `studies/history` view where the message "You have not yet participated in any external studies." message is shown when the user views their history of _internal_ studies and the list is empty. 

Old:
![Screenshot 2023-02-17 at 11 27 06 AM](https://user-images.githubusercontent.com/9041788/219815748-8d43fbbd-3180-482b-9649-63613a4e1bf2.png)

I think this was happening because, when the study list is empty, this line in the template file always returns false (presumably because `study` or `study_type` doesn't exist?).
```
{% if study.study_type.is_ember_frame_player %}
```

This PR fixes the problem by replacing the conditional for study type with a filter method for the determining the selected tab (currently just Lookit vs external, though it will continue to work if we add more tabs), so that the form can use the tab selection to set the appropriate message text.

Fix:
![Screenshot 2023-02-17 at 2 18 23 PM](https://user-images.githubusercontent.com/9041788/219816124-68fe231c-f828-4a3a-a071-e763d41f41e2.png)
