### PR TITLE
Bootstrap 5 privacy, contact, terms of use

### DIFF
--- a/web/templates/web/contact.html
+++ b/web/templates/web/contact.html
@@ -1,42 +1,37 @@
-{% extends "web/default.html" %}
+{% extends "web/base.html" %}
 {% load django_bootstrap5 %}
 {% load i18n %}
 {% block title %}
     Contact Us
 {% endblock title %}
 {% block content %}
-    <div class="main">
-        <div class="lookit-row lookit-page-title">
-            <div class="container">
-                <h2>Contact</h2>
-            </div>
-        </div>
-        <div class="lookit-row contact-row">
-            <div class="container">
-                <h3>{% trans "Technical difficulties" %}</h3>
-                <p>
-                    {% trans "To report any technical difficulties during participation, please contact our team by email at " %}
-                    <a href='mailto:lookit-tech@mit.edu'>lookit-tech@mit.edu" %}</a>
-                    {% trans "." %}
-                </p>
-                <h3>{% trans "Questions about the studies" %}</h3>
-                <p>
-                {% trans "If you have any questions or concerns about the studies, please first check our FAQ. With any additional questions, please contact us at " %}<a href='mailto:lookit@mit.edu'>lookit@mit.edu</a>{% trans "." %}
-            </p>
-            <h3>{% trans "For researchers" %}</h3>
-            <p>
-                {% trans "Lookit is available to all developmental researchers, and the code is entirely open- To learn more about running your own studies or contributing, please check out the " %}
-                <a href='https://lookit.readthedocs.io/en/develop'
-                   target="_blank"
-                   rel="noopener">{% trans "documentation" %}</a>
-                {% trans "." %}
-            </p>
-            <p>
-                {% trans "Several initial test studies of a prototype Lookit platform were completed in 2015; you can read about the results, and strengths and limitations of the platform, in " %}
-                <a href='https://direct.mit.edu/opmi/issue/1/1'>{% trans "these papers" %}</a>
-                {% trans "." %}
-            </p>
-        </div>
+<div class="container m-4">
+    <h2 class="mx-4 my-5">Contact</h2>
+    <h3 class="m-4">{% trans "Technical difficulties" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "To report any technical difficulties during participation, please contact our team by email at " %}
+            <a href='mailto:lookit-tech@mit.edu'>lookit-tech@mit.edu</a>{% trans "." %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "Questions about the studies" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "If you have any questions or concerns about the studies, please first check our FAQ. With any additional questions, please contact us at " %}<a href='mailto:lookit@mit.edu'>lookit@mit.edu</a>{% trans "." %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "For researchers" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "Lookit is available to all developmental researchers, and the code is entirely open- To learn more about running your own studies or contributing, please check out the " %}
+            <a href='https://lookit.readthedocs.io/en/develop'
+                target="_blank"
+                rel="noopener">{% trans "documentation" %}</a>{% trans "." %}
+        </p>
+        <p>
+            {% trans "Several initial test studies of a prototype Lookit platform were completed in 2015; you can read about the results, and strengths and limitations of the platform, in " %}
+            <a href='https://direct.mit.edu/opmi/issue/1/1'>{% trans "these papers" %}</a>{% trans "." %}
+        </p>
     </div>
 </div>
 {% endblock content %}

--- a/web/templates/web/contact.html
+++ b/web/templates/web/contact.html
@@ -5,33 +5,33 @@
     Contact Us
 {% endblock title %}
 {% block content %}
-<div class="container m-4">
-    <h2 class="mx-4 my-5">Contact</h2>
-    <h3 class="m-4">{% trans "Technical difficulties" %}</h3>
-    <div class="m-4">
-        <p>
-            {% trans "To report any technical difficulties during participation, please contact our team by email at " %}
-            <a href='mailto:lookit-tech@mit.edu'>lookit-tech@mit.edu</a>{% trans "." %}
+    <div class="container m-4">
+        <h2 class="mx-4 my-5">Contact</h2>
+        <h3 class="m-4">{% trans "Technical difficulties" %}</h3>
+        <div class="m-4">
+            <p>
+                {% trans "To report any technical difficulties during participation, please contact our team by email at " %}
+                <a href='mailto:lookit-tech@mit.edu'>lookit-tech@mit.edu</a>{% trans "." %}
         </p>
     </div>
     <h3 class="m-4">{% trans "Questions about the studies" %}</h3>
     <div class="m-4">
         <p>
-            {% trans "If you have any questions or concerns about the studies, please first check our FAQ. With any additional questions, please contact us at " %}<a href='mailto:lookit@mit.edu'>lookit@mit.edu</a>{% trans "." %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "For researchers" %}</h3>
-    <div class="m-4">
-        <p>
-            {% trans "Lookit is available to all developmental researchers, and the code is entirely open- To learn more about running your own studies or contributing, please check out the " %}
-            <a href='https://lookit.readthedocs.io/en/develop'
-                target="_blank"
-                rel="noopener">{% trans "documentation" %}</a>{% trans "." %}
-        </p>
-        <p>
-            {% trans "Several initial test studies of a prototype Lookit platform were completed in 2015; you can read about the results, and strengths and limitations of the platform, in " %}
-            <a href='https://direct.mit.edu/opmi/issue/1/1'>{% trans "these papers" %}</a>{% trans "." %}
-        </p>
-    </div>
+        {% trans "If you have any questions or concerns about the studies, please first check our FAQ. With any additional questions, please contact us at " %}<a href='mailto:lookit@mit.edu'>lookit@mit.edu</a>{% trans "." %}
+    </p>
+</div>
+<h3 class="m-4">{% trans "For researchers" %}</h3>
+<div class="m-4">
+    <p>
+        {% trans "Lookit is available to all developmental researchers, and the code is entirely open- To learn more about running your own studies or contributing, please check out the " %}
+        <a href='https://lookit.readthedocs.io/en/develop'
+           target="_blank"
+           rel="noopener">{% trans "documentation" %}</a>{% trans "." %}
+</p>
+<p>
+    {% trans "Several initial test studies of a prototype Lookit platform were completed in 2015; you can read about the results, and strengths and limitations of the platform, in " %}
+    <a href='https://direct.mit.edu/opmi/issue/1/1'>{% trans "these papers" %}</a>{% trans "." %}
+</p>
+</div>
 </div>
 {% endblock content %}

--- a/web/templates/web/faq.html
+++ b/web/templates/web/faq.html
@@ -6,9 +6,10 @@
     FAQ
 {% endblock title %}
 {% block content %}
-    <h1>{% trans "Frequently Asked Questions" %}</h1>
-    <h3 class="m-3">{% trans "Participation" %}</h3>
-    <div class="accordion" id="faq-accordion-participation">
+<div class="container m-4">
+    <h2 class="mx-4 my-5">{% trans "Frequently Asked Questions" %}</h2>
+    <h3 class="m-4">{% trans "Participation" %}</h3>
+    <div class="accordion m-4" id="faq-accordion-participation">
         <div class="accordion-item">
             <h2 class="accordion-header" id="heading-1">
                 <button class="accordion-button collapsed"
@@ -633,10 +634,8 @@
             </div>
         </div>
     </div>
-    <h3 class="m-3">
-        {% trans "Technical" %}
-    </h3>
-    <div class="accordion" id="faq-accordion-technical">
+    <h3 class="m-4">{% trans "Technical" %}</h3>
+    <div class="accordion m-4" id="faq-accordion-technical">
         <div class="accordion-item">
             <h2 class="accordion-header" id="heading-25">
                 <button class="accordion-button collapsed"
@@ -728,10 +727,8 @@
             </div>
         </div>
     </div>
-    <h3 class="m-3">
-        {% trans "For Researchers" %}
-    </h3>
-    <div class="accordion" id="faq-accordion-for-researchers">
+    <h3 class="m-4">{% trans "For Researchers" %}</h3>
+    <div class="accordion m-4" id="faq-accordion-for-researchers">
         <div class="accordion-item">
             <h2 class="accordion-header" id="heading-29">
                 <button class="accordion-button collapsed"
@@ -780,6 +777,7 @@
             </div>
         </div>
     </div>
+</div>
 {% endblock content %}
 {% block footer %}
     {% include 'web/_footer.html' %}

--- a/web/templates/web/faq.html
+++ b/web/templates/web/faq.html
@@ -6,27 +6,27 @@
     FAQ
 {% endblock title %}
 {% block content %}
-<div class="container m-4">
-    <h2 class="mx-4 my-5">{% trans "Frequently Asked Questions" %}</h2>
-    <h3 class="m-4">{% trans "Participation" %}</h3>
-    <div class="accordion m-4" id="faq-accordion-participation">
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-1">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-1"
-                        aria-expanded="false"
-                        aria-controls="collapse-1">
-                    {% trans "What is a 'study' about cognitive development?" %}
-                </button>
-            </h2>
-            <div id="collapse-1"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-1"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+    <div class="container m-4">
+        <h2 class="mx-4 my-5">{% trans "Frequently Asked Questions" %}</h2>
+        <h3 class="m-4">{% trans "Participation" %}</h3>
+        <div class="accordion m-4" id="faq-accordion-participation">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-1">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-1"
+                            aria-expanded="false"
+                            aria-controls="collapse-1">
+                        {% trans "What is a 'study' about cognitive development?" %}
+                    </button>
+                </h2>
+                <div id="collapse-1"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-1"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Cognitive development is the science of what kids understand and how they learn. Researchers in cognitive development are interested in questions like...</p>
                 <ul>
                     <li>What knowledge and abilities infants are born with, and what they have to learn from experience</li>
@@ -35,26 +35,26 @@
                 </ul>
                 <p>A study is meant to answer a very specific question about how children learn or what they know: for instance, 'Do three-month-olds recognize their parents' faces?'</p>
 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-2">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-2"
-                        aria-expanded="false"
-                        aria-controls="collapse-2">
-                    {% trans "Why participate in developmental research?" %}
-                </button>
-            </h2>
-            <div id="collapse-2"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-2"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate%}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-2">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-2"
+                            aria-expanded="false"
+                            aria-controls="collapse-2">
+                        {% trans "Why participate in developmental research?" %}
+                    </button>
+                </h2>
+                <div id="collapse-2"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-2"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate%}
                 <p>Lots of reasons! Here are three:</p>
                 <ul>
                     <li>Researchers work hard to make the studies engaging for children and families. We hope the study is fun for you and your child!</li>
@@ -62,26 +62,26 @@
                     <li>While research studies aren't usually designed to affect outcomes for individual children, the more we understand about children, the more effective we can be in building a world where they learn and thrive. Your participation helps all of us!</li>
                 </ul>
 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-3">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-3"
-                        aria-expanded="false"
-                        aria-controls="collapse-3">
-                    {% trans "What happens when my child participates in a research study?" %}
-                </button>
-            </h2>
-            <div id="collapse-3"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-3"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate%}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-3">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-3"
+                            aria-expanded="false"
+                            aria-controls="collapse-3">
+                        {% trans "What happens when my child participates in a research study?" %}
+                    </button>
+                </h2>
+                <div id="collapse-3"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-3"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate%}
                             <p>If you have a child and would like to participate, create an account [LINK] and take a look at what we have available for your child's age range.  Some studies can be done at any time, and some involve a scheduled video chat with a university-based researcher. Most studies require a laptop/desktop with a webcam. The study description will tell you if you need any other supplies (such as a marker and paper, or a high chair for your baby to sit in.)</p>
                             <p>Each study will begin in the same way: you and your child will learn what the research is about, and you can then decide whether or not you want to do it. In most cases you'll be asked to read a consent form and record yourself stating that you and your child agree to participate. In other cases, you may electronically sign a form. In addition to permission from their parent or guardian, older children will also be asked directly if they want to participate.</p>
                             <p>Individual studies vary widely- we encourage you to try lots of different ones! Depending on your child's age, your child may answer questions directly or we may be looking for indirect signs of what she thinks is going on--like how long she looks at a surprising outcome. Some things that may happen in studies include:</p>
@@ -93,72 +93,72 @@
                             </ul>
                             <p>Some portions of the study will be automatically recorded using your webcam and sent securely to the Lookit platform. Trained researchers will watch the video and record your child's responses--for instance, which way he pointed, or how long she looked at each image. We'll put these together with responses from lots of other children to learn more about how kids think!</p>
 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-4">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-4"
-                        aria-expanded="false"
-                        aria-controls="collapse-4">
-                    {% trans "Who creates the studies?" %}
-                </button>
-            </h2>
-            <div id="collapse-4"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-4"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% url "web:termsofuse" as termsofuse %}
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-4">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-4"
+                            aria-expanded="false"
+                            aria-controls="collapse-4">
+                        {% trans "Who creates the studies?" %}
+                    </button>
+                </h2>
+                <div id="collapse-4"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-4"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% url "web:termsofuse" as termsofuse %}
+                        {% blocktranslate %}
                 <p>All of the research conducted on the website is created by scientists to learn about child development, leading to articles in scientific journals. These publications can help inform other scientists, parents, educators, and policy-makers. Usually, these scientists work at colleges, universities, or hospitals. Rarely, a scientist who works at a nonprofit or a company might also do a study that fits this goal. If a study is meant to publish results in scientific journals for everyone to see (instead of just for one nonprofit or company), then it is possible it would appear on this website.</p>
                 <p>If a scientist wants to use this platform, their institution has to sign a contract with MIT where they agree to the <a href="{{ termsofuse }}">Terms of Use</a> and certify that their studies will be reviewed and approved by an institutional review board. Studies are also subject to review and approval by Lookit/Children Helping Science. As of January 2022, we have agreements with over 50 universities, including institutions in the United States, Canada, the United Kingdom, and European Union.</p>
 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-7">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-7"
-                        aria-expanded="false"
-                        aria-controls="collapse-7">
-                    {% trans "Who will my child and I meet when we do a study involving a scheduled video chat?" %}
-                </button>
-            </h2>
-            <div id="collapse-7"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-7"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-7">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-7"
+                            aria-expanded="false"
+                            aria-controls="collapse-7">
+                        {% trans "Who will my child and I meet when we do a study involving a scheduled video chat?" %}
+                    </button>
+                </h2>
+                <div id="collapse-7"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-7"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>The studies hosted on our site come from universities all around the world. For studies that involve a scheduled video chat, you will meet a researcher from the lab associated with the university doing the study. These researchers work as part of a team that always includes a "principal investigator" -- the supervisor (usually a professor) who is in charge of the lab). Studies will be conducted by someone under the direct supervision of that principal investigator (e.g., a lab manager, research assistant, or a postdoctoral, graduate, or undergraduate researcher in training).</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-8">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-8"
-                        aria-expanded="false"
-                        aria-controls="collapse-8">
-                    {% trans "Why are you running studies online instead of in person?" %}
-                </button>
-            </h2>
-            <div id="collapse-8"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-8"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-8">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-8"
+                            aria-expanded="false"
+                            aria-controls="collapse-8">
+                        {% trans "Why are you running studies online instead of in person?" %}
+                    </button>
+                </h2>
+                <div id="collapse-8"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-8"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Traditionally, developmental studies happen in a quiet room in a university lab. Researchers call or email local parents to see if they'd like to take part and schedule an appointment for them to come visit the lab.</p>
                 <p>While researchers have been exploring online studies with children for several years, the COVID pandemic in 2020 forced most developmental labs to stop in-person visits entirely. Some studies will always need to take place in a lab, but some work very well online, and we have found these studies have a number of benefits for both families and scientists.</p>
                 <p>Why complement these in-lab studies with online ones? We're hoping to...</p>
@@ -173,83 +173,83 @@
                     <li>Communicate with families about the research we're doing and what we can learn from it</li>
                 </ul>
                 {% endblocktranslate %}
-                </div>
-            </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-9">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-9"
-                        aria-expanded="false"
-                        aria-controls="collapse-9">
-                    {% trans "How do we provide consent to participate?" %}
-                </button>
-            </h2>
-            <div id="collapse-9"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-9"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
-                <p>Rather than having the parent or legal guardian sign a form, we ask that you read aloud (or sign in ASL) a statement of consent which is recorded using your webcam. This statement holds the same weight as a signed form, but should be less hassle for you. It also lets us verify that you understand written English and that you understand you're being videotaped.</p>
-                <p>Researchers watch these consent videos on a special page of the researcher interface, and record for each one whether the video shows informed consent. They cannot view other video or download data from a session unless they have confirmed that you consented to participate! If they see a consent video that does NOT clearly demonstrate informed consent--for instance, there was a technical problem and there's no audio--they may contact you to check, depending on your email settings.</p>
-                {% endblocktranslate %}
-                    <div class="d-flex justify-content-center">
-                        <video controls preload="metadata">
-                            <source src="{% static 'videos/consent.mp4' %}" type="video/mp4"/>
-                            <track label="English"
-                                   kind="captions"
-                                   srclang="en"
-                                   src="{% static 'videos/english/consent.vtt' %}"/>
-                        </video>
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-10">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-10"
-                        aria-expanded="false"
-                        aria-controls="collapse-10">
-                    {% trans "How is our information kept secure and confidential?" %}
-                </button>
-            </h2>
-            <div id="collapse-10"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-10"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-9">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-9"
+                            aria-expanded="false"
+                            aria-controls="collapse-9">
+                        {% trans "How do we provide consent to participate?" %}
+                    </button>
+                </h2>
+                <div id="collapse-9"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-9"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
+                <p>Rather than having the parent or legal guardian sign a form, we ask that you read aloud (or sign in ASL) a statement of consent which is recorded using your webcam. This statement holds the same weight as a signed form, but should be less hassle for you. It also lets us verify that you understand written English and that you understand you're being videotaped.</p>
+                <p>Researchers watch these consent videos on a special page of the researcher interface, and record for each one whether the video shows informed consent. They cannot view other video or download data from a session unless they have confirmed that you consented to participate! If they see a consent video that does NOT clearly demonstrate informed consent--for instance, there was a technical problem and there's no audio--they may contact you to check, depending on your email settings.</p>
+                {% endblocktranslate %}
+                        <div class="d-flex justify-content-center">
+                            <video controls preload="metadata">
+                                <source src="{% static 'videos/consent.mp4' %}" type="video/mp4"/>
+                                <track label="English"
+                                       kind="captions"
+                                       srclang="en"
+                                       src="{% static 'videos/english/consent.vtt' %}"/>
+                            </video>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-10">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-10"
+                            aria-expanded="false"
+                            aria-controls="collapse-10">
+                        {% trans "How is our information kept secure and confidential?" %}
+                    </button>
+                </h2>
+                <div id="collapse-10"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-10"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Researchers using Lookit agree to uphold a common set of standards about how data is protected and shared. For instance, they never publish children's names or birthdates, or information that could be used to calculate a birthdate.</p>
                 <p>The Lookit researcher interface is designed with participant data protection as the top priority. For instance, a special interface lets researchers confirm consent videos before they are able to download any other data from your session. Research groups can control who has access to what data in a very fine-grained way, for instance allowing an assistant to confirm consent and send gift cards, but not download study data.</p>
                 <p>All of your data, including video, is transmitted over a secure HTTPS connection to Lookit storage, and is encrypted at rest. We take security very seriously; in addition to making sure any software we use is up-to-date, cloud servers are configured securely, and unit tests cover checking that accessing data requires correct permissions, we conducted a risk assessment and detailed manual penetration testing with a security contractor prior to our 2020 launch.</p>
                 <p>See also 'Who will see our video?'</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-11">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-11"
-                        aria-expanded="false"
-                        aria-controls="collapse-11">
-                    {% trans "Who will see our video?" %}
-                </button>
-            </h2>
-            <div id="collapse-11"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-11"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-11">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-11"
+                            aria-expanded="false"
+                            aria-controls="collapse-11">
+                        {% trans "Who will see our video?" %}
+                    </button>
+                </h2>
+                <div id="collapse-11"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-11"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Lookit staff at MIT will have access to your video and other data in order to improve and promote the platform and help with troubleshooting. The researchers running the study you participated in will also have access to your video and other data (like responses to questions during the study, and information you fill out when registering a child) for research purposes. They will watch the video segments you send to mark down information specific to the study--for instance, what your child said, or how long he/she looked to the left versus the right of the screen. This research group may be at MIT or at another institution. All studies run on Lookit must be approved by an Institutional Review Board (IRB) that ensures participants' rights and welfare are protected. All researchers using Lookit also agree to Terms of Use that govern what data they can share and what sorts of studies are okay to run on Lookit; these rules are sometimes stricter than their own institution might be.  </p>
                 <p>Whether anyone else may view the video depends on the privacy settings you select at the end of the study. There are two decisions to make: whether to share your data with Databrary, and how to allow your video clips to be used by the researchers you have selected.</p>
                 <p>First, we ask if you would like to share your data (including video) with authorized users fo the secure data library Databrary. Data sharing will lead to faster progress in research on human development and behavior. Researchers who are granted access to the Databrary library must agree to treat the data with the same high standard of care they would use in their own laboratories. Learn more about Databrary's <a href="https://databrary.org/about.html">mission</a> or the <a href="https://databrary.org/about/agreement.html">requirements for authorized users</a>.</p>
@@ -261,523 +261,527 @@
                 </ul>
                 <p>If for some reason you do not select a privacy level, we treat the data as 'Private' and do not share with Databrary. Participants also have the option to withdraw all video besides consent at the end of the study if necessary (for instance, because someone was discussing state secrets in the background), and in this case it is automatically deleted. Privacy settings for completed sessions cannot automatically be changed retroactively. If you have any questions or concerns about privacy, please contact our team at <a href="mailto:lookit@mit.edu">lookit@mit.edu</a>.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-12">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-12"
-                        aria-expanded="false"
-                        aria-controls="collapse-12">
-                    {% trans "What information do researchers use from our video?" %}
-                </button>
-            </h2>
-            <div id="collapse-12"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-12"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    <p>
-                        {% trans "For children under about two years old, we usually design our studies to let their eyes do the talking! We're interested in where on the screen your child looks and/or how long your child looks at the screen rather than looking away. Our calibration videos (example shown below) help us get an idea of what it looks like when your child is looking to the right or the left, so we can code the rest of the video." %}
-                    </p>
-                    <div class="d-flex justify-content-center">
-                        <video controls preload="metadata">
-                            <source src="{% static 'videos/attentiongrabber.mp4' %}" type="video/mp4"/>
-                            <track label="English"
-                                   kind="captions"
-                                   srclang="en"
-                                   src="{% static 'videos/english/attentiongrabber.vtt' %}"/>
-                        </video>
-                    </div>
-                    <p>
-                        {% trans "Here's an example of a few children watching our calibration video--it's easy to see that they look to one side and then the other." %}
-                    </p>
-                    <div class="d-flex justify-content-center">
-                        <video controls preload="metadata">
-                            <source src="{% static 'videos/spinningball.mp4' %}" type="video/mp4"/>
-                            <track label="English"
-                                   kind="captions"
-                                   srclang="en"
-                                   src="{% static 'videos/english/spinningball.vtt' %}"/>
-                        </video>
-                    </div>
-                    <p>
-                        {% trans "Your child's decisions about where to look can give us lots of information about what he or she understands. Here are some of the techniques labs use to learn more about how children learn." %}
-                    </p>
-                    <h4>
-                        {% trans "Habituation" %}
-                    </h4>
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-12">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-12"
+                            aria-expanded="false"
+                            aria-controls="collapse-12">
+                        {% trans "What information do researchers use from our video?" %}
+                    </button>
+                </h2>
+                <div id="collapse-12"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-12"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        <p>
+                            {% trans "For children under about two years old, we usually design our studies to let their eyes do the talking! We're interested in where on the screen your child looks and/or how long your child looks at the screen rather than looking away. Our calibration videos (example shown below) help us get an idea of what it looks like when your child is looking to the right or the left, so we can code the rest of the video." %}
+                        </p>
+                        <div class="d-flex justify-content-center">
+                            <video controls preload="metadata">
+                                <source src="{% static 'videos/attentiongrabber.mp4' %}" type="video/mp4"/>
+                                <track label="English"
+                                       kind="captions"
+                                       srclang="en"
+                                       src="{% static 'videos/english/attentiongrabber.vtt' %}"/>
+                            </video>
+                        </div>
+                        <p>
+                            {% trans "Here's an example of a few children watching our calibration video--it's easy to see that they look to one side and then the other." %}
+                        </p>
+                        <div class="d-flex justify-content-center">
+                            <video controls preload="metadata">
+                                <source src="{% static 'videos/spinningball.mp4' %}" type="video/mp4"/>
+                                <track label="English"
+                                       kind="captions"
+                                       srclang="en"
+                                       src="{% static 'videos/english/spinningball.vtt' %}"/>
+                            </video>
+                        </div>
+                        <p>
+                            {% trans "Your child's decisions about where to look can give us lots of information about what he or she understands. Here are some of the techniques labs use to learn more about how children learn." %}
+                        </p>
+                        <h4>
+                            {% trans "Habituation" %}
+                        </h4>
+                        {% blocktranslate %}
                 <p>In a habituation study, we first show infants many examples of one type of object or event, and they lose interest over time. Infants typically look for a long time at the first pictures, but then they start to look away more quickly. Once their looking times are much less than they were initially, we show either a picture from a new category or a new picture from the familiar category. If infants now look longer to the novel example, we can tell that they understood--and got bored of--the category we showed initially.</p> <p>Habituation requires waiting for each individual infant to achieve some threshold of "boredness"--for instance, looking half as long at a picture as he or she did initially. Sometimes this is impractical, and we use familiarization instead. In a familiarization study, we show all babies the same number of examples, and then see how interested they are in the familiar versus a new category. Younger infants and those who have seen few examples tend to show a familiarity preference--they look longer at images similar to what they have seen before. Older infants and those who have seen many examples tend to show a novelty preference--they look longer at images that are different from the ones they saw before. You probably notice the same phenomenon when you hear a new song on the radio: initially you don't recognize it; after it's played several times you may like it and sing along; after it's played hundreds of times you would choose to listen to anything else.</p>
                 {% endblocktranslate %}
-                    <h4>
-                        {% trans "Violation of expectation" %}
-                    </h4>
-                    <p>
-                        {% trans "Infants and children already have rich expectations about how events work. Children (and adults for that matter) tend to look longer at things they find surprising, so in some cases, we can take their looking times as a measure of how surprised they are." %}
-                    </p>
-                    <h4>
-                        {% trans "Preferential looking" %}
-                    </h4>
-                    <p>
-                        {% trans "Even when they seem to be passive observers, children are making lots of decisions about where to look and what to pay attention to. In this technique, we present children with a choice between two side-by-side images or videos, and see if children spend more time looking at one of them. We may additionally play audio that matches one of the videos. The video below shows a participant looking to her left when asked to 'find clapping'; the display she's watching is shown at the top." %}
-                    </p>
-                    <div class="d-flex justify-content-center">
-                        <video controls preload="metadata">
-                            <source src="{% static 'videos/clapping.mp4' %}" type="video/mp4"/>
-                            <track label="English"
-                                   kind="captions"
-                                   srclang="en"
-                                   src="{% static 'videos/english/clapping.vtt' %}"/>
-                        </video>
+                        <h4>
+                            {% trans "Violation of expectation" %}
+                        </h4>
+                        <p>
+                            {% trans "Infants and children already have rich expectations about how events work. Children (and adults for that matter) tend to look longer at things they find surprising, so in some cases, we can take their looking times as a measure of how surprised they are." %}
+                        </p>
+                        <h4>
+                            {% trans "Preferential looking" %}
+                        </h4>
+                        <p>
+                            {% trans "Even when they seem to be passive observers, children are making lots of decisions about where to look and what to pay attention to. In this technique, we present children with a choice between two side-by-side images or videos, and see if children spend more time looking at one of them. We may additionally play audio that matches one of the videos. The video below shows a participant looking to her left when asked to 'find clapping'; the display she's watching is shown at the top." %}
+                        </p>
+                        <div class="d-flex justify-content-center">
+                            <video controls preload="metadata">
+                                <source src="{% static 'videos/clapping.mp4' %}" type="video/mp4"/>
+                                <track label="English"
+                                       kind="captions"
+                                       srclang="en"
+                                       src="{% static 'videos/english/clapping.vtt' %}"/>
+                            </video>
+                        </div>
+                        <h4>
+                            {% trans "Predictive looking" %}
+                        </h4>
+                        <p>
+                            {% trans "Children can often make sophisticated predictions about what they expect to see or hear next. One way we can see those predictions in young children is to look at their eye movements. For example, if a child sees a ball roll behind a barrier, she may look to the other edge of the barrier, expecting the ball to emerge there. We may also set up artificial predictive relationships--for instance, the syllable 'da' means a toy will appear at the left of the screen, and 'ba' means a toy will appear at the right. Then we can see whether children learn these relationships, and how they generalize, by watching where they look when they hear a syllable." %}
+                        </p>
+                        <p>
+                            {% trans "Older children may simply be able to answer spoken questions about what they think is happening. For instance, in a recent study, two women called an object two different made-up names, and children were asked which is the correct name for the object." %}
+                        </p>
+                        <div class="d-flex justify-content-center">
+                            <video controls preload="metadata">
+                                <source src="{% static 'videos/causal_ex2.mp4' %}" type="video/mp4"/>
+                                <track label="English"
+                                       kind="captions"
+                                       srclang="en"
+                                       src="{% static 'videos/english/causal_ex2.vtt' %}"/>
+                            </video>
+                        </div>
+                        <p>
+                            {% trans "Another way we can learn about how older children (and adults) think is to measure their reaction times. For instance, we might ask you to help your child learn to press one key when a circle appears and another key when a square appears, and then look at factors that influence how quickly they press a key." %}
+                        </p>
                     </div>
-                    <h4>
-                        {% trans "Predictive looking" %}
-                    </h4>
-                    <p>
-                        {% trans "Children can often make sophisticated predictions about what they expect to see or hear next. One way we can see those predictions in young children is to look at their eye movements. For example, if a child sees a ball roll behind a barrier, she may look to the other edge of the barrier, expecting the ball to emerge there. We may also set up artificial predictive relationships--for instance, the syllable 'da' means a toy will appear at the left of the screen, and 'ba' means a toy will appear at the right. Then we can see whether children learn these relationships, and how they generalize, by watching where they look when they hear a syllable." %}
-                    </p>
-                    <p>
-                        {% trans "Older children may simply be able to answer spoken questions about what they think is happening. For instance, in a recent study, two women called an object two different made-up names, and children were asked which is the correct name for the object." %}
-                    </p>
-                    <div class="d-flex justify-content-center">
-                        <video controls preload="metadata">
-                            <source src="{% static 'videos/causal_ex2.mp4' %}" type="video/mp4"/>
-                            <track label="English"
-                                   kind="captions"
-                                   srclang="en"
-                                   src="{% static 'videos/english/causal_ex2.vtt' %}"/>
-                        </video>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-13">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-13"
+                            aria-expanded="false"
+                            aria-controls="collapse-13">
+                        {% trans "My child wasn't paying attention, or we were interrupted. Can we try the study again?" %}
+                    </button>
+                </h2>
+                <div id="collapse-13"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-13"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        <p>
+                            {% trans "Certainly--thanks for your dedication! You may see a warning that you have already participated in the study when you go to try it again, but you can ignore it. You don't need to tell us that you tried the study before; we'll have a record of your previous participation." %}
+                        </p>
                     </div>
-                    <p>
-                        {% trans "Another way we can learn about how older children (and adults) think is to measure their reaction times. For instance, we might ask you to help your child learn to press one key when a circle appears and another key when a square appears, and then look at factors that influence how quickly they press a key." %}
-                    </p>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-13">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-13"
-                        aria-expanded="false"
-                        aria-controls="collapse-13">
-                    {% trans "My child wasn't paying attention, or we were interrupted. Can we try the study again?" %}
-                </button>
-            </h2>
-            <div id="collapse-13"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-13"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    <p>
-                        {% trans "Certainly--thanks for your dedication! You may see a warning that you have already participated in the study when you go to try it again, but you can ignore it. You don't need to tell us that you tried the study before; we'll have a record of your previous participation." %}
-                    </p>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-14">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-14"
+                            aria-expanded="false"
+                            aria-controls="collapse-14">
+                        {% trans "My child is outside the age range. Can he/she still participate in this study?" %}
+                    </button>
+                </h2>
+                <div id="collapse-14"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-14"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        <p>
+                            {% trans "Sure! We may not be able to use his or her data in our research directly, but if you're curious you're welcome to try the study anyway. (Sometimes big siblings really want their own turn!) If your child is just below the minimum age for a study, however, we encourage you to wait so that we'll be able to use the data." %}
+                        </p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-14">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-14"
-                        aria-expanded="false"
-                        aria-controls="collapse-14">
-                    {% trans "My child is outside the age range. Can he/she still participate in this study?" %}
-                </button>
-            </h2>
-            <div id="collapse-14"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-14"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    <p>
-                        {% trans "Sure! We may not be able to use his or her data in our research directly, but if you're curious you're welcome to try the study anyway. (Sometimes big siblings really want their own turn!) If your child is just below the minimum age for a study, however, we encourage you to wait so that we'll be able to use the data." %}
-                    </p>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-15">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-15"
+                            aria-expanded="false"
+                            aria-controls="collapse-15">
+                        {% trans "My child was born prematurely. Should we use his/her adjusted age?" %}
+                    </button>
+                </h2>
+                <div id="collapse-15"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-15"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        <p>
+                            {% trans "For study eligibility, we usually use the child's chronological age (time since birth), even for premature babies. If adjusted age is important for a particular study, we will make that clear in the study eligibility criteria." %}
+                        </p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-15">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-15"
-                        aria-expanded="false"
-                        aria-controls="collapse-15">
-                    {% trans "My child was born prematurely. Should we use his/her adjusted age?" %}
-                </button>
-            </h2>
-            <div id="collapse-15"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-15"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    <p>
-                        {% trans "For study eligibility, we usually use the child's chronological age (time since birth), even for premature babies. If adjusted age is important for a particular study, we will make that clear in the study eligibility criteria." %}
-                    </p>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-16">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-16"
+                            aria-expanded="false"
+                            aria-controls="collapse-16">
+                        {% trans "Our family speaks a language other than English at home. Can my child participate?" %}
+                    </button>
+                </h2>
+                <div id="collapse-16"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-16"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        <p>
+                            {% trans "Sure! Right now, instructions for children and parents are written only in English, so some of them may be confusing to a child who does not hear English regularly. However, you're welcome to try any of the studies and translate for your child if you can. If it matters for the study whether your child speaks any languages besides English, we'll ask specifically. You can also indicate the languages your child speaks or is learning to speak on your demographic survey." %}
+                        </p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-16">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-16"
-                        aria-expanded="false"
-                        aria-controls="collapse-16">
-                    {% trans "Our family speaks a language other than English at home. Can my child participate?" %}
-                </button>
-            </h2>
-            <div id="collapse-16"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-16"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    <p>
-                        {% trans "Sure! Right now, instructions for children and parents are written only in English, so some of them may be confusing to a child who does not hear English regularly. However, you're welcome to try any of the studies and translate for your child if you can. If it matters for the study whether your child speaks any languages besides English, we'll ask specifically. You can also indicate the languages your child speaks or is learning to speak on your demographic survey." %}
-                    </p>
-                </div>
-            </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-17">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-17"
-                        aria-expanded="false"
-                        aria-controls="collapse-17">
-                    {% trans "My child has been diagnosed with a developmental disorder or has special needs. Can he/she still participate?" %}
-                </button>
-            </h2>
-            <div id="collapse-17"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-17"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-17">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-17"
+                            aria-expanded="false"
+                            aria-controls="collapse-17">
+                        {% trans "My child has been diagnosed with a developmental disorder or has special needs. Can he/she still participate?" %}
+                    </button>
+                </h2>
+                <div id="collapse-17"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-17"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Of course! We're interested in how all children learn and grow. If you'd like, you can make a note of any developmental disorders in the comments section at the end of the study. We are excited that in the future, online studies may help more families participate in research to better understand their own children's diagnoses.</p>
                 <p>One note: most of our studies include both images and sound, and may be hard to understand if your child is blind or deaf. If you can, please feel free to help out by describing images or signing.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-18">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-18"
-                        aria-expanded="false"
-                        aria-controls="collapse-18">
-                    {% trans "I have multiple children in the age range for a study. Can they participate together?" %}
-                </button>
-            </h2>
-            <div id="collapse-18"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-18"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    <p>
-                        {% trans "If possible, we ask that each child participate separately. When children participate together they generally influence each other. That's a fascinating subject in its own right but usually not the focus of our research." %}
-                    </p>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-18">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-18"
+                            aria-expanded="false"
+                            aria-controls="collapse-18">
+                        {% trans "I have multiple children in the age range for a study. Can they participate together?" %}
+                    </button>
+                </h2>
+                <div id="collapse-18"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-18"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        <p>
+                            {% trans "If possible, we ask that each child participate separately. When children participate together they generally influence each other. That's a fascinating subject in its own right but usually not the focus of our research." %}
+                        </p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-19">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-19"
-                        aria-expanded="false"
-                        aria-controls="collapse-19">
-                    {% trans "But I've heard that young children should avoid 'screen time.'" %}
-                </button>
-            </h2>
-            <div id="collapse-19"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-19"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-19">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-19"
+                            aria-expanded="false"
+                            aria-controls="collapse-19">
+                        {% trans "But I've heard that young children should avoid 'screen time.'" %}
+                    </button>
+                </h2>
+                <div id="collapse-19"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-19"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>We agree with the American Academy of Pediatrics <a href="https://pediatrics.aappublications.org/content/138/5/e20162591" target="_blank" rel="noopener">advice</a> that children learn best from people, not screens! However, our studies are not intended to educate children, but to learn from them.</p>
                 <p>As part of a child's limited screen time, we hope that our studies will foster family conversation and engagement with science that offsets the few minutes spent watching a video instead of playing. And we do "walk the walk"--our own young children provide lots of feedback on our studies!</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-20">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-20"
-                        aria-expanded="false"
-                        aria-controls="collapse-20">
-                    {% trans "Will we be paid for our participation?" %}
-                </button>
-            </h2>
-            <div id="collapse-20"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-20"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    <p>
-                        {% trans "Some research groups provide gift cards or other compensation for completing their studies, and others rely on volunteers. (This often depends on the rules of the university that's doing the research.) This information will be listed on the study description page." %}
-                    </p>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-20">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-20"
+                            aria-expanded="false"
+                            aria-controls="collapse-20">
+                        {% trans "Will we be paid for our participation?" %}
+                    </button>
+                </h2>
+                <div id="collapse-20"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-20"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        <p>
+                            {% trans "Some research groups provide gift cards or other compensation for completing their studies, and others rely on volunteers. (This often depends on the rules of the university that's doing the research.) This information will be listed on the study description page." %}
+                        </p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-21">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-21"
-                        aria-expanded="false"
-                        aria-controls="collapse-21">
-                    {% trans "Can I learn the results of the research my child does?" %}
-                </button>
-            </h2>
-            <div id="collapse-21"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-21"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-21">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-21"
+                            aria-expanded="false"
+                            aria-controls="collapse-21">
+                        {% trans "Can I learn the results of the research my child does?" %}
+                    </button>
+                </h2>
+                <div id="collapse-21"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-21"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>You should expect to get an explanation about the purpose of every study you participate in when you consent to the study. At the end of the study, especially when it is a video chat, you should have a chance to ask any questions you like.</p>
                 <p>In general though, the goal of research studies is to learn about children in general, not any particular child. Thus, the information we get is usually not appropriate for making diagnoses or assessing the performance of individuals. For instance, while it might be interesting to learn that your child looked 70% of the time at videos where things fell up versus falling down today, we won't be able to tell you whether this means your child is going to be especially good at physics.</p>
                 <p>If you're interested in getting individual results right away, please see our <a href='resources'>Resources</a> section for fun at-home activities you can try with your child.</p>
                 <p>Researchers usually aim to share the general results of studies in scientific journals (e.g., “The majority of three-year-olds chose option A; the majority of five-year-olds chose option B."). You can click <a href = "https://childrenhelpingscience.com/publications">here</a> to see some examples of scientific research published with data collected online with children.</p>
                 <p>There can be a long lag between conducting a study and publication -- your five-year-olds might be eight-year-olds before the results are in press! So in addition to scientific publications, many of the labs that post studies on this website have ways for parents to sign up to receive updates. You can also set your communication preferences to be notified by Lookit when we have results from studies you participated in.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-22">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-22"
-                        aria-expanded="false"
-                        aria-controls="collapse-22">
-                    {% trans "I love this. How do I share this site?" %}
-                </button>
-            </h2>
-            <div id="collapse-22"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-22"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-22">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-22"
+                            aria-expanded="false"
+                            aria-controls="collapse-22">
+                        {% trans "I love this. How do I share this site?" %}
+                    </button>
+                </h2>
+                <div id="collapse-22"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-22"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Become a parent ambassador! One of the biggest challenges in developmental research is reaching families like you. With more children, we can also answer more sophisticated questions -- including questions about individual differences, the ways many different factors can interact to affect outcomes. Families like yours can help us make our science more representative and more reliable. </p>
                 <p>If you like what you are doing, please share this website (<a href = "https://lookit.mit.edu">https://lookit.mit.edu</a>), with our sincere thanks. Research on child development would be impossible without the support of parents like you.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-23">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-23"
-                        aria-expanded="false"
-                        aria-controls="collapse-23">
-                    {% trans "What is the Parent Researcher Collaborative (PaRC)?" %}
-                </button>
-            </h2>
-            <div id="collapse-23"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-23"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-23">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-23"
+                            aria-expanded="false"
+                            aria-controls="collapse-23">
+                        {% trans "What is the Parent Researcher Collaborative (PaRC)?" %}
+                    </button>
+                </h2>
+                <div id="collapse-23"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-23"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>If you are a parent who has participated with your child in a study on this website, or a university-based researcher who has posted a study on this website, then we consider you a member of the Parent Researcher Collaborative!</p>
                 <p>If you are asking who runs this website, the answer is that we are a collaboration between two projects for online studies with children, Lookit and Children Helping Science. Lookit was founded by <a href = "https://kimberscott.github.io/">Kim Scott</a> and <a href = "http://eccl.mit.edu/">Laura Schulz</a> at MIT, and is now lead by Executive Director <a href = "http://www.melissaklinestruhl.com/">Melissa Kline Struhl</a>.  The original Children Helping Science website was created by <a href = "https://projects.iq.harvard.edu/ccdlab">Elizabeth Bonawitz</a> at Harvard, <a href = "http://sll.stanford.edu/">Hyowon Gweon</a> at Stanford, <a href = "https://compdevlab.yale.edu/">Julian Jara-Ettinger</a> at Yale, <a href = "https://www.utdallas.edu/thinklab/">Candice Mills</a> at UT Dallas, <a href = "http://eccl.mit.edu/">Laura Schulz</a> at MIT, and <a href = "https://www.minerva.kgi.edu/people/mark-sheskin-phd/">Mark Sheskin</a> at Minerva University. Mark did the web development (based on an initial design by Junyi Chu, a student in Laura's lab) and the logo was designed by Natalia Vélez, a student in Hyowon's lab. </p>
                 <p>We decided it would be nice for there to be one place online where parents and researchers could go to connect with each other to support research into child development!</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-24">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-24"
-                        aria-expanded="false"
-                        aria-controls="collapse-24">
-                    {% trans "How can I contact you?" %}
-                </button>
-            </h2>
-            <div id="collapse-24"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-24"
-                 data-bs-parent="#faq-accordion-participation">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-24">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-24"
+                            aria-expanded="false"
+                            aria-controls="collapse-24">
+                        {% trans "How can I contact you?" %}
+                    </button>
+                </h2>
+                <div id="collapse-24"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-24"
+                     data-bs-parent="#faq-accordion-participation">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>For information about individual studies, please see the "study details" page, which will always include contact information for the lab running that study. </p>
                 <p>If you want to get in touch with the researchers organizing this website, you can reach us by email at <a href="mailto:lookit@mit.edu">lookit@mit.edu</a>.</p>
                 <p>To report any technical difficulties during participation, please contact our team by email at <a href="mailto:lookit-tech@mit.edu">lookit@mit.edu</a>.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-    <h3 class="m-4">{% trans "Technical" %}</h3>
-    <div class="accordion m-4" id="faq-accordion-technical">
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-25">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-25"
-                        aria-expanded="false"
-                        aria-controls="collapse-25">
-                    {% trans "What browsers are supported?" %}
-                </button>
-            </h2>
-            <div id="collapse-25"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-25"
-                 data-bs-parent="#faq-accordion-technical">
-                <div class="accordion-body">
-                    <p>
-                        {% trans "Lookit supports recent versions of Chrome and Firefox. We are not currently able to support Internet Explorer or Safari." %}
-                    </p>
+        <h3 class="m-4">
+            {% trans "Technical" %}
+        </h3>
+        <div class="accordion m-4" id="faq-accordion-technical">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-25">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-25"
+                            aria-expanded="false"
+                            aria-controls="collapse-25">
+                        {% trans "What browsers are supported?" %}
+                    </button>
+                </h2>
+                <div id="collapse-25"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-25"
+                     data-bs-parent="#faq-accordion-technical">
+                    <div class="accordion-body">
+                        <p>
+                            {% trans "Lookit supports recent versions of Chrome and Firefox. We are not currently able to support Internet Explorer or Safari." %}
+                        </p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-26">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-26"
-                        aria-expanded="false"
-                        aria-controls="collapse-26">
-                    {% trans "Can we do a study on my phone or tablet?" %}
-                </button>
-            </h2>
-            <div id="collapse-26"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-26"
-                 data-bs-parent="#faq-accordion-technical">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-26">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-26"
+                            aria-expanded="false"
+                            aria-controls="collapse-26">
+                        {% trans "Can we do a study on my phone or tablet?" %}
+                    </button>
+                </h2>
+                <div id="collapse-26"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-26"
+                     data-bs-parent="#faq-accordion-technical">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Most studies require a laptop or desktop with a webcam. Because we're measuring kids' looking patterns, we need a reasonably stable view of their eyes and a big enough screen that we can tell whether they're looking at the left or the right side of it. We're excited about the potential for touchscreen studies that allow us to observe infants and toddlers exploring, though!</p>
                 <p>Some studies, especially surveys meant for older children and teens, may work on your phone or tablet - the study description should mention this if so.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-27">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-27"
-                        aria-expanded="false"
-                        aria-controls="collapse-27">
-                    {% trans "My study isn't working, what can I do?" %}
-                </button>
-            </h2>
-            <div id="collapse-27"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-27"
-                 data-bs-parent="#faq-accordion-technical">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-27">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-27"
+                            aria-expanded="false"
+                            aria-controls="collapse-27">
+                        {% trans "My study isn't working, what can I do?" %}
+                    </button>
+                </h2>
+                <div id="collapse-27"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-27"
+                     data-bs-parent="#faq-accordion-technical">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>If you are trying to participate in a study and having difficulties, please start by contacting the researchers who made that specific study.  If you still need help, you can also reach the Lookit team for help at <a href="mailto:lookit-tech@mit.edu">lookit-tech@mit.edu</a>.</p>
                 <p>If you are a researcher working on creating a study, you can find help in our <a href="https://lookit.readthedocs.io/en/develop/index.html">documentation</a>, and in our <a href = "https://docs.google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/viewform">Slack community</a>.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-28">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-28"
-                        aria-expanded="false"
-                        aria-controls="collapse-28">
-                    {% trans "What security measures do you implement?" %}
-                </button>
-            </h2>
-            <div id="collapse-28"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-28"
-                 data-bs-parent="#faq-accordion-technical">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-28">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-28"
+                            aria-expanded="false"
+                            aria-controls="collapse-28">
+                        {% trans "What security measures do you implement?" %}
+                    </button>
+                </h2>
+                <div id="collapse-28"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-28"
+                     data-bs-parent="#faq-accordion-technical">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Here at Lookit we are very concerned about protecting your and your children's data, and our software is designed to take advantage of up-to-date security measures. You can read a bit about how we do this in our <a href = "https://lookit.readthedocs.io/en/develop/community-irb-and-legal-information.html#sub-processors-and-information-about-gdpr-compliance-dpas">documentation</a>, and an updated HECVAT is available by emailing <a href="mailto:lookit@mit.edu">lookit@mit.edu</a>.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-    <h3 class="m-4">{% trans "For Researchers" %}</h3>
-    <div class="accordion m-4" id="faq-accordion-for-researchers">
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-29">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-29"
-                        aria-expanded="false"
-                        aria-controls="collapse-29">
-                    {% trans "How can I list my study?" %}
-                </button>
-            </h2>
-            <div id="collapse-29"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-29"
-                 data-bs-parent="#faq-accordion-for-researchers">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+        <h3 class="m-4">
+            {% trans "For Researchers" %}
+        </h3>
+        <div class="accordion m-4" id="faq-accordion-for-researchers">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-29">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-29"
+                            aria-expanded="false"
+                            aria-controls="collapse-29">
+                        {% trans "How can I list my study?" %}
+                    </button>
+                </h2>
+                <div id="collapse-29"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-29"
+                     data-bs-parent="#faq-accordion-for-researchers">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>In order to list your study on this website, you first will need to have your institution sign a contract with MIT where they agree to the <a href="https://lookit.mit.edu/termsofuse">Terms of Use</a> and certify that their studies will be reviewed and approved by an institutional review board. You will also need to edit your IRB protocol to include online testing, or submit a new protocol for your proposed online study.</p>
                 <p>As of January 2022, we have agreements with over 50 universities, including institutions in the United States, Canada, the United Kingdom, and European Union. Please email <a href="mailto:lookit-tech@mit.edu">lookit@mit.edu</a> if you are not sure whether your institution already has an agreement, or if you need any help at all getting your paperwork in order.</p>
                 <p>While you are completing these steps, you can get started on Lookit by creating a lab account, creating your first study, and getting it peer reviewed by our researcher community. A step-by-step guide to getting started is available <a href="https://lookit.readthedocs.io/en/develop/researchers-start-here.html">here</a>.</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="accordion-item">
-            <h2 class="accordion-header" id="heading-30">
-                <button class="accordion-button collapsed"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-30"
-                        aria-expanded="false"
-                        aria-controls="collapse-30">
-                    {% trans "Where can I discuss best practices for online research with other researchers?" %}
-                </button>
-            </h2>
-            <div id="collapse-30"
-                 class="accordion-collapse collapse"
-                 aria-labelledby="heading-30"
-                 data-bs-parent="#faq-accordion-for-researchers">
-                <div class="accordion-body">
-                    {% blocktranslate %}
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="heading-30">
+                    <button class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-30"
+                            aria-expanded="false"
+                            aria-controls="collapse-30">
+                        {% trans "Where can I discuss best practices for online research with other researchers?" %}
+                    </button>
+                </h2>
+                <div id="collapse-30"
+                     class="accordion-collapse collapse"
+                     aria-labelledby="heading-30"
+                     data-bs-parent="#faq-accordion-for-researchers">
+                    <div class="accordion-body">
+                        {% blocktranslate %}
                 <p>Lookit has a <a href = "https://docs.google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/viewform">Slack community</a> for researchers to ask for help, conduct peer review, and discuss online research methods.</p>
                 <p>The Society for Research in Child Development also has a <a href = "https://commons.srcd.org/communities/community-home/digestviewer/viewthread?CommunityKey=bd3d326e-b7db-49bf-abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-b8e4-54ecda9de9d8&ReturnUrl=%2Fcommunities%2Fcommunity-home%2Fdigestviewer%3Fcommunitykey%3Dbd3d326e-b7db-49bf-abbb-73642ac0576c%26tab%3Ddigestviewer&tab=digestviewer">discussion forum</a> you might check out!</p>
                 {% endblocktranslate %}
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 {% endblock content %}
 {% block footer %}
     {% include 'web/_footer.html' %}

--- a/web/templates/web/privacy.html
+++ b/web/templates/web/privacy.html
@@ -1,241 +1,269 @@
-{% extends "web/default.html" %}
+{% extends "web/base.html" %}
 {% load django_bootstrap5 %}
 {% load i18n %}
 {% block title %}
     Privacy
 {% endblock title %}
 {% block content %}
-    <div class="main">
-        <div class="lookit-row lookit-page-title">
-            <div class="container">
-                <h2>{% trans "Privacy statement" %}</h2>
-            </div>
-        </div>
-        <div class="lookit-row policy">
-            <div class="container">
-                <h2>{% trans "Introduction" %}</h2>
-                <p>
-                    {% blocktranslate %}Lookit is committed to supporting the privacy of individuals who enroll on our Platform to conduct
-                research or serve as research subjects. This Privacy Statement explains how we handle and use the
-personal information we collect about our researchers and research participant community.{% endblocktranslate %}
-                </p>
-                <h2>{% trans "For participants" %}</h2>
-                <p>
-                    {% blocktranslate %}Lookit is a platform that many different researchers use to conduct studies about how children learn and
-                develop. It is run by the MIT Early Childhood Cognition Lab, which has access to all of the data
-                collected on Lookit. Researchers using Lookit to conduct studies only access your personal information
-if you choose to participate in their study.{% endblocktranslate %}
-                </p>
-                <h3>{% trans "What personal information we collect" %}</h3>
-                <p>
-                    {% trans "We collect the following kinds of personal information:" %}
-                </p>
-                {% blocktranslate %}<ul>
-                <li>Account data: basic contact information that may include your email address, nickname, mailing
-                    address, and contact preferences.</li>
-                <li>Child data: basic biographical information about your child(ren), including nickname, date of birth,
-                    and gestational age at birth.</li>
-                <li>Demographic data: background and biographical information such as your native language, race, age,
-                    educational background, and family history of particular medical conditions.</li>
-                <li>Study data: responses collected during particular studies conducted on Lookit, including webcam
-                    video of your family participating in the study, text entered in forms, the particular images that
-                    were shown, the timing of progression through the study, etc.</li>
-</ul>{% endblocktranslate %}
-                <h3>{% trans "How we collect personal information about you" %}</h3>
-                <p>
-                    {% blocktranslate %}The information we collect and maintain about you is the information you provide to us when registering
-                for a Lookit account, registering your children, updating your account or your children’s profiles,
-                completing or updating surveys, or participating in individual Lookit studies.{% endblocktranslate %}
-                </p>
-                <h3>{% trans "When we share your personal information" %}</h3>
-                <p>
-                    {% trans "When you participate in a Lookit study, we share the following information with the research group conducting the study:" %}
-                </p>
-                {% blocktranslate %}
-            <ul>
-                <li>Your account data</li>
-                <li>The child data for the child who is participating</li>
-                <li>Your demographic data</i>
-                <li>The study data for this particular study session</li>
-            </ul>{% endblocktranslate %}
-                <p>
-                    {% trans "Your email address is not shared directly with the research group, although they can contact you via Lookit in accordance with your contact preferences." %}
-                </p>
-                <p>
-                    {% blocktranslate %}Researchers may publish the results of a study, including individual responses. However, although they
-                may publish the ages of participants, they may not publish participant birthdates (or information that
-could be used to calculate birthdates).{% endblocktranslate %}
-                </p>
-                <p>
-                    {% blocktranslate %}We and/or the researchers responsible for a study may share video of your family’s participation for
-                scientific, educational, and/or publicity purposes, but only if you choose at the conclusion of a study
-                to allow such usage. Researchers may also share your video and other data with Databrary if you choose
-                at the conclusion of a study to allow that. We don’t publish video of participants such that it can be
-                linked to individual demographic data (e.g., household income or number of parents/guardians), and
-researchers must also agree not to do so in order to use Lookit.{% endblocktranslate %}
-                </p>
-                <p>
-                    {% blocktranslate %}We don’t share, sell, publish, or otherwise disclose your contact information (email and/or mailing
-                address) to anyone but the researchers involved in a study. Researchers must also agree not to disclose
-                your contact information in order to use Lookit.{% endblocktranslate %}
-                </p>
-                <h3>{% trans "How we use your personal information" %}</h3>
-                <p>
-                    {% trans "We may use your personal information (account, child, demographic, and study data) for a variety of purposes, including to:" %}
-                </p>
-                {% blocktranslate %}<ul>
-                <li>Provide you with the research studies you have enrolled in, and information about which studies your
-                    children are eligible for</li>
-                <li>Send you information about studies you may be interested in, reminders to participate in multi-part
-                    studies, and/or results of studies you have participated in, subject to your contact preferences
-                </li>
-                <li>Improve the Lookit platform: e.g., detect and fix technical problems or identify new features that
-                    would be helpful</li>
-                <li>Develop data analysis tools for Lookit researchers</li>
-                <li>Provide technical support to study researchers</li>
-                <li>Assess the quality of data collected on the platform (e.g., how well an observer can tell which
-                    direction children are looking)</li>
-                <li>Evaluate recruitment and family engagement efforts (e.g., see how many participants come from rural
-                    vs. urban areas)</li>
-                <li>Recruit participants or researchers to use Lookit (e.g., sharing a short video clip of your child
-                    having fun – ONLY if you have chosen to allow use of the video for publicity)</li>
-            </ul>
-{% endblocktranslate %}
-                <p>
-                    {% blocktranslate %}Researchers use the data collected in their studies to address particular scientific questions. It may
-                also turn out that data collected for one study can help to answer a related question later on. If
-                researchers are using any additional information about you in their study, beyond what is collected on
-                Lookit – for instance, if you are participating in a follow-up online session for an in-person study –
-                they must tell you that in the study consent form.{% endblocktranslate %}
-                </p>
-                <p>
-                    {% trans "There are some basic rules about how personal information may be used that all Lookit researchers agree to, including:" %}
-                </p>
-                {% blocktranslate %}
-            <ul>
-                <li>They may not use usernames, child nicknames, or contact information as a subject of research.</li>
-                <li>They may contact families by postal mail only in order to send compensation for study participation
-                    or materials needed for participation.</li>
-            </ul>
-            {% endblocktranslate %}
-                <p>
-                    {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
-                dataprotection@mit.edu. We will always respect a request by you to stop processing your personal
-                information (subject to our legal obligations).{% endblocktranslate %}
-                </p>
-                <h3>{% trans "How your information is stored and secured" %}</h3>
-                <p>
-                    {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
-                that you may provide. We also periodically monitor our system for possible vulnerabilities and attacks,
-                consistent with industry standards. Only authenticated users with specific permissions may access the
-                data. All data is transmitted via a secure https connection, and all video data is encrypted at rest on
-                the storage systems used by Lookit to provide data to researchers. Researchers are responsible for their
-                own secure storage of data once they obtain it from Lookit. You should be aware, however, that since the
-                internet is not a 100% secure environment, there’s no guarantee that information may not be accessed,
-                disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial safeguards.
-                It's your responsibility to protect the security of your account details, including your username and
-                password.{% endblocktranslate %}
-                </p>
-                <h3>{% trans "How long we keep your personal information" %}</h3>
-                <p>
-                    {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
-                a record for you until such time as you tell us that you no longer wish us to keep in touch. If you wish
-                to remove your account, we will retain a core set of information about you to fulfill administrative
-                tasks and legal obligations. If you have participated in Lookit studies, the personal information
-                already shared with those researchers may not generally be ‘taken back,’ as it is part of a scientific
-dataset and removing your data could affect already published findings.{% endblocktranslate %}
-                </p>
-                <h2>{% trans "For researchers" %}</h2>
-                <h3>{% trans "What personal information we collect" %}</h3>
-                <p>
-                    {% blocktranslate %}We may collect basic biographic/contact information about you and your representative organization,
-including name, title, business addresses, phone numbers, and email addresses.{% endblocktranslate %}
-                </p>
-                <h3>{% trans "How we collect personal information about you" %}</h3>
-                <p>
-                    {% blocktranslate %}The information we collect and maintain about you is that which you have provided to us when registering
-                to use Lookit, updating your profile, or creating or editing a study.{% endblocktranslate %}
-                </p>
-                <h3>{% trans "How we use your personal information" %}</h3>
-                <p>
-                    {% trans "We use your personal information for a number of legitimate purposes, including the performance of contractual obligations. Specifically, we use your personal information to:" %}
-                </p>
-                {% blocktranslate %}<ul>
-                <li>Provide you with the research services for which you have enrolled.</li>
-                <li>Perform administrative tasks and for internal record keeping purposes.</li>
-                <li>Create and analyze aggregated (fully anonymized) information about our users for statistical
-                    research purposes in support of our mission.</li>
-            </ul>
-{% endblocktranslate %}
-                <p>
-                    {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
-                dataprotection@mit.edu. We will always respect a request by you to stop processing your personal
-                information (subject to our legal obligations).{% endblocktranslate %}
-                </p>
-                <h3>{% trans "When we share your personal information" %}</h3>
-                <p>
-                    {% trans "We do not share your personal information with any third parties." %}
-                </p>
-                <h3>{% trans "How your information is stored and secured" %}</h3>
-                <p>
-                    {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
-                that you may provide. We also periodically monitor our system for possible vulnerabilities and attacks,
-                consistent with industry standards. Only authenticated users with specific permissions may access the
-                data. All data is transmitted via a secure https connection. You should be aware, however, that since
-                the internet is not a 100% secure environment, there’s no guarantee that information may not be
-                accessed, disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial
-                safeguards. It's your responsibility to protect the security of your account details, including your
-                username and password.{% endblocktranslate %}
-                </p>
-                <h3>{% trans "How long we keep your personal information" %}</h3>
-                <p>
-                    {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
-                a record for you until such time as you tell us that you no longer wish us to keep in touch. If you no
-                longer wish to hear from Lookit, we will retain a core set of information about you to fulfill
-                administrative tasks and legal obligations.{% endblocktranslate %}
-                </p>
-                <h2>{% trans "For everyone" %}</h2>
-                <h3>{% trans "Rights for individuals in the European Economic Area" %}</h3>
-                <p>
-                    {% blocktranslate %}You have the right in certain circumstances to (1) access your personal information; (2) to correct or
-                erase information; (3) restrict processing; and (4) object to communications, direct marketing, or
-                profiling. To the extent applicable, the EU’s General Data Protection Regulation provides further
-                information about your rights. You also have the right to lodge complaints with your national or
-                regional data protection authority.{% endblocktranslate %}
-                </p>
-                <p>
-                    {% blocktranslate %}If you are inclined to exercise these rights, we request an opportunity to discuss with you any concerns
-                you may have. To protect the personal information we hold, we may also request further information to
-                verify your identify when exercising these rights. Upon a request to erase information, we will maintain
-                a core set of personal data to ensure we do not contact you inadvertently in the future, as well as any
-                information necessary for archival purposes. We may also need to retain some financial information for
-                legal purposes, including US IRS compliance. In the event of an actual or threatened legal claim, we may
-                retain your information for purposes of establishing, defending against or exercising our rights with
-                respect to such claim.{% endblocktranslate %}
-                </p>
-                <p>
-                    {% blocktranslate %}By providing information directly to Lookit, you consent to the transfer of your personal information
-                outside of the European Economic Area to the United States. You understand that the current laws and
-                regulations of the United States may not provide the same level of protection as the data and privacy
-                laws and regulations of the EEA.{% endblocktranslate %}
-                </p>
-                <p>
-                    {% trans "You are under no statutory or contractual obligation to provide any personal data to us." %}
-                </p>
-                <h3>
-                    {% trans "Additional Information" %}
-                </h3>
-                <p>
-                    {% blocktranslate %}We may change this Privacy Statement from time to time. If we make any significant changes in the way we
-                treat your personal information we will make this clear on our website or by contacting you directly.{% endblocktranslate %}
-                </p>
-                <p>
-                    {% trans "The controller for your personal information is MIT. We can be contacted at dataprotection@mit.edu." %}
-                </p>
-                <p class="last-update">
-                    {% trans "This policy was last updated in June 2018." %}
-                </p>
-            </div>
-        </div>
+<div class="container m-4">
+    <h2 class="mx-4 my-5">{% trans "Privacy statement" %}</h2>
+    <h2 class="m-4">{% trans "Introduction" %}</h2>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}Lookit is committed to supporting the privacy of individuals who enroll on our Platform to conduct
+        research or serve as research subjects. This Privacy Statement explains how we handle and use the
+    personal information we collect about our researchers and research participant community.{% endblocktranslate %}
+        </p>
     </div>
+    <h2 class="m-4">{% trans "For participants" %}</h2>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}Lookit is a platform that many different researchers use to conduct studies about how children learn and
+        develop. It is run by the MIT Early Childhood Cognition Lab, which has access to all of the data
+        collected on Lookit. Researchers using Lookit to conduct studies only access your personal information
+    if you choose to participate in their study.{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "We collect the following kinds of personal information:" %}
+        </p>
+    </div>
+    <div class="m-4">
+        {% blocktranslate %}<ul>
+        <li>Account data: basic contact information that may include your email address, nickname, mailing
+            address, and contact preferences.</li>
+        <li>Child data: basic biographical information about your child(ren), including nickname, date of birth,
+            and gestational age at birth.</li>
+        <li>Demographic data: background and biographical information such as your native language, race, age,
+            educational background, and family history of particular medical conditions.</li>
+        <li>Study data: responses collected during particular studies conducted on Lookit, including webcam
+            video of your family participating in the study, text entered in forms, the particular images that
+            were shown, the timing of progression through the study, etc.</li>
+        </ul>{% endblocktranslate %}
+    </div>
+    <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}The information we collect and maintain about you is the information you provide to us when registering
+        for a Lookit account, registering your children, updating your account or your children’s profiles,
+        completing or updating surveys, or participating in individual Lookit studies.{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "When we share your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "When you participate in a Lookit study, we share the following information with the research group conducting the study:" %}
+        </p>
+    </div>
+    <div class="m-4">
+        {% blocktranslate %}
+        <ul>
+            <li>Your account data</li>
+            <li>The child data for the child who is participating</li>
+            <li>Your demographic data</i>
+            <li>The study data for this particular study session</li>
+        </ul>{% endblocktranslate %}
+        <p>
+            {% trans "Your email address is not shared directly with the research group, although they can contact you via Lookit in accordance with your contact preferences." %}
+        </p>
+        <p>
+            {% blocktranslate %}Researchers may publish the results of a study, including individual responses. However, although they
+        may publish the ages of participants, they may not publish participant birthdates (or information that
+    could be used to calculate birthdates).{% endblocktranslate %}
+        </p>
+        <p>
+            {% blocktranslate %}We and/or the researchers responsible for a study may share video of your family’s participation for
+        scientific, educational, and/or publicity purposes, but only if you choose at the conclusion of a study
+        to allow such usage. Researchers may also share your video and other data with Databrary if you choose
+        at the conclusion of a study to allow that. We don’t publish video of participants such that it can be
+        linked to individual demographic data (e.g., household income or number of parents/guardians), and
+    researchers must also agree not to do so in order to use Lookit.{% endblocktranslate %}
+        </p>
+        <p>
+            {% blocktranslate %}We don’t share, sell, publish, or otherwise disclose your contact information (email and/or mailing
+        address) to anyone but the researchers involved in a study. Researchers must also agree not to disclose
+        your contact information in order to use Lookit.{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "We may use your personal information (account, child, demographic, and study data) for a variety of purposes, including to:" %}
+        </p>
+        {% blocktranslate %}<ul>
+        <li>Provide you with the research studies you have enrolled in, and information about which studies your
+            children are eligible for</li>
+        <li>Send you information about studies you may be interested in, reminders to participate in multi-part
+            studies, and/or results of studies you have participated in, subject to your contact preferences
+        </li>
+        <li>Improve the Lookit platform: e.g., detect and fix technical problems or identify new features that
+            would be helpful</li>
+        <li>Develop data analysis tools for Lookit researchers</li>
+        <li>Provide technical support to study researchers</li>
+        <li>Assess the quality of data collected on the platform (e.g., how well an observer can tell which
+            direction children are looking)</li>
+        <li>Evaluate recruitment and family engagement efforts (e.g., see how many participants come from rural
+            vs. urban areas)</li>
+        <li>Recruit participants or researchers to use Lookit (e.g., sharing a short video clip of your child
+            having fun – ONLY if you have chosen to allow use of the video for publicity)</li>
+        </ul>
+        {% endblocktranslate %}
+            <p>
+                {% blocktranslate %}Researchers use the data collected in their studies to address particular scientific questions. It may
+            also turn out that data collected for one study can help to answer a related question later on. If
+            researchers are using any additional information about you in their study, beyond what is collected on
+            Lookit – for instance, if you are participating in a follow-up online session for an in-person study –
+            they must tell you that in the study consent form.{% endblocktranslate %}
+            </p>
+            <p>
+                {% trans "There are some basic rules about how personal information may be used that all Lookit researchers agree to, including:" %}
+            </p>
+        {% blocktranslate %}
+        <ul>
+            <li>They may not use usernames, child nicknames, or contact information as a subject of research.</li>
+            <li>They may contact families by postal mail only in order to send compensation for study participation
+                or materials needed for participation.</li>
+        </ul>
+        {% endblocktranslate %}
+        <p>
+            {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
+        dataprotection@mit.edu. We will always respect a request by you to stop processing your personal
+        information (subject to our legal obligations).{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How your information is stored and secured" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
+        that you may provide. We also periodically monitor our system for possible vulnerabilities and attacks,
+        consistent with industry standards. Only authenticated users with specific permissions may access the
+        data. All data is transmitted via a secure https connection, and all video data is encrypted at rest on
+        the storage systems used by Lookit to provide data to researchers. Researchers are responsible for their
+        own secure storage of data once they obtain it from Lookit. You should be aware, however, that since the
+        internet is not a 100% secure environment, there’s no guarantee that information may not be accessed,
+        disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial safeguards.
+        It's your responsibility to protect the security of your account details, including your username and
+        password.{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How long we keep your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
+        a record for you until such time as you tell us that you no longer wish us to keep in touch. If you wish
+        to remove your account, we will retain a core set of information about you to fulfill administrative
+        tasks and legal obligations. If you have participated in Lookit studies, the personal information
+        already shared with those researchers may not generally be ‘taken back,’ as it is part of a scientific
+    dataset and removing your data could affect already published findings.{% endblocktranslate %}
+        </p>
+    </div>
+    <h2 class="m-4">{% trans "For researchers" %}</h2>
+    <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We may collect basic biographic/contact information about you and your representative organization,
+    including name, title, business addresses, phone numbers, and email addresses.{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}The information we collect and maintain about you is that which you have provided to us when registering
+        to use Lookit, updating your profile, or creating or editing a study.{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "We use your personal information for a number of legitimate purposes, including the performance of contractual obligations. Specifically, we use your personal information to:" %}
+        </p>
+        {% blocktranslate %}<ul>
+            <li>Provide you with the research services for which you have enrolled.</li>
+            <li>Perform administrative tasks and for internal record keeping purposes.</li>
+            <li>Create and analyze aggregated (fully anonymized) information about our users for statistical
+                research purposes in support of our mission.</li>
+        </ul>
+        {% endblocktranslate %}
+        <p>
+            {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
+        dataprotection@mit.edu. We will always respect a request by you to stop processing your personal
+        information (subject to our legal obligations).{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "When we share your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "We do not share your personal information with any third parties." %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How your information is stored and secured" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
+        that you may provide. We also periodically monitor our system for possible vulnerabilities and attacks,
+        consistent with industry standards. Only authenticated users with specific permissions may access the
+        data. All data is transmitted via a secure https connection. You should be aware, however, that since
+        the internet is not a 100% secure environment, there’s no guarantee that information may not be
+        accessed, disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial
+        safeguards. It's your responsibility to protect the security of your account details, including your
+        username and password.{% endblocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How long we keep your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
+        a record for you until such time as you tell us that you no longer wish us to keep in touch. If you no
+        longer wish to hear from Lookit, we will retain a core set of information about you to fulfill
+        administrative tasks and legal obligations.{% endblocktranslate %}
+        </p>
+    </div>
+    <h2 class="m-4">{% trans "For everyone" %}</h2>
+    <h3 class="m-4">{% trans "Rights for individuals in the European Economic Area" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}You have the right in certain circumstances to (1) access your personal information; (2) to correct or
+        erase information; (3) restrict processing; and (4) object to communications, direct marketing, or
+        profiling. To the extent applicable, the EU’s General Data Protection Regulation provides further
+        information about your rights. You also have the right to lodge complaints with your national or
+        regional data protection authority.{% endblocktranslate %}
+        </p>
+        <p>
+            {% blocktranslate %}If you are inclined to exercise these rights, we request an opportunity to discuss with you any concerns
+        you may have. To protect the personal information we hold, we may also request further information to
+        verify your identify when exercising these rights. Upon a request to erase information, we will maintain
+        a core set of personal data to ensure we do not contact you inadvertently in the future, as well as any
+        information necessary for archival purposes. We may also need to retain some financial information for
+        legal purposes, including US IRS compliance. In the event of an actual or threatened legal claim, we may
+        retain your information for purposes of establishing, defending against or exercising our rights with
+        respect to such claim.{% endblocktranslate %}
+        </p>
+        <p>
+            {% blocktranslate %}By providing information directly to Lookit, you consent to the transfer of your personal information
+        outside of the European Economic Area to the United States. You understand that the current laws and
+        regulations of the United States may not provide the same level of protection as the data and privacy
+        laws and regulations of the EEA.{% endblocktranslate %}
+        </p>
+        <p>
+            {% trans "You are under no statutory or contractual obligation to provide any personal data to us." %}
+        </p>
+    </div>
+    <h3 class="m-4">
+        {% trans "Additional Information" %}
+    </h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We may change this Privacy Statement from time to time. If we make any significant changes in the way we
+        treat your personal information we will make this clear on our website or by contacting you directly.{% endblocktranslate %}
+        </p>
+        <p>
+            {% trans "The controller for your personal information is MIT. We can be contacted at dataprotection@mit.edu." %}
+        </p>
+        <p class="text-center fst-italic">
+            {% trans "This policy was last updated in June 2018." %}
+        </p>
+    </div>
+</div>
 {% endblock content %}

--- a/web/templates/web/privacy.html
+++ b/web/templates/web/privacy.html
@@ -5,33 +5,33 @@
     Privacy
 {% endblock title %}
 {% block content %}
-<div class="container m-4">
-    <h2 class="mx-4 my-5">{% trans "Privacy statement" %}</h2>
-    <h2 class="m-4">{% trans "Introduction" %}</h2>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}Lookit is committed to supporting the privacy of individuals who enroll on our Platform to conduct
+    <div class="container m-4">
+        <h2 class="mx-4 my-5">{% trans "Privacy statement" %}</h2>
+        <h2 class="m-4">{% trans "Introduction" %}</h2>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}Lookit is committed to supporting the privacy of individuals who enroll on our Platform to conduct
         research or serve as research subjects. This Privacy Statement explains how we handle and use the
     personal information we collect about our researchers and research participant community.{% endblocktranslate %}
-        </p>
-    </div>
-    <h2 class="m-4">{% trans "For participants" %}</h2>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}Lookit is a platform that many different researchers use to conduct studies about how children learn and
+            </p>
+        </div>
+        <h2 class="m-4">{% trans "For participants" %}</h2>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}Lookit is a platform that many different researchers use to conduct studies about how children learn and
         develop. It is run by the MIT Early Childhood Cognition Lab, which has access to all of the data
         collected on Lookit. Researchers using Lookit to conduct studies only access your personal information
     if you choose to participate in their study.{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
-    <div class="m-4">
-        <p>
-            {% trans "We collect the following kinds of personal information:" %}
-        </p>
-    </div>
-    <div class="m-4">
-        {% blocktranslate %}<ul>
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
+        <div class="m-4">
+            <p>
+                {% trans "We collect the following kinds of personal information:" %}
+            </p>
+        </div>
+        <div class="m-4">
+            {% blocktranslate %}<ul>
         <li>Account data: basic contact information that may include your email address, nickname, mailing
             address, and contact preferences.</li>
         <li>Child data: basic biographical information about your child(ren), including nickname, date of birth,
@@ -42,57 +42,57 @@
             video of your family participating in the study, text entered in forms, the particular images that
             were shown, the timing of progression through the study, etc.</li>
         </ul>{% endblocktranslate %}
-    </div>
-    <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}The information we collect and maintain about you is the information you provide to us when registering
+        </div>
+        <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}The information we collect and maintain about you is the information you provide to us when registering
         for a Lookit account, registering your children, updating your account or your children’s profiles,
         completing or updating surveys, or participating in individual Lookit studies.{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "When we share your personal information" %}</h3>
-    <div class="m-4">
-        <p>
-            {% trans "When you participate in a Lookit study, we share the following information with the research group conducting the study:" %}
-        </p>
-    </div>
-    <div class="m-4">
-        {% blocktranslate %}
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "When we share your personal information" %}</h3>
+        <div class="m-4">
+            <p>
+                {% trans "When you participate in a Lookit study, we share the following information with the research group conducting the study:" %}
+            </p>
+        </div>
+        <div class="m-4">
+            {% blocktranslate %}
         <ul>
             <li>Your account data</li>
             <li>The child data for the child who is participating</li>
             <li>Your demographic data</i>
             <li>The study data for this particular study session</li>
         </ul>{% endblocktranslate %}
-        <p>
-            {% trans "Your email address is not shared directly with the research group, although they can contact you via Lookit in accordance with your contact preferences." %}
-        </p>
-        <p>
-            {% blocktranslate %}Researchers may publish the results of a study, including individual responses. However, although they
+            <p>
+                {% trans "Your email address is not shared directly with the research group, although they can contact you via Lookit in accordance with your contact preferences." %}
+            </p>
+            <p>
+                {% blocktranslate %}Researchers may publish the results of a study, including individual responses. However, although they
         may publish the ages of participants, they may not publish participant birthdates (or information that
     could be used to calculate birthdates).{% endblocktranslate %}
-        </p>
-        <p>
-            {% blocktranslate %}We and/or the researchers responsible for a study may share video of your family’s participation for
+            </p>
+            <p>
+                {% blocktranslate %}We and/or the researchers responsible for a study may share video of your family’s participation for
         scientific, educational, and/or publicity purposes, but only if you choose at the conclusion of a study
         to allow such usage. Researchers may also share your video and other data with Databrary if you choose
         at the conclusion of a study to allow that. We don’t publish video of participants such that it can be
         linked to individual demographic data (e.g., household income or number of parents/guardians), and
     researchers must also agree not to do so in order to use Lookit.{% endblocktranslate %}
-        </p>
-        <p>
-            {% blocktranslate %}We don’t share, sell, publish, or otherwise disclose your contact information (email and/or mailing
+            </p>
+            <p>
+                {% blocktranslate %}We don’t share, sell, publish, or otherwise disclose your contact information (email and/or mailing
         address) to anyone but the researchers involved in a study. Researchers must also agree not to disclose
         your contact information in order to use Lookit.{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
-    <div class="m-4">
-        <p>
-            {% trans "We may use your personal information (account, child, demographic, and study data) for a variety of purposes, including to:" %}
-        </p>
-        {% blocktranslate %}<ul>
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
+        <div class="m-4">
+            <p>
+                {% trans "We may use your personal information (account, child, demographic, and study data) for a variety of purposes, including to:" %}
+            </p>
+            {% blocktranslate %}<ul>
         <li>Provide you with the research studies you have enrolled in, and information about which studies your
             children are eligible for</li>
         <li>Send you information about studies you may be interested in, reminders to participate in multi-part
@@ -120,23 +120,23 @@
             <p>
                 {% trans "There are some basic rules about how personal information may be used that all Lookit researchers agree to, including:" %}
             </p>
-        {% blocktranslate %}
+            {% blocktranslate %}
         <ul>
             <li>They may not use usernames, child nicknames, or contact information as a subject of research.</li>
             <li>They may contact families by postal mail only in order to send compensation for study participation
                 or materials needed for participation.</li>
         </ul>
         {% endblocktranslate %}
-        <p>
-            {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
+            <p>
+                {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
         dataprotection@mit.edu. We will always respect a request by you to stop processing your personal
         information (subject to our legal obligations).{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "How your information is stored and secured" %}</h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "How your information is stored and secured" %}</h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
         that you may provide. We also periodically monitor our system for possible vulnerabilities and attacks,
         consistent with industry standards. Only authenticated users with specific permissions may access the
         data. All data is transmitted via a secure https connection, and all video data is encrypted at rest on
@@ -146,62 +146,62 @@
         disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial safeguards.
         It's your responsibility to protect the security of your account details, including your username and
         password.{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "How long we keep your personal information" %}</h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "How long we keep your personal information" %}</h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
         a record for you until such time as you tell us that you no longer wish us to keep in touch. If you wish
         to remove your account, we will retain a core set of information about you to fulfill administrative
         tasks and legal obligations. If you have participated in Lookit studies, the personal information
         already shared with those researchers may not generally be ‘taken back,’ as it is part of a scientific
     dataset and removing your data could affect already published findings.{% endblocktranslate %}
-        </p>
-    </div>
-    <h2 class="m-4">{% trans "For researchers" %}</h2>
-    <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}We may collect basic biographic/contact information about you and your representative organization,
+            </p>
+        </div>
+        <h2 class="m-4">{% trans "For researchers" %}</h2>
+        <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}We may collect basic biographic/contact information about you and your representative organization,
     including name, title, business addresses, phone numbers, and email addresses.{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}The information we collect and maintain about you is that which you have provided to us when registering
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}The information we collect and maintain about you is that which you have provided to us when registering
         to use Lookit, updating your profile, or creating or editing a study.{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
-    <div class="m-4">
-        <p>
-            {% trans "We use your personal information for a number of legitimate purposes, including the performance of contractual obligations. Specifically, we use your personal information to:" %}
-        </p>
-        {% blocktranslate %}<ul>
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
+        <div class="m-4">
+            <p>
+                {% trans "We use your personal information for a number of legitimate purposes, including the performance of contractual obligations. Specifically, we use your personal information to:" %}
+            </p>
+            {% blocktranslate %}<ul>
             <li>Provide you with the research services for which you have enrolled.</li>
             <li>Perform administrative tasks and for internal record keeping purposes.</li>
             <li>Create and analyze aggregated (fully anonymized) information about our users for statistical
                 research purposes in support of our mission.</li>
         </ul>
         {% endblocktranslate %}
-        <p>
-            {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
+            <p>
+                {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
         dataprotection@mit.edu. We will always respect a request by you to stop processing your personal
         information (subject to our legal obligations).{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "When we share your personal information" %}</h3>
-    <div class="m-4">
-        <p>
-            {% trans "We do not share your personal information with any third parties." %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "How your information is stored and secured" %}</h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "When we share your personal information" %}</h3>
+        <div class="m-4">
+            <p>
+                {% trans "We do not share your personal information with any third parties." %}
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "How your information is stored and secured" %}</h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
         that you may provide. We also periodically monitor our system for possible vulnerabilities and attacks,
         consistent with industry standards. Only authenticated users with specific permissions may access the
         data. All data is transmitted via a secure https connection. You should be aware, however, that since
@@ -209,29 +209,29 @@
         accessed, disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial
         safeguards. It's your responsibility to protect the security of your account details, including your
         username and password.{% endblocktranslate %}
-        </p>
-    </div>
-    <h3 class="m-4">{% trans "How long we keep your personal information" %}</h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
+            </p>
+        </div>
+        <h3 class="m-4">{% trans "How long we keep your personal information" %}</h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
         a record for you until such time as you tell us that you no longer wish us to keep in touch. If you no
         longer wish to hear from Lookit, we will retain a core set of information about you to fulfill
         administrative tasks and legal obligations.{% endblocktranslate %}
-        </p>
-    </div>
-    <h2 class="m-4">{% trans "For everyone" %}</h2>
-    <h3 class="m-4">{% trans "Rights for individuals in the European Economic Area" %}</h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}You have the right in certain circumstances to (1) access your personal information; (2) to correct or
+            </p>
+        </div>
+        <h2 class="m-4">{% trans "For everyone" %}</h2>
+        <h3 class="m-4">{% trans "Rights for individuals in the European Economic Area" %}</h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}You have the right in certain circumstances to (1) access your personal information; (2) to correct or
         erase information; (3) restrict processing; and (4) object to communications, direct marketing, or
         profiling. To the extent applicable, the EU’s General Data Protection Regulation provides further
         information about your rights. You also have the right to lodge complaints with your national or
         regional data protection authority.{% endblocktranslate %}
-        </p>
-        <p>
-            {% blocktranslate %}If you are inclined to exercise these rights, we request an opportunity to discuss with you any concerns
+            </p>
+            <p>
+                {% blocktranslate %}If you are inclined to exercise these rights, we request an opportunity to discuss with you any concerns
         you may have. To protect the personal information we hold, we may also request further information to
         verify your identify when exercising these rights. Upon a request to erase information, we will maintain
         a core set of personal data to ensure we do not contact you inadvertently in the future, as well as any
@@ -239,31 +239,31 @@
         legal purposes, including US IRS compliance. In the event of an actual or threatened legal claim, we may
         retain your information for purposes of establishing, defending against or exercising our rights with
         respect to such claim.{% endblocktranslate %}
-        </p>
-        <p>
-            {% blocktranslate %}By providing information directly to Lookit, you consent to the transfer of your personal information
+            </p>
+            <p>
+                {% blocktranslate %}By providing information directly to Lookit, you consent to the transfer of your personal information
         outside of the European Economic Area to the United States. You understand that the current laws and
         regulations of the United States may not provide the same level of protection as the data and privacy
         laws and regulations of the EEA.{% endblocktranslate %}
-        </p>
-        <p>
-            {% trans "You are under no statutory or contractual obligation to provide any personal data to us." %}
-        </p>
-    </div>
-    <h3 class="m-4">
-        {% trans "Additional Information" %}
-    </h3>
-    <div class="m-4">
-        <p>
-            {% blocktranslate %}We may change this Privacy Statement from time to time. If we make any significant changes in the way we
+            </p>
+            <p>
+                {% trans "You are under no statutory or contractual obligation to provide any personal data to us." %}
+            </p>
+        </div>
+        <h3 class="m-4">
+            {% trans "Additional Information" %}
+        </h3>
+        <div class="m-4">
+            <p>
+                {% blocktranslate %}We may change this Privacy Statement from time to time. If we make any significant changes in the way we
         treat your personal information we will make this clear on our website or by contacting you directly.{% endblocktranslate %}
-        </p>
-        <p>
-            {% trans "The controller for your personal information is MIT. We can be contacted at dataprotection@mit.edu." %}
-        </p>
-        <p class="text-center fst-italic">
-            {% trans "This policy was last updated in June 2018." %}
-        </p>
+            </p>
+            <p>
+                {% trans "The controller for your personal information is MIT. We can be contacted at dataprotection@mit.edu." %}
+            </p>
+            <p class="text-center fst-italic">
+                {% trans "This policy was last updated in June 2018." %}
+            </p>
+        </div>
     </div>
-</div>
 {% endblock content %}

--- a/web/templates/web/termsofuse.html
+++ b/web/templates/web/termsofuse.html
@@ -1,488 +1,498 @@
-{% extends "web/default.html" %}
+{% extends "web/base.html" %}
 {% load django_bootstrap5 %}
 {% load i18n %}
 {% block title %}
     Terms of Use
 {% endblock title %}
 {% block content %}
-    <section>
-        <article class="row">
-            <div>
-                <div class="main">
-                    <div class="lookit-row lookit-page-title">
-                        <div class="container">
-                            <h2>Terms of Use</h2>
-                        </div>
-                    </div>
-                    <div class="lookit-row policy">
-                        <div class="container">
-                            <p>
-                                Welcome to the Lookit Platform, an online platform for developmental research studies. You
-                                should read and understand these terms and conditions, which govern your use of the Lookit
-                                Platform. Researchers may be especially interested in the sections not in italic when first
-                                learning about the Platform.
-                            </p>
-                            <h3>Overview</h3>
-                            <em>
-                                <p>
-                                    These Terms of Service, with our Privacy Policy, are a resource for you to get a deeper
-                                    understanding of your obligations and rights with respect to the Lookit Platform
-                                    including how we use information and data we collect from you. We may modify these Terms
-                                    of Service from time to time as we deem appropriate, so you should check back in
-                                    frequently to confirm the terms upon which you may use the Lookit Platform. We will
-                                    notify you of any modifications to these Terms by posting them on the Lookit Platform.
-                                    Use of the Lookit Platform after the effective date of the updated Terms constitutes
-                                    your agreement to the updated Terms.
-                                </p>
-                                <p>
-                                    The terms "we", "us" "our" and similar terms refer to Lookit. The terms “you,” “your,”
-                                    “Researcher” and similar terms refer to users of our Platform. The term “Platform”
-                                    refers to the online Lookit Platform. “Terms” or “Agreement” refers to these Terms of
-                                    Service, as may be amended from time to time by us.
-                                </p>
-                            </em>
-                            <p>
-                                A study "posted on Lookit" refers to any study which has been submitted for and received
-                                approval to appear on the Lookit website.
-                            </p>
-                            <p>
-                                A study "conducted on Lookit" refers to studies which, additionally, perform all consent
-                                procedures and data collection without leaving the Lookit web domain.
-                            </p>
-                            <p>
-                                There are several types of data collected on the Lookit Platform. These comprise:
-                            </p>
-                            <ol>
-                                <li>
-                                    Account data: information about a Lookit account holder, representing an adult
-                                    participant or family: e.g., contact information, email preferences
-                                </li>
-                                <li>
-                                    Child data: information about a Lookit participant, representing a child associated with
-                                    a particular Lookit account: e.g., birthdate, gender, gestational age at birth, medical
-                                    diagnoses
-                                </li>
-                                <li>
-                                    Demographic survey data: responses to a demographic survey associated with a Lookit
-                                    account: e.g., approximate geographic location, household income, parental education
-                                </li>
-                                <li>
-                                    Study data, including video: responses collected during a child’s participation in a
-                                    particular Lookit study: webcam video of the child and parent as well as text data
-                                    including form responses, on-screen selections, which stimuli were shown, etc.
-                                </li>
-                            </ol>
-                            <p>
-                                In addition, the term "External data" refers to video, text, or other data, including consent
-                                records, collected from participants in a study posted (but not conducted) on Lookit. this
-                                includes data from studies which are conducted asynchronously on another web platform as
-                                well those which are collected at a scheduled session (online or in person.)
-                            </p>
-                            <em>
-                                <p>
-                                    Other capitalized terms may be defined below in these Terms.
-                                </p>
-                            </em>
-                            <h3>Acceptance of Terms of Service</h3>
-                            <em>
-                                <p>
-                                    These Terms, which include our Privacy Policy, are a binding legal agreement and govern
-                                    your use of the Platform, including all features and functionalities, applications,
-                                    updates, notifications and our user interfaces, and all content and software associated
-                                    therewith. By checking the “I accept the Terms & Conditions” box during the account set
-                                    up or by downloading, using, visiting, or browsing the Platform, you accept and agree to
-                                    be bound by these Terms as amended from time to time. If you do not agree to these
-                                    Terms, you are not authorized to use, and you should not use, the Platform.
-                                </p>
-                            </em>
-                            <h3>Use of the Platform</h3>
-                            <em>
-                                <p>
-                                    Account Registration. In order to use the Platform, you will need to provide to us
-                                    certain basic information such as your name, institution, and email address. You agree
-                                    that all information you provide to us will be complete, true and correct and that you
-                                    will keep it up-to-date. During the registration process, you will choose a user name
-                                    and password for your use of the Platform. You will be responsible for securing your
-                                    user name and password and for all use of the Platform using your email address or
-                                    password. You will be solely liable for any use of the Platform under your account and
-                                    password. You agree to notify us promptly of any unauthorized use or disclosure of your
-                                    password. We reserve the right to refuse use of or revoke use of any username in our
-                                    discretion.
-                                    Basic use of the Platform is offered free of charge. However, we reserve the right to
-                                    establish fees for use of the Platform at any time or to charge additional fees for
-                                    premium services, data access or additional functionality.
-                                </p>
-                                <p>
-                                    Researcher Obligations. Your use of the Platform and of external data generated by Lookit
-                                    participants shall be solely for your own educational and academic use. You will comply
-                                    with all applicable laws in connection with your use of the Platform and resulting
-                                    external data, as well as all applicable policies of your Institution. You will not
-                                    attempt to circumnavigate or violate any security feature of the Platform, including
-                                    accessing any Platform features, interactive areas, information or profiles for which
-                                    you do not have permission or other content or information not intended for you.
-                                </p>
-                            </em>
-                            <p>
-                                All Researchers are responsible for their own use of the Platform, and for their use of
-                                external data generated by Lookit participants. Researchers also assume responsibility for
-                                any adverse events associated with participation in their studies. As part of your use of
-                                the Platform and resulting external data, you agree that you:
-                            </p>
-                            <ol>
-                                <li>
-                                    Will not use account or child nicknames, email addresses, or mailing addresses of Lookit
-                                    participants, accessed via Researchers’ use of the Lookit platform, as a subject of
-                                    research.
-                                </li>
-                                <li>
-                                    Will not share, sell, publish, or otherwise disclose participant contact information
-                                    (email or mailing addresses) obtained as a result of their use of the Lookit platform.
-                                    For instance, participant contact information may not be added to a lab participant
-                                    database that is used for local recruitment.
-                                </li>
-                                <li>
-                                    May contact families by email, through the Lookit Platform, only in accordance with
-                                    those families’ email preferences, and only for communication related to their Lookit
-                                    studies.
-                                </li>
-                                <li>
-                                    May contact families by postal mail only to send payment/prizes for participation or
-                                    materials needed to participate in a study (e.g., a book to read together), and not for
-                                    any other communication.
-                                </li>
-                                <li>
-                                    Subject to any applicable institutional review, may study relationships between the same
-                                    child’s behavior in the same study (some studies may comprise multiple sessions, for
-                                    instance to look at individual differences, test-retest reliability, or the effects of
-                                    an intervention); between the same child’s behavior in different studies run by the
-                                    Researcher; and between siblings’ behavior on the same study or different studies run by
-                                    the Researcher.
-                                </li>
-                                <li>
-                                    Subject to any applicable institutional review, may combine data with another Lookit
-                                    Researcher to examine relationships among the same child’s or siblings’ behavior on
-                                    studies run by the Researcher in conjunction with studies run by another Researcher.
-                                </li>
-                                <li>
-                                    <strong>Will not publish either individual participant birthdates or information that
-                                    could be combined to calculate participant birthdates </strong> (for instance, the
-                                    participant’s age in days at time of testing plus the test date).
-                                </li>
-                                <li>
-                                    May use parent and child nicknames only for communication with participants, and may not
-                                    publish individual child or account nicknames stored in child and account records. Child
-                                    names may be incidentally included in video recordings or parent comments that are
-                                    published, although we encourage researchers to redact child names when possible from
-                                    written comments.
-                                </li>
-                                <li>
-                                    With the exception of linking external data to corresponding Lookit data for studies
-                                    posted on Lookit, will not use video or other data in order to link outside information
-                                    available about a specific participant to an associated child, account, or experimental
-                                    session, without specific IRB approval to do so. Any other planned integration of
-                                    outside data must be reported to Lookit at the time the study is submitted.
-                                </li>
-                                <li>
-                                    <strong>Will not publish the "global ID" fields for account, child, or demographic
-                                    survey records.</strong> These fields can be accessed by all researchers using the
-                                    Lookit platform, so publication could lead to unintentional linkage of data from the
-                                    same individuals. Researchers receive access to the global IDs in case necessary; for
-                                    instance, to facilitate financial record-keeping and any necessary linking of accounts
-                                    and children across studies. The 5-character account, child, and demographic "ID" fields
-                                    provided for download may be published; these are specific to the study. Researchers
-                                    wishing to publish persistent identifiers for data from multiple connected studies must
-                                    either create a table linking IDs across studies, or generate their own random IDs.
-                                </li>
-                                <li>
-                                    <strong>Will not publish video of Lookit participants such that it can be matched with
-                                        individual demographic survey data (e.g., household income, number of
-                                    parents/guardians). </strong>
-                                </li>
-                                <li>
-                                    <strong>Will not collect external data from studies posted on Lookit with the intent to
-                                    circumvent the terms of this agreement.</strong>
-                                </li>
-                            </ol>
-                            <h3>Use and Storage of Data By Lookit and Researchers</h3>
-                            <p>
-                                <em>The following guidelines pertain to the use and storage of Lookit data.</em>
-                            </p>
-                            <ol>
-                                <li>
-                                    Researchers may download local copies of their Lookit data, including study data and
-                                    video, and account, child, and demographic survey data from Lookit participants who have
-                                    participated in their studies. Lookit may also keep copies of this data, including study
-                                    data and video, indefinitely.
-                                </li>
-                                <li>
-                                    Lookit assumes no responsibility for losses incurred by the Researchers in the event
-                                    that data stored by Lookit, including study design information, is lost or corrupted.
-                                </li>
-                                <li>Researchers retain ownership of study data, including video, for their own studies.</li>
-                                <li>
-                                    Lookit retains ownership of account, child, and demographic survey response data
-                                    collected on Lookit.
-                                </li>
-                                <li>
-                                    <strong>Lookit reserves the right to use any data collected on the Lookit platform,
-                                        including account, child, demographic, and study data, for the following purposes:
-                                    </strong>
-                                    <ol>
-                                        <li>
-                                            To improve the Lookit platform: e.g., detect and fix technical problems or
-                                            identify new features that would be helpful
-                                        </li>
-                                        <li>
-                                            To develop data analysis tools for Lookit researchers, including automated gaze
-                                            coding
-                                        </li>
-                                        <li>To provide technical support to study researchers</li>
-                                        <li>
-                                            To assess the quality of data collected on the platform (for instance, how well
-                                            an observer can tell which direction children are looking)
-                                        </li>
-                                        <li>To evaluate recruitment and family engagement efforts</li>
-                                        <li>To recruit participants or researchers to use Lookit</li>
-                                    </ol>
-                                </li>
-                                <li>Lookit may publish the results of the above described methodological research.</li>
-                            </ol>
-                            <h3>Restrictions on Data Collection on Lookit</h3>
-                            <p>
-                                <em>The following guidelines pertain to the use and storage of Lookit data, and apply to all
-                                    studies posted on the Lookit platform, whether they are also conducted there or are
-                                conducted using an external platform or scheduled session.</em>
-                            </p>
-                            <ol>
-                                <li>
-                                    Researchers must provide accurate contact information to be posted along with all
-                                    studies they conduct on Lookit, <strong>and must respond promptly to parent
-                                communication. </strong>
-                            </li>
-                            <li>
-                                Researchers agree to accurately represent the procedures and goals of their studies. In
-                                addition to obtaining approval from any appropriate institutional review board,
-                                researchers agree to notify Lookit of deception involved in any study designs, at the
-                                time the study is submitted for Lookit review. <strong>Deception that must be disclosed
-                                to Lookit includes deliberate omission of information or presentation of any
-                                misleading information to either the parent or the child, either in the course of
-                            the study itself or regarding the study’s purpose and procedures. </strong>Examples
-                            include telling the child that he or she performed better or worse than peers when
-                            children were in fact assigned randomly to receive such feedback; telling a parent that
-                            researchers expect to observe a particular behavior that is not actually expected, in
-                            order to avoid parental bias; or failing to disclose in a study about child-parent
-                            interaction that the researchers are primarily interested in gender differences in
-                            interaction styles.
-                        </li>
-                        <li>
-                            In all study designs, the child must remain in the same room with his or her parent at
-                            all times. No infancy study session (for children 0 - 12 months) may be designed to last
-                            longer than 30 minutes, and no experiment session may be designed to last longer than 90
-                            minutes. Purely observational periods may extend longer if approved by Lookit--for
-                            instance, if the goal of a study is to observe conversation during a family meal or
-                            independent child play.
-                        </li>
-                        <li>
-                            In all study designs, the parent must be able to end the study session at any point.
-                            This functionality is built into Lookit and may not be altered. Equivalent functionality
-                            must be available in any study posted on Lookit and conducted elsewhere. Parents must be
-                            informed of this option at the beginning of every study.
-                        </li>
-                        <li>
-                            Researchers acknowledge that all studies are subject to review and final approval by
-                            Lookit. Lookit reserves the right to reject a study and/or request revisions for any
-                            reason. However, Lookit approval is not based on a complete review of research practices
-                            and does not constitute endorsement of a study. Researchers still hold ultimate
-                            responsibility for their study design and ethical compliance.
-                        </li>
-                        <li>
-                            Researchers agree to post studies and collect data from participants only on the Lookit
-                            production platform (https://lookit.mit.edu). Researchers granted access to a Lookit
-                            staging site may use this only for study development and usability testing, and may not
-                            obtain parental consent via this site.
-                        </li>
-                    </ol>
-                    <h3>Informed Consent Guidelines</h3>
-                    <em>
-                        <p>
-                            Studies which are posted on Lookit but conducted elsewhere must use informed consent
-                            procedures as required by the Researcher's institutional review board. Lookit reserves
-                            the right to require any studies posted on the Lookit platform to conduct informed
-                            consent procedures on Lookit.
-                        </p>
-                        <p>
-                            The remainder of this section applies only to those studies which are both posted and
-                            conducted on lookit.
-                        </p>
-                    </em>
-                    <p>
-                        Researchers may study participants from birth through seventeen years of age (i.e., until the
-                        eighteenth birthday) and their parents or legal guardians on Lookit. Researchers may also
-                        study adult participants. For studies with only adult participants, researchers agree to
-                        record a statement of informed consent from the participant. <strong>For studies with child
-                        participants, researchers agree to record a statement of informed consent from a child
-                        participant’s parent or legal guardian at the start of any Lookit study, and to
-                        additionally record a statement of assent from any child participant aged eight years or
-                    older.</strong>Parents and guardians of all ages may consent to participation on behalf
-                    of themselves and their children (that is, if the parent is a minor, his or her own parent’s
-                    consent is not additionally required).
-                </p>
-                <p>
-                    If only parental consent is obtained, data from child participants eight years of age and
-                    older must be treated as if valid consent was not obtained. Researchers may at their own
-                    discretion and/or based on their own institution’s policies record an assent statement from
-                    children under eight years as well.
-                </p>
-                <p>
-                    Consent/assent may occur after a webcam setup/configuration step but must precede any other
-                    Lookit study elements. Researchers must use the standard Lookit consent and, if applicable,
-                    assent form element(s) for this section, providing additional text relevant to the
-                    particular study which will be inserted in the spaces indicated. No translations or
-                    adaptations of these elements may be used without the approval of both the Researchers’
-                    institutional review board and Lookit. For studies that involve any webcam access, a verbal
-                    (or ASL) statement of consent (and assent if applicable) must be recorded via webcam. For
-                    studies that do not involve any webcam or audio recording (e.g., that consist entirely of a
-                    survey), Lookit’s non-webcam form elements may be used.
-                </p>
-                <p>
-                    Researchers agree that they will view the consent recording before viewing any other video
-                    data collected during the same session and that they will check that the recording
-                    demonstrates informed adult consent and child assent if applicable. If the statement(s) is
-                    audible (or a signed statement in ASL is interpretable), appropriate study measures may then
-                    be coded by the researcher and the data may be used for research purposes. If a technical
-                    issue (e.g. lack of audio recording) prevented collection of informed consent from the
-                    parent, and the parent has set communication preferences to allow researchers to email with
-                    questions about their participation, Researchers may instead confirm consent by emailing the
-                    account holder and receiving back a reply that contains the statement “Yes, I am this
-                    child's parent or legal guardian and we both agreed to participate in this study” or text
-                    equivalent in meaning.
-                </p>
-                <p>
-                    Unless parental consent and, if applicable, child assent are confirmed, Researchers may not
-                    view any other video associated with this study session, and may not use any other data from
-                    the session in their analysis, although the number of such records and aggregate data about
-                    the associated accounts (e.g., how many unique children, how many were in the age range) may
-                    be reported. Researchers are responsible for storing and maintaining any necessary records
-                    of confirmation of consent/assent.
-                </p>
-                <h3>Video Privacy</h3>
-                <p>
-                    Researchers agree to solicit selections for the privacy level of video data at the end of any
-                    Lookit study that is conducted on the Lookit platform. Researchers must use the standard
-                    Lookit exit survey element for this section, providing additional text relevant to the
-                    particular study which will be inserted in the spaces indicated. Parents must have the
-                    option to withdraw their video from the study at this point. Language may be modified,
-                    subject to approval by Lookit, as required by Researchers’ institutional review board (for
-                    instance, to add more detail about Databrary).
-                </p>
-                <p>
-                    If video is withdrawn for a session, any video other than the consent recording will be
-                    automatically made unavailable by Lookit. In the event that Researchers download data during
-                    an ongoing study session and video is later withdrawn, and in the event of any discrepancy
-                    between withdrawal information and Lookit's automatic removal of video, Researchers agree to
-                    delete without viewing any associated session video they have downloaded other than the
-                    consent recording.
-                </p>
-                <p>
-                    Researchers may share video and other session data, account data, child data, and demographic
-                    data on Databrary for sessions where parents opt to allow this usage, subject to approval of
-                    the appropriate institutional review board. Researchers agree to share video data only in
-                    accordance with the parent’s privacy selections. If privacy selections are missing, video
-                    must be treated either as if withdrawn or as if the parent had selected ‘private’ use, and
-                    data must not be shared with Databrary.
-                </p>
-                <h3>Participant Payment</h3>
-                <p>
-                    Researchers may choose whether to pay participants, and the form of payment, subject to any
-                    applicable IRB review at their own institutions. The purpose of payment must be to
-                    compensate participants for their time and effort, and must not be coercive. Lookit may set
-                    guidelines for acceptable payment ranges. Payment may include: money or gift certificates,
-                    or physical prizes (e.g., an age-appropriate book or game), either emailed or sent via
-                    postal mail. Future payment options may include Lookit points, redeemable on the Lookit
-                    Platform for gift certificates and other prizes, and may be pooled across studies.
-                </p>
-                <p>
-                    Information about payment must be included in the study description submitted to Lookit and
-                    is subject to Lookit approval. This information must include when, how, how much, and under
-                    what conditions participants will be paid.
-                    <strong>
-                        Without prior approval by Lookit, payment
-                        may not depend on the child’s behavior or performance, even if that behavior renders
-                        data unusable (e.g., if an infant fusses and his parent ends the session
-                        early).
-                    </strong>
-                    Payment may not depend on the parent’s video privacy selections.
-                </p>
-                <p>
-                    Even if payment is to be sent via postal mail, families may not be required to provide a
-                    mailing address in order to participate. When practical, families should be offered the
-                    opportunity to select alternate compensation in this case.
-                </p>
-                <p>
-                    Researchers are responsible for verifying participation and sending payment or recording the
-                    number of Lookit points participants should receive. Researchers are responsible for the
-                    cost of all participant payment, including reimbursing Lookit for Lookit points based on a
-                    price agreed upon at the start of the study. Lookit may, at its discretion, also choose to
-                    itself offer Lookit points for study participation. Researchers are not responsible for the
-                    costs of such compensation.
-                </p>
-                <h3>Copyright Violation</h3>
-                <em>
-                    <p>
-                        It is MIT’s policy to respond to notices of alleged copyright infringement that comply
-                        with the Digital Millennium Copyright Act. Copyright owners who believe their material
-                        has been infringed on the Platform should contact MIT's designated copyright agent at
-                        dcma-agent@mit.edu, or at 77 Massachusetts Ave., Cambridge, MA 02138-4307 Attention: MIT
-                        DMCA Agent, W92-263A.
-                    </p>
-                    <p>
-                        Notification must include: (a) identification of the copyrighted work, or, in the case of
-                        multiple works at the same location, a representative list of such works at that site;
-                        (b) identification of the material that is claimed to be infringing or to be the subject
-                        of infringing activity; (c) information for us to be able to contact the complaining
-                        party (e.g., email address, phone number); (d) a statement that the complaining party
-                        believes that the use of the material has not been authorized by the copyright owner or
-                        an authorized agent; and (e) a statement that the information in the notification is
-                        accurate and that the complaining party is authorized to act on behalf of the copyright
-                        owner.
-                    </p>
-                </em>
-                <h3>Entire Agreement</h3>
-                <em>
-                    <p>
-                        These terms and conditions constitute the entire agreement between you and MIT with
-                        respect to your use of the Platform, superseding any prior agreements between you and
-                        MIT regarding your use of the Platform. The failure of MIT to exercise or enforce any
-                        right or provision of the terms and conditions shall not constitute a waiver of such
-                        right or provision. If any provision of the terms and conditions is found by a court of
-                        competent jurisdiction to be invalid, the parties nevertheless agree that the court
-                        should endeavor to give effect to the parties' intentions as reflected in the provision,
-                        and the other provisions of the terms and conditions remain in full force and effect.
-                    </p>
-                </em>
-                <h3>Governing Law</h3>
-                <em>
-                    <p>
-                        You agree that any dispute arising out of or relating to these terms and conditions or
-                        any content posted to the Platform will be governed by the laws of the Commonwealth of
-                        Massachusetts, excluding its conflicts of law provisions. You further consent to the
-                        personal jurisdiction of and exclusive venue in the federal and state courts located in
-                        and serving Boston, Massachusetts as the legal forum for any such dispute.
-                    </p>
-                </em>
-                <p class="last-update">
-                    Last updated October 13, 2021
-                    <a href="https://github.com/lookit/research-resources/commits/master/lookit%20static%20pages/termsofuse.html"
-                       target="_blank"
-                       rel="noopener">[Changelog]</a>
-                    <a href="https://mailman.mit.edu/mailman/listinfo/lookit-terms-notifications"
-                       target="_blank"
-                       rel="noopener">[Change notifications]</a>
-                </p>
-            </div>
-        </div>
+<div class="container m-4">
+    <h2 class="mx-4 my-5">Terms of Use</h2>
+    <div class="m-4">
+        <p>
+            Welcome to the Lookit Platform, an online platform for developmental research studies. You
+            should read and understand these terms and conditions, which govern your use of the Lookit
+            Platform. Researchers may be especially interested in the sections not in italic when first
+            learning about the Platform.
+        </p>
+    </div>
+    <h3 class="m-4">Overview</h3>
+    <div class="m-4">
+        <em>
+            <p>
+                These Terms of Service, with our Privacy Policy, are a resource for you to get a deeper
+                understanding of your obligations and rights with respect to the Lookit Platform
+                including how we use information and data we collect from you. We may modify these Terms
+                of Service from time to time as we deem appropriate, so you should check back in
+                frequently to confirm the terms upon which you may use the Lookit Platform. We will
+                notify you of any modifications to these Terms by posting them on the Lookit Platform.
+                Use of the Lookit Platform after the effective date of the updated Terms constitutes
+                your agreement to the updated Terms.
+            </p>
+            <p>
+                The terms "we", "us" "our" and similar terms refer to Lookit. The terms “you,” “your,”
+                “Researcher” and similar terms refer to users of our Platform. The term “Platform”
+                refers to the online Lookit Platform. “Terms” or “Agreement” refers to these Terms of
+                Service, as may be amended from time to time by us.
+            </p>
+        </em>
+        <p>
+            A study "posted on Lookit" refers to any study which has been submitted for and received
+            approval to appear on the Lookit website.
+        </p>
+        <p>
+            A study "conducted on Lookit" refers to studies which, additionally, perform all consent
+            procedures and data collection without leaving the Lookit web domain.
+        </p>
+        <p>
+            There are several types of data collected on the Lookit Platform. These comprise:
+        </p>
+        <ol>
+            <li>
+                Account data: information about a Lookit account holder, representing an adult
+                participant or family: e.g., contact information, email preferences
+            </li>
+            <li>
+                Child data: information about a Lookit participant, representing a child associated with
+                a particular Lookit account: e.g., birthdate, gender, gestational age at birth, medical
+                diagnoses
+            </li>
+            <li>
+                Demographic survey data: responses to a demographic survey associated with a Lookit
+                account: e.g., approximate geographic location, household income, parental education
+            </li>
+            <li>
+                Study data, including video: responses collected during a child’s participation in a
+                particular Lookit study: webcam video of the child and parent as well as text data
+                including form responses, on-screen selections, which stimuli were shown, etc.
+            </li>
+        </ol>
+        <p>
+            In addition, the term "External data" refers to video, text, or other data, including consent
+            records, collected from participants in a study posted (but not conducted) on Lookit. this
+            includes data from studies which are conducted asynchronously on another web platform as
+            well those which are collected at a scheduled session (online or in person.)
+        </p>
+        <em>
+            <p>
+                Other capitalized terms may be defined below in these Terms.
+            </p>
+        </em>
+    </div>
+    <h3 class="m-4">Acceptance of Terms of Service</h3>
+    <div class="m-4">
+        <em>
+            <p>
+                These Terms, which include our Privacy Policy, are a binding legal agreement and govern
+                your use of the Platform, including all features and functionalities, applications,
+                updates, notifications and our user interfaces, and all content and software associated
+                therewith. By checking the “I accept the Terms & Conditions” box during the account set
+                up or by downloading, using, visiting, or browsing the Platform, you accept and agree to
+                be bound by these Terms as amended from time to time. If you do not agree to these
+                Terms, you are not authorized to use, and you should not use, the Platform.
+            </p>
+        </em>
+    </div>
+    <h3 class="m-4">Use of the Platform</h3>
+    <div class="m-4">
+        <em>
+            <p>
+                Account Registration. In order to use the Platform, you will need to provide to us
+                certain basic information such as your name, institution, and email address. You agree
+                that all information you provide to us will be complete, true and correct and that you
+                will keep it up-to-date. During the registration process, you will choose a user name
+                and password for your use of the Platform. You will be responsible for securing your
+                user name and password and for all use of the Platform using your email address or
+                password. You will be solely liable for any use of the Platform under your account and
+                password. You agree to notify us promptly of any unauthorized use or disclosure of your
+                password. We reserve the right to refuse use of or revoke use of any username in our
+                discretion.
+                Basic use of the Platform is offered free of charge. However, we reserve the right to
+                establish fees for use of the Platform at any time or to charge additional fees for
+                premium services, data access or additional functionality.
+            </p>
+            <p>
+                Researcher Obligations. Your use of the Platform and of external data generated by Lookit
+                participants shall be solely for your own educational and academic use. You will comply
+                with all applicable laws in connection with your use of the Platform and resulting
+                external data, as well as all applicable policies of your Institution. You will not
+                attempt to circumnavigate or violate any security feature of the Platform, including
+                accessing any Platform features, interactive areas, information or profiles for which
+                you do not have permission or other content or information not intended for you.
+            </p>
+        </em>
+        <p>
+            All Researchers are responsible for their own use of the Platform, and for their use of
+            external data generated by Lookit participants. Researchers also assume responsibility for
+            any adverse events associated with participation in their studies. As part of your use of
+            the Platform and resulting external data, you agree that you:
+        </p>
+        <ol>
+            <li>
+                Will not use account or child nicknames, email addresses, or mailing addresses of Lookit
+                participants, accessed via Researchers’ use of the Lookit platform, as a subject of
+                research.
+            </li>
+            <li>
+                Will not share, sell, publish, or otherwise disclose participant contact information
+                (email or mailing addresses) obtained as a result of their use of the Lookit platform.
+                For instance, participant contact information may not be added to a lab participant
+                database that is used for local recruitment.
+            </li>
+            <li>
+                May contact families by email, through the Lookit Platform, only in accordance with
+                those families’ email preferences, and only for communication related to their Lookit
+                studies.
+            </li>
+            <li>
+                May contact families by postal mail only to send payment/prizes for participation or
+                materials needed to participate in a study (e.g., a book to read together), and not for
+                any other communication.
+            </li>
+            <li>
+                Subject to any applicable institutional review, may study relationships between the same
+                child’s behavior in the same study (some studies may comprise multiple sessions, for
+                instance to look at individual differences, test-retest reliability, or the effects of
+                an intervention); between the same child’s behavior in different studies run by the
+                Researcher; and between siblings’ behavior on the same study or different studies run by
+                the Researcher.
+            </li>
+            <li>
+                Subject to any applicable institutional review, may combine data with another Lookit
+                Researcher to examine relationships among the same child’s or siblings’ behavior on
+                studies run by the Researcher in conjunction with studies run by another Researcher.
+            </li>
+            <li>
+                <strong>Will not publish either individual participant birthdates or information that
+                could be combined to calculate participant birthdates </strong> (for instance, the
+                participant’s age in days at time of testing plus the test date).
+            </li>
+            <li>
+                May use parent and child nicknames only for communication with participants, and may not
+                publish individual child or account nicknames stored in child and account records. Child
+                names may be incidentally included in video recordings or parent comments that are
+                published, although we encourage researchers to redact child names when possible from
+                written comments.
+            </li>
+            <li>
+                With the exception of linking external data to corresponding Lookit data for studies
+                posted on Lookit, will not use video or other data in order to link outside information
+                available about a specific participant to an associated child, account, or experimental
+                session, without specific IRB approval to do so. Any other planned integration of
+                outside data must be reported to Lookit at the time the study is submitted.
+            </li>
+            <li>
+                <strong>Will not publish the "global ID" fields for account, child, or demographic
+                survey records.</strong> These fields can be accessed by all researchers using the
+                Lookit platform, so publication could lead to unintentional linkage of data from the
+                same individuals. Researchers receive access to the global IDs in case necessary; for
+                instance, to facilitate financial record-keeping and any necessary linking of accounts
+                and children across studies. The 5-character account, child, and demographic "ID" fields
+                provided for download may be published; these are specific to the study. Researchers
+                wishing to publish persistent identifiers for data from multiple connected studies must
+                either create a table linking IDs across studies, or generate their own random IDs.
+            </li>
+            <li>
+                <strong>Will not publish video of Lookit participants such that it can be matched with
+                    individual demographic survey data (e.g., household income, number of
+                parents/guardians). </strong>
+            </li>
+            <li>
+                <strong>Will not collect external data from studies posted on Lookit with the intent to
+                circumvent the terms of this agreement.</strong>
+            </li>
+        </ol>
+    </div>
+    <h3 class="m-4">Use and Storage of Data By Lookit and Researchers</h3>
+    <div class="m-4">
+        <p>
+            <em>The following guidelines pertain to the use and storage of Lookit data.</em>
+        </p>
+        <ol>
+            <li>
+                Researchers may download local copies of their Lookit data, including study data and
+                video, and account, child, and demographic survey data from Lookit participants who have
+                participated in their studies. Lookit may also keep copies of this data, including study
+                data and video, indefinitely.
+            </li>
+            <li>
+                Lookit assumes no responsibility for losses incurred by the Researchers in the event
+                that data stored by Lookit, including study design information, is lost or corrupted.
+            </li>
+            <li>Researchers retain ownership of study data, including video, for their own studies.</li>
+            <li>
+                Lookit retains ownership of account, child, and demographic survey response data
+                collected on Lookit.
+            </li>
+            <li>
+                <strong>Lookit reserves the right to use any data collected on the Lookit platform,
+                    including account, child, demographic, and study data, for the following purposes:
+                </strong>
+                <ol>
+                    <li>
+                        To improve the Lookit platform: e.g., detect and fix technical problems or
+                        identify new features that would be helpful
+                    </li>
+                    <li>
+                        To develop data analysis tools for Lookit researchers, including automated gaze
+                        coding
+                    </li>
+                    <li>To provide technical support to study researchers</li>
+                    <li>
+                        To assess the quality of data collected on the platform (for instance, how well
+                        an observer can tell which direction children are looking)
+                    </li>
+                    <li>To evaluate recruitment and family engagement efforts</li>
+                    <li>To recruit participants or researchers to use Lookit</li>
+                </ol>
+            </li>
+            <li>Lookit may publish the results of the above described methodological research.</li>
+        </ol>
+    </div>
+    <h3 class="m-4">Restrictions on Data Collection on Lookit</h3>
+    <div class="m-4">
+        <p>
+            <em>The following guidelines pertain to the use and storage of Lookit data, and apply to all
+                studies posted on the Lookit platform, whether they are also conducted there or are
+            conducted using an external platform or scheduled session.</em>
+        </p>
+        <ol>
+            <li>
+                Researchers must provide accurate contact information to be posted along with all
+                studies they conduct on Lookit, <strong>and must respond promptly to parent
+                communication. </strong>
+            </li>
+            <li>
+                Researchers agree to accurately represent the procedures and goals of their studies. In
+                addition to obtaining approval from any appropriate institutional review board,
+                researchers agree to notify Lookit of deception involved in any study designs, at the
+                time the study is submitted for Lookit review. <strong>Deception that must be disclosed
+                to Lookit includes deliberate omission of information or presentation of any
+                misleading information to either the parent or the child, either in the course of
+                the study itself or regarding the study’s purpose and procedures. </strong>Examples
+                include telling the child that he or she performed better or worse than peers when
+                children were in fact assigned randomly to receive such feedback; telling a parent that
+                researchers expect to observe a particular behavior that is not actually expected, in
+                order to avoid parental bias; or failing to disclose in a study about child-parent
+                interaction that the researchers are primarily interested in gender differences in
+                interaction styles.
+            </li>
+            <li>
+                In all study designs, the child must remain in the same room with his or her parent at
+                all times. No infancy study session (for children 0 - 12 months) may be designed to last
+                longer than 30 minutes, and no experiment session may be designed to last longer than 90
+                minutes. Purely observational periods may extend longer if approved by Lookit--for
+                instance, if the goal of a study is to observe conversation during a family meal or
+                independent child play.
+            </li>
+            <li>
+                In all study designs, the parent must be able to end the study session at any point.
+                This functionality is built into Lookit and may not be altered. Equivalent functionality
+                must be available in any study posted on Lookit and conducted elsewhere. Parents must be
+                informed of this option at the beginning of every study.
+            </li>
+            <li>
+                Researchers acknowledge that all studies are subject to review and final approval by
+                Lookit. Lookit reserves the right to reject a study and/or request revisions for any
+                reason. However, Lookit approval is not based on a complete review of research practices
+                and does not constitute endorsement of a study. Researchers still hold ultimate
+                responsibility for their study design and ethical compliance.
+            </li>
+            <li>
+                Researchers agree to post studies and collect data from participants only on the Lookit
+                production platform (https://lookit.mit.edu). Researchers granted access to a Lookit
+                staging site may use this only for study development and usability testing, and may not
+                obtain parental consent via this site.
+            </li>
+        </ol>
+    </div>
+    <h3 class="m-4">Informed Consent Guidelines</h3>
+    <div class="m-4">
+        <em>
+            <p>
+                Studies which are posted on Lookit but conducted elsewhere must use informed consent
+                procedures as required by the Researcher's institutional review board. Lookit reserves
+                the right to require any studies posted on the Lookit platform to conduct informed
+                consent procedures on Lookit.
+            </p>
+            <p>
+                The remainder of this section applies only to those studies which are both posted and
+                conducted on lookit.
+            </p>
+        </em>
+        <p>
+            Researchers may study participants from birth through seventeen years of age (i.e., until the
+            eighteenth birthday) and their parents or legal guardians on Lookit. Researchers may also
+            study adult participants. For studies with only adult participants, researchers agree to
+            record a statement of informed consent from the participant. <strong>For studies with child
+            participants, researchers agree to record a statement of informed consent from a child
+            participant’s parent or legal guardian at the start of any Lookit study, and to
+            additionally record a statement of assent from any child participant aged eight years or
+            older.</strong>Parents and guardians of all ages may consent to participation on behalf
+            of themselves and their children (that is, if the parent is a minor, his or her own parent’s
+            consent is not additionally required).
+        </p>
+        <p>
+            If only parental consent is obtained, data from child participants eight years of age and
+            older must be treated as if valid consent was not obtained. Researchers may at their own
+            discretion and/or based on their own institution’s policies record an assent statement from
+            children under eight years as well.
+        </p>
+        <p>
+            Consent/assent may occur after a webcam setup/configuration step but must precede any other
+            Lookit study elements. Researchers must use the standard Lookit consent and, if applicable,
+            assent form element(s) for this section, providing additional text relevant to the
+            particular study which will be inserted in the spaces indicated. No translations or
+            adaptations of these elements may be used without the approval of both the Researchers’
+            institutional review board and Lookit. For studies that involve any webcam access, a verbal
+            (or ASL) statement of consent (and assent if applicable) must be recorded via webcam. For
+            studies that do not involve any webcam or audio recording (e.g., that consist entirely of a
+            survey), Lookit’s non-webcam form elements may be used.
+        </p>
+        <p>
+            Researchers agree that they will view the consent recording before viewing any other video
+            data collected during the same session and that they will check that the recording
+            demonstrates informed adult consent and child assent if applicable. If the statement(s) is
+            audible (or a signed statement in ASL is interpretable), appropriate study measures may then
+            be coded by the researcher and the data may be used for research purposes. If a technical
+            issue (e.g. lack of audio recording) prevented collection of informed consent from the
+            parent, and the parent has set communication preferences to allow researchers to email with
+            questions about their participation, Researchers may instead confirm consent by emailing the
+            account holder and receiving back a reply that contains the statement “Yes, I am this
+            child's parent or legal guardian and we both agreed to participate in this study” or text
+            equivalent in meaning.
+        </p>
+        <p>
+            Unless parental consent and, if applicable, child assent are confirmed, Researchers may not
+            view any other video associated with this study session, and may not use any other data from
+            the session in their analysis, although the number of such records and aggregate data about
+            the associated accounts (e.g., how many unique children, how many were in the age range) may
+            be reported. Researchers are responsible for storing and maintaining any necessary records
+            of confirmation of consent/assent.
+        </p>
+    </div>
+    <h3 class="m-4">Video Privacy</h3>
+    <div class="m-4">
+        <p>
+            Researchers agree to solicit selections for the privacy level of video data at the end of any
+            Lookit study that is conducted on the Lookit platform. Researchers must use the standard
+            Lookit exit survey element for this section, providing additional text relevant to the
+            particular study which will be inserted in the spaces indicated. Parents must have the
+            option to withdraw their video from the study at this point. Language may be modified,
+            subject to approval by Lookit, as required by Researchers’ institutional review board (for
+            instance, to add more detail about Databrary).
+        </p>
+        <p>
+            If video is withdrawn for a session, any video other than the consent recording will be
+            automatically made unavailable by Lookit. In the event that Researchers download data during
+            an ongoing study session and video is later withdrawn, and in the event of any discrepancy
+            between withdrawal information and Lookit's automatic removal of video, Researchers agree to
+            delete without viewing any associated session video they have downloaded other than the
+            consent recording.
+        </p>
+        <p>
+            Researchers may share video and other session data, account data, child data, and demographic
+            data on Databrary for sessions where parents opt to allow this usage, subject to approval of
+            the appropriate institutional review board. Researchers agree to share video data only in
+            accordance with the parent’s privacy selections. If privacy selections are missing, video
+            must be treated either as if withdrawn or as if the parent had selected ‘private’ use, and
+            data must not be shared with Databrary.
+        </p>
+    </div>
+    <h3 class="m-4">Participant Payment</h3>
+    <div class="m-4">
+        <p>
+            Researchers may choose whether to pay participants, and the form of payment, subject to any
+            applicable IRB review at their own institutions. The purpose of payment must be to
+            compensate participants for their time and effort, and must not be coercive. Lookit may set
+            guidelines for acceptable payment ranges. Payment may include: money or gift certificates,
+            or physical prizes (e.g., an age-appropriate book or game), either emailed or sent via
+            postal mail. Future payment options may include Lookit points, redeemable on the Lookit
+            Platform for gift certificates and other prizes, and may be pooled across studies.
+        </p>
+        <p>
+            Information about payment must be included in the study description submitted to Lookit and
+            is subject to Lookit approval. This information must include when, how, how much, and under
+            what conditions participants will be paid.
+            <strong>
+                Without prior approval by Lookit, payment
+                may not depend on the child’s behavior or performance, even if that behavior renders
+                data unusable (e.g., if an infant fusses and his parent ends the session
+                early).
+            </strong>
+            Payment may not depend on the parent’s video privacy selections.
+        </p>
+        <p>
+            Even if payment is to be sent via postal mail, families may not be required to provide a
+            mailing address in order to participate. When practical, families should be offered the
+            opportunity to select alternate compensation in this case.
+        </p>
+        <p>
+            Researchers are responsible for verifying participation and sending payment or recording the
+            number of Lookit points participants should receive. Researchers are responsible for the
+            cost of all participant payment, including reimbursing Lookit for Lookit points based on a
+            price agreed upon at the start of the study. Lookit may, at its discretion, also choose to
+            itself offer Lookit points for study participation. Researchers are not responsible for the
+            costs of such compensation.
+        </p>
+    </div>
+    <h3 class="m-4">Copyright Violation</h3>
+    <div class="m-4">
+        <em>
+            <p>
+                It is MIT’s policy to respond to notices of alleged copyright infringement that comply
+                with the Digital Millennium Copyright Act. Copyright owners who believe their material
+                has been infringed on the Platform should contact MIT's designated copyright agent at
+                dcma-agent@mit.edu, or at 77 Massachusetts Ave., Cambridge, MA 02138-4307 Attention: MIT
+                DMCA Agent, W92-263A.
+            </p>
+            <p>
+                Notification must include: (a) identification of the copyrighted work, or, in the case of
+                multiple works at the same location, a representative list of such works at that site;
+                (b) identification of the material that is claimed to be infringing or to be the subject
+                of infringing activity; (c) information for us to be able to contact the complaining
+                party (e.g., email address, phone number); (d) a statement that the complaining party
+                believes that the use of the material has not been authorized by the copyright owner or
+                an authorized agent; and (e) a statement that the information in the notification is
+                accurate and that the complaining party is authorized to act on behalf of the copyright
+                owner.
+            </p>
+        </em>
+    </div>
+    <h3 class="m-4">Entire Agreement</h3>
+    <div class="m-4">
+        <em>
+            <p>
+                These terms and conditions constitute the entire agreement between you and MIT with
+                respect to your use of the Platform, superseding any prior agreements between you and
+                MIT regarding your use of the Platform. The failure of MIT to exercise or enforce any
+                right or provision of the terms and conditions shall not constitute a waiver of such
+                right or provision. If any provision of the terms and conditions is found by a court of
+                competent jurisdiction to be invalid, the parties nevertheless agree that the court
+                should endeavor to give effect to the parties' intentions as reflected in the provision,
+                and the other provisions of the terms and conditions remain in full force and effect.
+            </p>
+        </em>
+    </div>
+    <h3 class="m-4">Governing Law</h3>
+    <div class="m-4">
+        <em>
+            <p>
+                You agree that any dispute arising out of or relating to these terms and conditions or
+                any content posted to the Platform will be governed by the laws of the Commonwealth of
+                Massachusetts, excluding its conflicts of law provisions. You further consent to the
+                personal jurisdiction of and exclusive venue in the federal and state courts located in
+                and serving Boston, Massachusetts as the legal forum for any such dispute.
+            </p>
+        </em>
+        <p class="last-update">
+            Last updated October 13, 2021
+            <a href="https://github.com/lookit/research-resources/commits/master/lookit%20static%20pages/termsofuse.html"
+                target="_blank"
+                rel="noopener">[Changelog]</a>
+            <a href="https://mailman.mit.edu/mailman/listinfo/lookit-terms-notifications"
+                target="_blank"
+                rel="noopener">[Change notifications]</a>
+        </p>
     </div>
 </div>
-</article>
-</section>
 {% endblock content %}

--- a/web/templates/web/termsofuse.html
+++ b/web/templates/web/termsofuse.html
@@ -5,260 +5,260 @@
     Terms of Use
 {% endblock title %}
 {% block content %}
-<div class="container m-4">
-    <h2 class="mx-4 my-5">Terms of Use</h2>
-    <div class="m-4">
-        <p>
-            Welcome to the Lookit Platform, an online platform for developmental research studies. You
-            should read and understand these terms and conditions, which govern your use of the Lookit
-            Platform. Researchers may be especially interested in the sections not in italic when first
-            learning about the Platform.
-        </p>
-    </div>
-    <h3 class="m-4">Overview</h3>
-    <div class="m-4">
-        <em>
+    <div class="container m-4">
+        <h2 class="mx-4 my-5">Terms of Use</h2>
+        <div class="m-4">
             <p>
-                These Terms of Service, with our Privacy Policy, are a resource for you to get a deeper
-                understanding of your obligations and rights with respect to the Lookit Platform
-                including how we use information and data we collect from you. We may modify these Terms
-                of Service from time to time as we deem appropriate, so you should check back in
-                frequently to confirm the terms upon which you may use the Lookit Platform. We will
-                notify you of any modifications to these Terms by posting them on the Lookit Platform.
-                Use of the Lookit Platform after the effective date of the updated Terms constitutes
-                your agreement to the updated Terms.
+                Welcome to the Lookit Platform, an online platform for developmental research studies. You
+                should read and understand these terms and conditions, which govern your use of the Lookit
+                Platform. Researchers may be especially interested in the sections not in italic when first
+                learning about the Platform.
+            </p>
+        </div>
+        <h3 class="m-4">Overview</h3>
+        <div class="m-4">
+            <em>
+                <p>
+                    These Terms of Service, with our Privacy Policy, are a resource for you to get a deeper
+                    understanding of your obligations and rights with respect to the Lookit Platform
+                    including how we use information and data we collect from you. We may modify these Terms
+                    of Service from time to time as we deem appropriate, so you should check back in
+                    frequently to confirm the terms upon which you may use the Lookit Platform. We will
+                    notify you of any modifications to these Terms by posting them on the Lookit Platform.
+                    Use of the Lookit Platform after the effective date of the updated Terms constitutes
+                    your agreement to the updated Terms.
+                </p>
+                <p>
+                    The terms "we", "us" "our" and similar terms refer to Lookit. The terms “you,” “your,”
+                    “Researcher” and similar terms refer to users of our Platform. The term “Platform”
+                    refers to the online Lookit Platform. “Terms” or “Agreement” refers to these Terms of
+                    Service, as may be amended from time to time by us.
+                </p>
+            </em>
+            <p>
+                A study "posted on Lookit" refers to any study which has been submitted for and received
+                approval to appear on the Lookit website.
             </p>
             <p>
-                The terms "we", "us" "our" and similar terms refer to Lookit. The terms “you,” “your,”
-                “Researcher” and similar terms refer to users of our Platform. The term “Platform”
-                refers to the online Lookit Platform. “Terms” or “Agreement” refers to these Terms of
-                Service, as may be amended from time to time by us.
-            </p>
-        </em>
-        <p>
-            A study "posted on Lookit" refers to any study which has been submitted for and received
-            approval to appear on the Lookit website.
-        </p>
-        <p>
-            A study "conducted on Lookit" refers to studies which, additionally, perform all consent
-            procedures and data collection without leaving the Lookit web domain.
-        </p>
-        <p>
-            There are several types of data collected on the Lookit Platform. These comprise:
-        </p>
-        <ol>
-            <li>
-                Account data: information about a Lookit account holder, representing an adult
-                participant or family: e.g., contact information, email preferences
-            </li>
-            <li>
-                Child data: information about a Lookit participant, representing a child associated with
-                a particular Lookit account: e.g., birthdate, gender, gestational age at birth, medical
-                diagnoses
-            </li>
-            <li>
-                Demographic survey data: responses to a demographic survey associated with a Lookit
-                account: e.g., approximate geographic location, household income, parental education
-            </li>
-            <li>
-                Study data, including video: responses collected during a child’s participation in a
-                particular Lookit study: webcam video of the child and parent as well as text data
-                including form responses, on-screen selections, which stimuli were shown, etc.
-            </li>
-        </ol>
-        <p>
-            In addition, the term "External data" refers to video, text, or other data, including consent
-            records, collected from participants in a study posted (but not conducted) on Lookit. this
-            includes data from studies which are conducted asynchronously on another web platform as
-            well those which are collected at a scheduled session (online or in person.)
-        </p>
-        <em>
-            <p>
-                Other capitalized terms may be defined below in these Terms.
-            </p>
-        </em>
-    </div>
-    <h3 class="m-4">Acceptance of Terms of Service</h3>
-    <div class="m-4">
-        <em>
-            <p>
-                These Terms, which include our Privacy Policy, are a binding legal agreement and govern
-                your use of the Platform, including all features and functionalities, applications,
-                updates, notifications and our user interfaces, and all content and software associated
-                therewith. By checking the “I accept the Terms & Conditions” box during the account set
-                up or by downloading, using, visiting, or browsing the Platform, you accept and agree to
-                be bound by these Terms as amended from time to time. If you do not agree to these
-                Terms, you are not authorized to use, and you should not use, the Platform.
-            </p>
-        </em>
-    </div>
-    <h3 class="m-4">Use of the Platform</h3>
-    <div class="m-4">
-        <em>
-            <p>
-                Account Registration. In order to use the Platform, you will need to provide to us
-                certain basic information such as your name, institution, and email address. You agree
-                that all information you provide to us will be complete, true and correct and that you
-                will keep it up-to-date. During the registration process, you will choose a user name
-                and password for your use of the Platform. You will be responsible for securing your
-                user name and password and for all use of the Platform using your email address or
-                password. You will be solely liable for any use of the Platform under your account and
-                password. You agree to notify us promptly of any unauthorized use or disclosure of your
-                password. We reserve the right to refuse use of or revoke use of any username in our
-                discretion.
-                Basic use of the Platform is offered free of charge. However, we reserve the right to
-                establish fees for use of the Platform at any time or to charge additional fees for
-                premium services, data access or additional functionality.
+                A study "conducted on Lookit" refers to studies which, additionally, perform all consent
+                procedures and data collection without leaving the Lookit web domain.
             </p>
             <p>
-                Researcher Obligations. Your use of the Platform and of external data generated by Lookit
-                participants shall be solely for your own educational and academic use. You will comply
-                with all applicable laws in connection with your use of the Platform and resulting
-                external data, as well as all applicable policies of your Institution. You will not
-                attempt to circumnavigate or violate any security feature of the Platform, including
-                accessing any Platform features, interactive areas, information or profiles for which
-                you do not have permission or other content or information not intended for you.
+                There are several types of data collected on the Lookit Platform. These comprise:
             </p>
-        </em>
-        <p>
-            All Researchers are responsible for their own use of the Platform, and for their use of
-            external data generated by Lookit participants. Researchers also assume responsibility for
-            any adverse events associated with participation in their studies. As part of your use of
-            the Platform and resulting external data, you agree that you:
-        </p>
-        <ol>
-            <li>
-                Will not use account or child nicknames, email addresses, or mailing addresses of Lookit
-                participants, accessed via Researchers’ use of the Lookit platform, as a subject of
-                research.
-            </li>
-            <li>
-                Will not share, sell, publish, or otherwise disclose participant contact information
-                (email or mailing addresses) obtained as a result of their use of the Lookit platform.
-                For instance, participant contact information may not be added to a lab participant
-                database that is used for local recruitment.
-            </li>
-            <li>
-                May contact families by email, through the Lookit Platform, only in accordance with
-                those families’ email preferences, and only for communication related to their Lookit
-                studies.
-            </li>
-            <li>
-                May contact families by postal mail only to send payment/prizes for participation or
-                materials needed to participate in a study (e.g., a book to read together), and not for
-                any other communication.
-            </li>
-            <li>
-                Subject to any applicable institutional review, may study relationships between the same
-                child’s behavior in the same study (some studies may comprise multiple sessions, for
-                instance to look at individual differences, test-retest reliability, or the effects of
-                an intervention); between the same child’s behavior in different studies run by the
-                Researcher; and between siblings’ behavior on the same study or different studies run by
-                the Researcher.
-            </li>
-            <li>
-                Subject to any applicable institutional review, may combine data with another Lookit
-                Researcher to examine relationships among the same child’s or siblings’ behavior on
-                studies run by the Researcher in conjunction with studies run by another Researcher.
-            </li>
-            <li>
-                <strong>Will not publish either individual participant birthdates or information that
-                could be combined to calculate participant birthdates </strong> (for instance, the
-                participant’s age in days at time of testing plus the test date).
-            </li>
-            <li>
-                May use parent and child nicknames only for communication with participants, and may not
-                publish individual child or account nicknames stored in child and account records. Child
-                names may be incidentally included in video recordings or parent comments that are
-                published, although we encourage researchers to redact child names when possible from
-                written comments.
-            </li>
-            <li>
-                With the exception of linking external data to corresponding Lookit data for studies
-                posted on Lookit, will not use video or other data in order to link outside information
-                available about a specific participant to an associated child, account, or experimental
-                session, without specific IRB approval to do so. Any other planned integration of
-                outside data must be reported to Lookit at the time the study is submitted.
-            </li>
-            <li>
-                <strong>Will not publish the "global ID" fields for account, child, or demographic
-                survey records.</strong> These fields can be accessed by all researchers using the
-                Lookit platform, so publication could lead to unintentional linkage of data from the
-                same individuals. Researchers receive access to the global IDs in case necessary; for
-                instance, to facilitate financial record-keeping and any necessary linking of accounts
-                and children across studies. The 5-character account, child, and demographic "ID" fields
-                provided for download may be published; these are specific to the study. Researchers
-                wishing to publish persistent identifiers for data from multiple connected studies must
-                either create a table linking IDs across studies, or generate their own random IDs.
-            </li>
-            <li>
-                <strong>Will not publish video of Lookit participants such that it can be matched with
-                    individual demographic survey data (e.g., household income, number of
-                parents/guardians). </strong>
-            </li>
-            <li>
-                <strong>Will not collect external data from studies posted on Lookit with the intent to
-                circumvent the terms of this agreement.</strong>
-            </li>
-        </ol>
-    </div>
-    <h3 class="m-4">Use and Storage of Data By Lookit and Researchers</h3>
-    <div class="m-4">
-        <p>
-            <em>The following guidelines pertain to the use and storage of Lookit data.</em>
-        </p>
-        <ol>
-            <li>
-                Researchers may download local copies of their Lookit data, including study data and
-                video, and account, child, and demographic survey data from Lookit participants who have
-                participated in their studies. Lookit may also keep copies of this data, including study
-                data and video, indefinitely.
-            </li>
-            <li>
-                Lookit assumes no responsibility for losses incurred by the Researchers in the event
-                that data stored by Lookit, including study design information, is lost or corrupted.
-            </li>
-            <li>Researchers retain ownership of study data, including video, for their own studies.</li>
-            <li>
-                Lookit retains ownership of account, child, and demographic survey response data
-                collected on Lookit.
-            </li>
-            <li>
-                <strong>Lookit reserves the right to use any data collected on the Lookit platform,
-                    including account, child, demographic, and study data, for the following purposes:
-                </strong>
-                <ol>
-                    <li>
-                        To improve the Lookit platform: e.g., detect and fix technical problems or
-                        identify new features that would be helpful
-                    </li>
-                    <li>
-                        To develop data analysis tools for Lookit researchers, including automated gaze
-                        coding
-                    </li>
-                    <li>To provide technical support to study researchers</li>
-                    <li>
-                        To assess the quality of data collected on the platform (for instance, how well
-                        an observer can tell which direction children are looking)
-                    </li>
-                    <li>To evaluate recruitment and family engagement efforts</li>
-                    <li>To recruit participants or researchers to use Lookit</li>
-                </ol>
-            </li>
-            <li>Lookit may publish the results of the above described methodological research.</li>
-        </ol>
-    </div>
-    <h3 class="m-4">Restrictions on Data Collection on Lookit</h3>
-    <div class="m-4">
-        <p>
-            <em>The following guidelines pertain to the use and storage of Lookit data, and apply to all
-                studies posted on the Lookit platform, whether they are also conducted there or are
-            conducted using an external platform or scheduled session.</em>
-        </p>
-        <ol>
-            <li>
-                Researchers must provide accurate contact information to be posted along with all
-                studies they conduct on Lookit, <strong>and must respond promptly to parent
+            <ol>
+                <li>
+                    Account data: information about a Lookit account holder, representing an adult
+                    participant or family: e.g., contact information, email preferences
+                </li>
+                <li>
+                    Child data: information about a Lookit participant, representing a child associated with
+                    a particular Lookit account: e.g., birthdate, gender, gestational age at birth, medical
+                    diagnoses
+                </li>
+                <li>
+                    Demographic survey data: responses to a demographic survey associated with a Lookit
+                    account: e.g., approximate geographic location, household income, parental education
+                </li>
+                <li>
+                    Study data, including video: responses collected during a child’s participation in a
+                    particular Lookit study: webcam video of the child and parent as well as text data
+                    including form responses, on-screen selections, which stimuli were shown, etc.
+                </li>
+            </ol>
+            <p>
+                In addition, the term "External data" refers to video, text, or other data, including consent
+                records, collected from participants in a study posted (but not conducted) on Lookit. this
+                includes data from studies which are conducted asynchronously on another web platform as
+                well those which are collected at a scheduled session (online or in person.)
+            </p>
+            <em>
+                <p>
+                    Other capitalized terms may be defined below in these Terms.
+                </p>
+            </em>
+        </div>
+        <h3 class="m-4">Acceptance of Terms of Service</h3>
+        <div class="m-4">
+            <em>
+                <p>
+                    These Terms, which include our Privacy Policy, are a binding legal agreement and govern
+                    your use of the Platform, including all features and functionalities, applications,
+                    updates, notifications and our user interfaces, and all content and software associated
+                    therewith. By checking the “I accept the Terms & Conditions” box during the account set
+                    up or by downloading, using, visiting, or browsing the Platform, you accept and agree to
+                    be bound by these Terms as amended from time to time. If you do not agree to these
+                    Terms, you are not authorized to use, and you should not use, the Platform.
+                </p>
+            </em>
+        </div>
+        <h3 class="m-4">Use of the Platform</h3>
+        <div class="m-4">
+            <em>
+                <p>
+                    Account Registration. In order to use the Platform, you will need to provide to us
+                    certain basic information such as your name, institution, and email address. You agree
+                    that all information you provide to us will be complete, true and correct and that you
+                    will keep it up-to-date. During the registration process, you will choose a user name
+                    and password for your use of the Platform. You will be responsible for securing your
+                    user name and password and for all use of the Platform using your email address or
+                    password. You will be solely liable for any use of the Platform under your account and
+                    password. You agree to notify us promptly of any unauthorized use or disclosure of your
+                    password. We reserve the right to refuse use of or revoke use of any username in our
+                    discretion.
+                    Basic use of the Platform is offered free of charge. However, we reserve the right to
+                    establish fees for use of the Platform at any time or to charge additional fees for
+                    premium services, data access or additional functionality.
+                </p>
+                <p>
+                    Researcher Obligations. Your use of the Platform and of external data generated by Lookit
+                    participants shall be solely for your own educational and academic use. You will comply
+                    with all applicable laws in connection with your use of the Platform and resulting
+                    external data, as well as all applicable policies of your Institution. You will not
+                    attempt to circumnavigate or violate any security feature of the Platform, including
+                    accessing any Platform features, interactive areas, information or profiles for which
+                    you do not have permission or other content or information not intended for you.
+                </p>
+            </em>
+            <p>
+                All Researchers are responsible for their own use of the Platform, and for their use of
+                external data generated by Lookit participants. Researchers also assume responsibility for
+                any adverse events associated with participation in their studies. As part of your use of
+                the Platform and resulting external data, you agree that you:
+            </p>
+            <ol>
+                <li>
+                    Will not use account or child nicknames, email addresses, or mailing addresses of Lookit
+                    participants, accessed via Researchers’ use of the Lookit platform, as a subject of
+                    research.
+                </li>
+                <li>
+                    Will not share, sell, publish, or otherwise disclose participant contact information
+                    (email or mailing addresses) obtained as a result of their use of the Lookit platform.
+                    For instance, participant contact information may not be added to a lab participant
+                    database that is used for local recruitment.
+                </li>
+                <li>
+                    May contact families by email, through the Lookit Platform, only in accordance with
+                    those families’ email preferences, and only for communication related to their Lookit
+                    studies.
+                </li>
+                <li>
+                    May contact families by postal mail only to send payment/prizes for participation or
+                    materials needed to participate in a study (e.g., a book to read together), and not for
+                    any other communication.
+                </li>
+                <li>
+                    Subject to any applicable institutional review, may study relationships between the same
+                    child’s behavior in the same study (some studies may comprise multiple sessions, for
+                    instance to look at individual differences, test-retest reliability, or the effects of
+                    an intervention); between the same child’s behavior in different studies run by the
+                    Researcher; and between siblings’ behavior on the same study or different studies run by
+                    the Researcher.
+                </li>
+                <li>
+                    Subject to any applicable institutional review, may combine data with another Lookit
+                    Researcher to examine relationships among the same child’s or siblings’ behavior on
+                    studies run by the Researcher in conjunction with studies run by another Researcher.
+                </li>
+                <li>
+                    <strong>Will not publish either individual participant birthdates or information that
+                    could be combined to calculate participant birthdates </strong> (for instance, the
+                    participant’s age in days at time of testing plus the test date).
+                </li>
+                <li>
+                    May use parent and child nicknames only for communication with participants, and may not
+                    publish individual child or account nicknames stored in child and account records. Child
+                    names may be incidentally included in video recordings or parent comments that are
+                    published, although we encourage researchers to redact child names when possible from
+                    written comments.
+                </li>
+                <li>
+                    With the exception of linking external data to corresponding Lookit data for studies
+                    posted on Lookit, will not use video or other data in order to link outside information
+                    available about a specific participant to an associated child, account, or experimental
+                    session, without specific IRB approval to do so. Any other planned integration of
+                    outside data must be reported to Lookit at the time the study is submitted.
+                </li>
+                <li>
+                    <strong>Will not publish the "global ID" fields for account, child, or demographic
+                    survey records.</strong> These fields can be accessed by all researchers using the
+                    Lookit platform, so publication could lead to unintentional linkage of data from the
+                    same individuals. Researchers receive access to the global IDs in case necessary; for
+                    instance, to facilitate financial record-keeping and any necessary linking of accounts
+                    and children across studies. The 5-character account, child, and demographic "ID" fields
+                    provided for download may be published; these are specific to the study. Researchers
+                    wishing to publish persistent identifiers for data from multiple connected studies must
+                    either create a table linking IDs across studies, or generate their own random IDs.
+                </li>
+                <li>
+                    <strong>Will not publish video of Lookit participants such that it can be matched with
+                        individual demographic survey data (e.g., household income, number of
+                    parents/guardians). </strong>
+                </li>
+                <li>
+                    <strong>Will not collect external data from studies posted on Lookit with the intent to
+                    circumvent the terms of this agreement.</strong>
+                </li>
+            </ol>
+        </div>
+        <h3 class="m-4">Use and Storage of Data By Lookit and Researchers</h3>
+        <div class="m-4">
+            <p>
+                <em>The following guidelines pertain to the use and storage of Lookit data.</em>
+            </p>
+            <ol>
+                <li>
+                    Researchers may download local copies of their Lookit data, including study data and
+                    video, and account, child, and demographic survey data from Lookit participants who have
+                    participated in their studies. Lookit may also keep copies of this data, including study
+                    data and video, indefinitely.
+                </li>
+                <li>
+                    Lookit assumes no responsibility for losses incurred by the Researchers in the event
+                    that data stored by Lookit, including study design information, is lost or corrupted.
+                </li>
+                <li>Researchers retain ownership of study data, including video, for their own studies.</li>
+                <li>
+                    Lookit retains ownership of account, child, and demographic survey response data
+                    collected on Lookit.
+                </li>
+                <li>
+                    <strong>Lookit reserves the right to use any data collected on the Lookit platform,
+                        including account, child, demographic, and study data, for the following purposes:
+                    </strong>
+                    <ol>
+                        <li>
+                            To improve the Lookit platform: e.g., detect and fix technical problems or
+                            identify new features that would be helpful
+                        </li>
+                        <li>
+                            To develop data analysis tools for Lookit researchers, including automated gaze
+                            coding
+                        </li>
+                        <li>To provide technical support to study researchers</li>
+                        <li>
+                            To assess the quality of data collected on the platform (for instance, how well
+                            an observer can tell which direction children are looking)
+                        </li>
+                        <li>To evaluate recruitment and family engagement efforts</li>
+                        <li>To recruit participants or researchers to use Lookit</li>
+                    </ol>
+                </li>
+                <li>Lookit may publish the results of the above described methodological research.</li>
+            </ol>
+        </div>
+        <h3 class="m-4">Restrictions on Data Collection on Lookit</h3>
+        <div class="m-4">
+            <p>
+                <em>The following guidelines pertain to the use and storage of Lookit data, and apply to all
+                    studies posted on the Lookit platform, whether they are also conducted there or are
+                conducted using an external platform or scheduled session.</em>
+            </p>
+            <ol>
+                <li>
+                    Researchers must provide accurate contact information to be posted along with all
+                    studies they conduct on Lookit, <strong>and must respond promptly to parent
                 communication. </strong>
             </li>
             <li>
@@ -268,231 +268,231 @@
                 time the study is submitted for Lookit review. <strong>Deception that must be disclosed
                 to Lookit includes deliberate omission of information or presentation of any
                 misleading information to either the parent or the child, either in the course of
-                the study itself or regarding the study’s purpose and procedures. </strong>Examples
-                include telling the child that he or she performed better or worse than peers when
-                children were in fact assigned randomly to receive such feedback; telling a parent that
-                researchers expect to observe a particular behavior that is not actually expected, in
-                order to avoid parental bias; or failing to disclose in a study about child-parent
-                interaction that the researchers are primarily interested in gender differences in
-                interaction styles.
-            </li>
-            <li>
-                In all study designs, the child must remain in the same room with his or her parent at
-                all times. No infancy study session (for children 0 - 12 months) may be designed to last
-                longer than 30 minutes, and no experiment session may be designed to last longer than 90
-                minutes. Purely observational periods may extend longer if approved by Lookit--for
-                instance, if the goal of a study is to observe conversation during a family meal or
-                independent child play.
-            </li>
-            <li>
-                In all study designs, the parent must be able to end the study session at any point.
-                This functionality is built into Lookit and may not be altered. Equivalent functionality
-                must be available in any study posted on Lookit and conducted elsewhere. Parents must be
-                informed of this option at the beginning of every study.
-            </li>
-            <li>
-                Researchers acknowledge that all studies are subject to review and final approval by
-                Lookit. Lookit reserves the right to reject a study and/or request revisions for any
-                reason. However, Lookit approval is not based on a complete review of research practices
-                and does not constitute endorsement of a study. Researchers still hold ultimate
-                responsibility for their study design and ethical compliance.
-            </li>
-            <li>
-                Researchers agree to post studies and collect data from participants only on the Lookit
-                production platform (https://lookit.mit.edu). Researchers granted access to a Lookit
-                staging site may use this only for study development and usability testing, and may not
-                obtain parental consent via this site.
-            </li>
-        </ol>
-    </div>
-    <h3 class="m-4">Informed Consent Guidelines</h3>
-    <div class="m-4">
-        <em>
-            <p>
-                Studies which are posted on Lookit but conducted elsewhere must use informed consent
-                procedures as required by the Researcher's institutional review board. Lookit reserves
-                the right to require any studies posted on the Lookit platform to conduct informed
-                consent procedures on Lookit.
-            </p>
-            <p>
-                The remainder of this section applies only to those studies which are both posted and
-                conducted on lookit.
-            </p>
-        </em>
+            the study itself or regarding the study’s purpose and procedures. </strong>Examples
+            include telling the child that he or she performed better or worse than peers when
+            children were in fact assigned randomly to receive such feedback; telling a parent that
+            researchers expect to observe a particular behavior that is not actually expected, in
+            order to avoid parental bias; or failing to disclose in a study about child-parent
+            interaction that the researchers are primarily interested in gender differences in
+            interaction styles.
+        </li>
+        <li>
+            In all study designs, the child must remain in the same room with his or her parent at
+            all times. No infancy study session (for children 0 - 12 months) may be designed to last
+            longer than 30 minutes, and no experiment session may be designed to last longer than 90
+            minutes. Purely observational periods may extend longer if approved by Lookit--for
+            instance, if the goal of a study is to observe conversation during a family meal or
+            independent child play.
+        </li>
+        <li>
+            In all study designs, the parent must be able to end the study session at any point.
+            This functionality is built into Lookit and may not be altered. Equivalent functionality
+            must be available in any study posted on Lookit and conducted elsewhere. Parents must be
+            informed of this option at the beginning of every study.
+        </li>
+        <li>
+            Researchers acknowledge that all studies are subject to review and final approval by
+            Lookit. Lookit reserves the right to reject a study and/or request revisions for any
+            reason. However, Lookit approval is not based on a complete review of research practices
+            and does not constitute endorsement of a study. Researchers still hold ultimate
+            responsibility for their study design and ethical compliance.
+        </li>
+        <li>
+            Researchers agree to post studies and collect data from participants only on the Lookit
+            production platform (https://lookit.mit.edu). Researchers granted access to a Lookit
+            staging site may use this only for study development and usability testing, and may not
+            obtain parental consent via this site.
+        </li>
+    </ol>
+</div>
+<h3 class="m-4">Informed Consent Guidelines</h3>
+<div class="m-4">
+    <em>
         <p>
-            Researchers may study participants from birth through seventeen years of age (i.e., until the
-            eighteenth birthday) and their parents or legal guardians on Lookit. Researchers may also
-            study adult participants. For studies with only adult participants, researchers agree to
-            record a statement of informed consent from the participant. <strong>For studies with child
-            participants, researchers agree to record a statement of informed consent from a child
-            participant’s parent or legal guardian at the start of any Lookit study, and to
-            additionally record a statement of assent from any child participant aged eight years or
-            older.</strong>Parents and guardians of all ages may consent to participation on behalf
-            of themselves and their children (that is, if the parent is a minor, his or her own parent’s
-            consent is not additionally required).
+            Studies which are posted on Lookit but conducted elsewhere must use informed consent
+            procedures as required by the Researcher's institutional review board. Lookit reserves
+            the right to require any studies posted on the Lookit platform to conduct informed
+            consent procedures on Lookit.
         </p>
         <p>
-            If only parental consent is obtained, data from child participants eight years of age and
-            older must be treated as if valid consent was not obtained. Researchers may at their own
-            discretion and/or based on their own institution’s policies record an assent statement from
-            children under eight years as well.
+            The remainder of this section applies only to those studies which are both posted and
+            conducted on lookit.
+        </p>
+    </em>
+    <p>
+        Researchers may study participants from birth through seventeen years of age (i.e., until the
+        eighteenth birthday) and their parents or legal guardians on Lookit. Researchers may also
+        study adult participants. For studies with only adult participants, researchers agree to
+        record a statement of informed consent from the participant. <strong>For studies with child
+        participants, researchers agree to record a statement of informed consent from a child
+        participant’s parent or legal guardian at the start of any Lookit study, and to
+        additionally record a statement of assent from any child participant aged eight years or
+    older.</strong>Parents and guardians of all ages may consent to participation on behalf
+    of themselves and their children (that is, if the parent is a minor, his or her own parent’s
+    consent is not additionally required).
+</p>
+<p>
+    If only parental consent is obtained, data from child participants eight years of age and
+    older must be treated as if valid consent was not obtained. Researchers may at their own
+    discretion and/or based on their own institution’s policies record an assent statement from
+    children under eight years as well.
+</p>
+<p>
+    Consent/assent may occur after a webcam setup/configuration step but must precede any other
+    Lookit study elements. Researchers must use the standard Lookit consent and, if applicable,
+    assent form element(s) for this section, providing additional text relevant to the
+    particular study which will be inserted in the spaces indicated. No translations or
+    adaptations of these elements may be used without the approval of both the Researchers’
+    institutional review board and Lookit. For studies that involve any webcam access, a verbal
+    (or ASL) statement of consent (and assent if applicable) must be recorded via webcam. For
+    studies that do not involve any webcam or audio recording (e.g., that consist entirely of a
+    survey), Lookit’s non-webcam form elements may be used.
+</p>
+<p>
+    Researchers agree that they will view the consent recording before viewing any other video
+    data collected during the same session and that they will check that the recording
+    demonstrates informed adult consent and child assent if applicable. If the statement(s) is
+    audible (or a signed statement in ASL is interpretable), appropriate study measures may then
+    be coded by the researcher and the data may be used for research purposes. If a technical
+    issue (e.g. lack of audio recording) prevented collection of informed consent from the
+    parent, and the parent has set communication preferences to allow researchers to email with
+    questions about their participation, Researchers may instead confirm consent by emailing the
+    account holder and receiving back a reply that contains the statement “Yes, I am this
+    child's parent or legal guardian and we both agreed to participate in this study” or text
+    equivalent in meaning.
+</p>
+<p>
+    Unless parental consent and, if applicable, child assent are confirmed, Researchers may not
+    view any other video associated with this study session, and may not use any other data from
+    the session in their analysis, although the number of such records and aggregate data about
+    the associated accounts (e.g., how many unique children, how many were in the age range) may
+    be reported. Researchers are responsible for storing and maintaining any necessary records
+    of confirmation of consent/assent.
+</p>
+</div>
+<h3 class="m-4">Video Privacy</h3>
+<div class="m-4">
+    <p>
+        Researchers agree to solicit selections for the privacy level of video data at the end of any
+        Lookit study that is conducted on the Lookit platform. Researchers must use the standard
+        Lookit exit survey element for this section, providing additional text relevant to the
+        particular study which will be inserted in the spaces indicated. Parents must have the
+        option to withdraw their video from the study at this point. Language may be modified,
+        subject to approval by Lookit, as required by Researchers’ institutional review board (for
+        instance, to add more detail about Databrary).
+    </p>
+    <p>
+        If video is withdrawn for a session, any video other than the consent recording will be
+        automatically made unavailable by Lookit. In the event that Researchers download data during
+        an ongoing study session and video is later withdrawn, and in the event of any discrepancy
+        between withdrawal information and Lookit's automatic removal of video, Researchers agree to
+        delete without viewing any associated session video they have downloaded other than the
+        consent recording.
+    </p>
+    <p>
+        Researchers may share video and other session data, account data, child data, and demographic
+        data on Databrary for sessions where parents opt to allow this usage, subject to approval of
+        the appropriate institutional review board. Researchers agree to share video data only in
+        accordance with the parent’s privacy selections. If privacy selections are missing, video
+        must be treated either as if withdrawn or as if the parent had selected ‘private’ use, and
+        data must not be shared with Databrary.
+    </p>
+</div>
+<h3 class="m-4">Participant Payment</h3>
+<div class="m-4">
+    <p>
+        Researchers may choose whether to pay participants, and the form of payment, subject to any
+        applicable IRB review at their own institutions. The purpose of payment must be to
+        compensate participants for their time and effort, and must not be coercive. Lookit may set
+        guidelines for acceptable payment ranges. Payment may include: money or gift certificates,
+        or physical prizes (e.g., an age-appropriate book or game), either emailed or sent via
+        postal mail. Future payment options may include Lookit points, redeemable on the Lookit
+        Platform for gift certificates and other prizes, and may be pooled across studies.
+    </p>
+    <p>
+        Information about payment must be included in the study description submitted to Lookit and
+        is subject to Lookit approval. This information must include when, how, how much, and under
+        what conditions participants will be paid.
+        <strong>
+            Without prior approval by Lookit, payment
+            may not depend on the child’s behavior or performance, even if that behavior renders
+            data unusable (e.g., if an infant fusses and his parent ends the session
+            early).
+        </strong>
+        Payment may not depend on the parent’s video privacy selections.
+    </p>
+    <p>
+        Even if payment is to be sent via postal mail, families may not be required to provide a
+        mailing address in order to participate. When practical, families should be offered the
+        opportunity to select alternate compensation in this case.
+    </p>
+    <p>
+        Researchers are responsible for verifying participation and sending payment or recording the
+        number of Lookit points participants should receive. Researchers are responsible for the
+        cost of all participant payment, including reimbursing Lookit for Lookit points based on a
+        price agreed upon at the start of the study. Lookit may, at its discretion, also choose to
+        itself offer Lookit points for study participation. Researchers are not responsible for the
+        costs of such compensation.
+    </p>
+</div>
+<h3 class="m-4">Copyright Violation</h3>
+<div class="m-4">
+    <em>
+        <p>
+            It is MIT’s policy to respond to notices of alleged copyright infringement that comply
+            with the Digital Millennium Copyright Act. Copyright owners who believe their material
+            has been infringed on the Platform should contact MIT's designated copyright agent at
+            dcma-agent@mit.edu, or at 77 Massachusetts Ave., Cambridge, MA 02138-4307 Attention: MIT
+            DMCA Agent, W92-263A.
         </p>
         <p>
-            Consent/assent may occur after a webcam setup/configuration step but must precede any other
-            Lookit study elements. Researchers must use the standard Lookit consent and, if applicable,
-            assent form element(s) for this section, providing additional text relevant to the
-            particular study which will be inserted in the spaces indicated. No translations or
-            adaptations of these elements may be used without the approval of both the Researchers’
-            institutional review board and Lookit. For studies that involve any webcam access, a verbal
-            (or ASL) statement of consent (and assent if applicable) must be recorded via webcam. For
-            studies that do not involve any webcam or audio recording (e.g., that consist entirely of a
-            survey), Lookit’s non-webcam form elements may be used.
+            Notification must include: (a) identification of the copyrighted work, or, in the case of
+            multiple works at the same location, a representative list of such works at that site;
+            (b) identification of the material that is claimed to be infringing or to be the subject
+            of infringing activity; (c) information for us to be able to contact the complaining
+            party (e.g., email address, phone number); (d) a statement that the complaining party
+            believes that the use of the material has not been authorized by the copyright owner or
+            an authorized agent; and (e) a statement that the information in the notification is
+            accurate and that the complaining party is authorized to act on behalf of the copyright
+            owner.
         </p>
+    </em>
+</div>
+<h3 class="m-4">Entire Agreement</h3>
+<div class="m-4">
+    <em>
         <p>
-            Researchers agree that they will view the consent recording before viewing any other video
-            data collected during the same session and that they will check that the recording
-            demonstrates informed adult consent and child assent if applicable. If the statement(s) is
-            audible (or a signed statement in ASL is interpretable), appropriate study measures may then
-            be coded by the researcher and the data may be used for research purposes. If a technical
-            issue (e.g. lack of audio recording) prevented collection of informed consent from the
-            parent, and the parent has set communication preferences to allow researchers to email with
-            questions about their participation, Researchers may instead confirm consent by emailing the
-            account holder and receiving back a reply that contains the statement “Yes, I am this
-            child's parent or legal guardian and we both agreed to participate in this study” or text
-            equivalent in meaning.
+            These terms and conditions constitute the entire agreement between you and MIT with
+            respect to your use of the Platform, superseding any prior agreements between you and
+            MIT regarding your use of the Platform. The failure of MIT to exercise or enforce any
+            right or provision of the terms and conditions shall not constitute a waiver of such
+            right or provision. If any provision of the terms and conditions is found by a court of
+            competent jurisdiction to be invalid, the parties nevertheless agree that the court
+            should endeavor to give effect to the parties' intentions as reflected in the provision,
+            and the other provisions of the terms and conditions remain in full force and effect.
         </p>
+    </em>
+</div>
+<h3 class="m-4">Governing Law</h3>
+<div class="m-4">
+    <em>
         <p>
-            Unless parental consent and, if applicable, child assent are confirmed, Researchers may not
-            view any other video associated with this study session, and may not use any other data from
-            the session in their analysis, although the number of such records and aggregate data about
-            the associated accounts (e.g., how many unique children, how many were in the age range) may
-            be reported. Researchers are responsible for storing and maintaining any necessary records
-            of confirmation of consent/assent.
+            You agree that any dispute arising out of or relating to these terms and conditions or
+            any content posted to the Platform will be governed by the laws of the Commonwealth of
+            Massachusetts, excluding its conflicts of law provisions. You further consent to the
+            personal jurisdiction of and exclusive venue in the federal and state courts located in
+            and serving Boston, Massachusetts as the legal forum for any such dispute.
         </p>
-    </div>
-    <h3 class="m-4">Video Privacy</h3>
-    <div class="m-4">
-        <p>
-            Researchers agree to solicit selections for the privacy level of video data at the end of any
-            Lookit study that is conducted on the Lookit platform. Researchers must use the standard
-            Lookit exit survey element for this section, providing additional text relevant to the
-            particular study which will be inserted in the spaces indicated. Parents must have the
-            option to withdraw their video from the study at this point. Language may be modified,
-            subject to approval by Lookit, as required by Researchers’ institutional review board (for
-            instance, to add more detail about Databrary).
-        </p>
-        <p>
-            If video is withdrawn for a session, any video other than the consent recording will be
-            automatically made unavailable by Lookit. In the event that Researchers download data during
-            an ongoing study session and video is later withdrawn, and in the event of any discrepancy
-            between withdrawal information and Lookit's automatic removal of video, Researchers agree to
-            delete without viewing any associated session video they have downloaded other than the
-            consent recording.
-        </p>
-        <p>
-            Researchers may share video and other session data, account data, child data, and demographic
-            data on Databrary for sessions where parents opt to allow this usage, subject to approval of
-            the appropriate institutional review board. Researchers agree to share video data only in
-            accordance with the parent’s privacy selections. If privacy selections are missing, video
-            must be treated either as if withdrawn or as if the parent had selected ‘private’ use, and
-            data must not be shared with Databrary.
-        </p>
-    </div>
-    <h3 class="m-4">Participant Payment</h3>
-    <div class="m-4">
-        <p>
-            Researchers may choose whether to pay participants, and the form of payment, subject to any
-            applicable IRB review at their own institutions. The purpose of payment must be to
-            compensate participants for their time and effort, and must not be coercive. Lookit may set
-            guidelines for acceptable payment ranges. Payment may include: money or gift certificates,
-            or physical prizes (e.g., an age-appropriate book or game), either emailed or sent via
-            postal mail. Future payment options may include Lookit points, redeemable on the Lookit
-            Platform for gift certificates and other prizes, and may be pooled across studies.
-        </p>
-        <p>
-            Information about payment must be included in the study description submitted to Lookit and
-            is subject to Lookit approval. This information must include when, how, how much, and under
-            what conditions participants will be paid.
-            <strong>
-                Without prior approval by Lookit, payment
-                may not depend on the child’s behavior or performance, even if that behavior renders
-                data unusable (e.g., if an infant fusses and his parent ends the session
-                early).
-            </strong>
-            Payment may not depend on the parent’s video privacy selections.
-        </p>
-        <p>
-            Even if payment is to be sent via postal mail, families may not be required to provide a
-            mailing address in order to participate. When practical, families should be offered the
-            opportunity to select alternate compensation in this case.
-        </p>
-        <p>
-            Researchers are responsible for verifying participation and sending payment or recording the
-            number of Lookit points participants should receive. Researchers are responsible for the
-            cost of all participant payment, including reimbursing Lookit for Lookit points based on a
-            price agreed upon at the start of the study. Lookit may, at its discretion, also choose to
-            itself offer Lookit points for study participation. Researchers are not responsible for the
-            costs of such compensation.
-        </p>
-    </div>
-    <h3 class="m-4">Copyright Violation</h3>
-    <div class="m-4">
-        <em>
-            <p>
-                It is MIT’s policy to respond to notices of alleged copyright infringement that comply
-                with the Digital Millennium Copyright Act. Copyright owners who believe their material
-                has been infringed on the Platform should contact MIT's designated copyright agent at
-                dcma-agent@mit.edu, or at 77 Massachusetts Ave., Cambridge, MA 02138-4307 Attention: MIT
-                DMCA Agent, W92-263A.
-            </p>
-            <p>
-                Notification must include: (a) identification of the copyrighted work, or, in the case of
-                multiple works at the same location, a representative list of such works at that site;
-                (b) identification of the material that is claimed to be infringing or to be the subject
-                of infringing activity; (c) information for us to be able to contact the complaining
-                party (e.g., email address, phone number); (d) a statement that the complaining party
-                believes that the use of the material has not been authorized by the copyright owner or
-                an authorized agent; and (e) a statement that the information in the notification is
-                accurate and that the complaining party is authorized to act on behalf of the copyright
-                owner.
-            </p>
-        </em>
-    </div>
-    <h3 class="m-4">Entire Agreement</h3>
-    <div class="m-4">
-        <em>
-            <p>
-                These terms and conditions constitute the entire agreement between you and MIT with
-                respect to your use of the Platform, superseding any prior agreements between you and
-                MIT regarding your use of the Platform. The failure of MIT to exercise or enforce any
-                right or provision of the terms and conditions shall not constitute a waiver of such
-                right or provision. If any provision of the terms and conditions is found by a court of
-                competent jurisdiction to be invalid, the parties nevertheless agree that the court
-                should endeavor to give effect to the parties' intentions as reflected in the provision,
-                and the other provisions of the terms and conditions remain in full force and effect.
-            </p>
-        </em>
-    </div>
-    <h3 class="m-4">Governing Law</h3>
-    <div class="m-4">
-        <em>
-            <p>
-                You agree that any dispute arising out of or relating to these terms and conditions or
-                any content posted to the Platform will be governed by the laws of the Commonwealth of
-                Massachusetts, excluding its conflicts of law provisions. You further consent to the
-                personal jurisdiction of and exclusive venue in the federal and state courts located in
-                and serving Boston, Massachusetts as the legal forum for any such dispute.
-            </p>
-        </em>
-        <p class="last-update">
-            Last updated October 13, 2021
-            <a href="https://github.com/lookit/research-resources/commits/master/lookit%20static%20pages/termsofuse.html"
-                target="_blank"
-                rel="noopener">[Changelog]</a>
-            <a href="https://mailman.mit.edu/mailman/listinfo/lookit-terms-notifications"
-                target="_blank"
-                rel="noopener">[Change notifications]</a>
-        </p>
-    </div>
+    </em>
+    <p class="last-update">
+        Last updated October 13, 2021
+        <a href="https://github.com/lookit/research-resources/commits/master/lookit%20static%20pages/termsofuse.html"
+           target="_blank"
+           rel="noopener">[Changelog]</a>
+        <a href="https://mailman.mit.edu/mailman/listinfo/lookit-terms-notifications"
+           target="_blank"
+           rel="noopener">[Change notifications]</a>
+    </p>
+</div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
These are the Bootstrap 5 changes to the privacy, contact and terms of use pages. Also some minor changes to the FAQ page for consistency.

Sorry that the file diffs aren't particularly helpful. I followed CJ's lead and tried to remove unnecessary markup. The headers and margins should be consistent across these pages now. I did use some container divs around the content to help with formatting, but can change/remove this. Just let me know.

# Privacy
<img width="70%" alt="Screenshot 2023-03-06 at 3 13 09 PM" src="https://user-images.githubusercontent.com/9041788/223278706-9b075a7f-3299-4a62-a5f3-72e52659fc78.png">
<img width="70%" alt="Screenshot 2023-03-06 at 3 13 22 PM" src="https://user-images.githubusercontent.com/9041788/223278751-3f5213c5-db22-43f8-8670-bfdfa50307ed.png">

# Terms of Use
<img width="70%" alt="Screenshot 2023-03-06 at 3 13 48 PM" src="https://user-images.githubusercontent.com/9041788/223278781-cd3f4c91-a03a-4415-888a-f065cd520727.png">
<img width="70%" alt="Screenshot 2023-03-06 at 3 15 11 PM" src="https://user-images.githubusercontent.com/9041788/223278829-1f0c517c-ce2d-4b81-8b5b-43a2492e65eb.png">

# Contact
<img width="70%" alt="Screenshot 2023-03-06 at 3 14 53 PM" src="https://user-images.githubusercontent.com/9041788/223278808-a4b7fa31-b3e6-4740-a601-8f9d0fb7f41b.png">

# FAQ
<img width="70%" alt="Screenshot 2023-03-06 at 3 12 54 PM" src="https://user-images.githubusercontent.com/9041788/223278678-95f90e20-f5a9-4d2d-820e-ea9758abfb05.png">