### PR TITLE
Bootstrap 5 experimenter nav bar

### DIFF
--- a/exp/templates/exp/_navigation.html
+++ b/exp/templates/exp/_navigation.html
@@ -1,43 +1,47 @@
 {% extends "web/_navigation.html" %}
 {% load web_extras %}
 {% block nav_links %}
-    {% nav_link request 'exp:support' 'Support Lookit' %}
-    {% nav_link request 'exp:study-list' 'Manage Studies' %}
-    {% nav_link request 'exp:participant-list' 'View Participants' %}
-    {% if perms.accounts.can_view_analytics %}
-        {% nav_link request 'exp:study-participant-analytics' 'Recruitment Stats' %}
-    {% endif %}
-    <div class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle"
-           href="#"
-           id="navbarDropdown"
-           role="button"
-           data-bs-toggle="dropdown"
-           aria-expanded="false">
-            Help
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <div>
-                <a class="dropdown-item"
-                   href="https://lookit.readthedocs.io/"
-                   target="_blank"
-                   rel="noopener">Docs</a>
+    <div class="navbar-nav nav-pills navbar-collapse collapse w-100 order-1 collapse1 mx-auto justify-content-center">
+        {% nav_link request 'exp:support' 'Support Lookit' %}
+        {% nav_link request 'exp:study-list' 'Manage Studies' %}
+        {% nav_link request 'exp:participant-list' 'View Participants' %}
+        {% if perms.accounts.can_view_analytics %}
+            {% nav_link request 'exp:study-participant-analytics' 'Recruitment Stats' %}
+        {% endif %}
+    </div>
+    <div class="navbar-nav nav-pills navbar-collapse collapse order-2 collapse1 ms-auto justify-content-end">
+        <div class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle"
+               href="#"
+               id="navbarDropdown"
+               role="button"
+               data-bs-toggle="dropdown"
+               aria-expanded="false">
+                Help
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                <div>
+                    <a class="dropdown-item"
+                       href="https://lookit.readthedocs.io/"
+                       target="_blank"
+                       rel="noopener">Docs</a>
+                </div>
             </div>
         </div>
-    </div>
-    <div class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle"
-           href="#"
-           id="navbarDropdown"
-           role="button"
-           data-bs-toggle="dropdown"
-           aria-expanded="false">
-            {{ request.user.identicon_small_html }} {{ request.user.get_short_name }}
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            {% dropdown_item request 'accounts:manage-account' 'Mangage Account' %}
-            {% dropdown_item request 'exp:lab-list' 'Manage Labs' %}
-            {% dropdown_item request 'logout' 'Logout' %}
+        <div class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle"
+               href="#"
+               id="navbarDropdown"
+               role="button"
+               data-bs-toggle="dropdown"
+               aria-expanded="false">
+                {{ request.user.identicon_small_html }} {{ request.user.get_short_name }}
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                {% dropdown_item request 'accounts:manage-account' 'Mangage Account' %}
+                {% dropdown_item request 'exp:lab-list' 'Manage Labs' %}
+                {% dropdown_item request 'logout' 'Logout' %}
+            </div>
         </div>
     </div>
 {% endblock nav_links %}

--- a/exp/templates/exp/_navigation.html
+++ b/exp/templates/exp/_navigation.html
@@ -5,9 +5,6 @@
         {% nav_link request 'exp:support' 'Support Lookit' %}
         {% nav_link request 'exp:study-list' 'Manage Studies' %}
         {% nav_link request 'exp:participant-list' 'View Participants' %}
-        {% if perms.accounts.can_view_analytics %}
-            {% nav_link request 'exp:study-participant-analytics' 'Recruitment Stats' %}
-        {% endif %}
     </div>
     <div class="navbar-nav nav-pills navbar-collapse collapse order-2 collapse1 ms-auto justify-content-end">
         <div class="nav-item dropdown">

--- a/web/templates/web/_navigation.html
+++ b/web/templates/web/_navigation.html
@@ -5,7 +5,7 @@
 <header class="row" id="navbar-row">
     <nav class="navbar navbar-expand-md bg-light text-dark">
         <div class="container-fluid">
-            <div class="navbar-nav nav-pills me-auto w-100 me-auto order-0 w-100">
+            <div class="navbar-nav nav-pills me-auto me-auto order-0">
                 {% nav_link request 'web:home' 'Home' %}
                 {% if user.is_researcher %}
                     {% nav_link request 'exp:study-list' experimenter %}

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -99,7 +99,13 @@ def nav_link(request, url_name, text, html_classes=None):
         SafeText: HTML of navigation item
     """
     if html_classes is None:
-        html_classes = ["nav-link", "navbar-link", "link-secondary", "text-center"]
+        html_classes = [
+            "nav-link",
+            "navbar-link",
+            "link-secondary",
+            "text-center",
+            "px-3",
+        ]
     url = reverse(url_name)
     aria_current = ""
     if active_nav(request, url):


### PR DESCRIPTION
Bootstrap 5 changes to the experimenter app navigation bar. 
This is styled to match the web app nav bar, with some minor spacing differences to make the nav items fit nicely.
I also removed the "Recruitment Stats" (analytics page) navigation item from the experimenter nav bar because we have not updated that page for bootstrap 5.

Wide window
![Screenshot 2023-03-10 at 4 44 57 PM](https://user-images.githubusercontent.com/9041788/224454594-2887af10-5652-4b81-bfc3-b79e8596dc01.png)

Narrow window
![Screenshot 2023-03-10 at 4 45 15 PM](https://user-images.githubusercontent.com/9041788/224454601-6066ce40-61ba-45a6-90a2-37da2a1bcd34.png)

Help dropdown
![Screenshot 2023-03-10 at 4 45 29 PM](https://user-images.githubusercontent.com/9041788/224454611-104766ec-ecf4-4fe7-99f0-644b577fe77f.png)

Account dropdown
![Screenshot 2023-03-10 at 4 45 42 PM](https://user-images.githubusercontent.com/9041788/224454621-f11542c0-f3a0-43f4-8af4-db6585935dc2.png)

