### PR TITLE
BS5 content and navbar spacing

### DIFF
--- a/accounts/templates/accounts/participant_detail.html
+++ b/accounts/templates/accounts/participant_detail.html
@@ -13,14 +13,14 @@
 {% endbreadcrumb %}
 {% endblock breadcrumb %}
 {% block content %}
-    <h1>
-        {{ user.identicon_html }}
-        {% if user.nickname %}
-            {{ user.nickname }}
-        {% else %}
-            {% trans "Participant ID" %} {{ user.id }}
-        {% endif %}
-    </h1>
+    {% if user.nickname %}
+        {% set_variable user.identicon_html|add:" "|add:user.nickname as title_text %}
+    {% else %}
+        {% trans "Participant ID" as trans_ppt_id %}
+        {% set_variable user.id|stringformat:"d" as user_id_str %}
+        {% set_variable user.identicon_html|add:" "|add:trans_ppt_id|add:" "|add:user_id_str as title_text %}
+    {% endif %}
+    {% page_title title_text %}
     <div>Last Active: {{ user.last_login|date:"n/d/Y"|default:"N/A" }}</div>
     <div>Participant global ID: {{ user.uuid }}</div>
     <div class="row mb-3 mt-4">

--- a/accounts/templates/accounts/participant_list.html
+++ b/accounts/templates/accounts/participant_list.html
@@ -8,7 +8,7 @@
 {% endblock title %}
 {% block content %}
     {% button_primary_classes "btn-sm" as btn_primary_classes %}
-    <h1>Participants</h1>
+    {% page_title "Participants" %}
     <form method="get">
         <input id="search-participants"
                class="form-control"

--- a/exp/templates/exp/support.html
+++ b/exp/templates/exp/support.html
@@ -1,9 +1,10 @@
 {% extends "exp/base.html" %}
+{% load web_extras %}
 {% block title %}
     Support Lookit
 {% endblock title %}
 {% block content %}
-    <h1>How Researchers can Support Lookit</h1>
+    {% page_title "How Researchers can Support Lookit" %}
     <p>
         Lookit is free for labs to use, but like any open source software project, it's not free to run!
         On this page, you can learn about ways to keep Lookit running (and getting better!) for a long time

--- a/studies/templates/studies/_all_json_and_csv_data.html
+++ b/studies/templates/studies/_all_json_and_csv_data.html
@@ -4,7 +4,6 @@
 {% load web_extras %}
 {% load static %}
 {% load bootstrap_icons %}
-{% load web_extras %}
 {% block title %}
     All Responses | {{ study.name }}
 {% endblock title %}
@@ -36,7 +35,11 @@
     {% url 'exp:study-demographics-download-csv' pk=study.id as url_demographics_download_csv %}
     {% url 'exp:study-demographics-download-dict-csv' pk=study.id as url_demographics_download_dict %}
     {% button_primary_classes as btn_primary_classes %}
-    <h1>All Responses</h1>
+    {% if active == 'demographics' %}
+        {% page_title "Demographic Snapshots" %}
+    {% else %}
+        {% page_title "All Responses" %}
+    {% endif %}
     <div class="row">
         <div class="col">{% include "studies/_response_nav_tabs.html" with active=active %}</div>
     </div>

--- a/studies/templates/studies/_all_json_and_csv_data.html
+++ b/studies/templates/studies/_all_json_and_csv_data.html
@@ -43,245 +43,243 @@
     <div class="row">
         <div class="col">{% include "studies/_response_nav_tabs.html" with active=active %}</div>
     </div>
-    <div class="container px-4">
-        <div class="row my-4 all-responses">
-            <div class="col">
-                {% if active == 'all' %}
-                    <form id="data-options" method="get">
-                        {% if n_responses %}
-                            <p>
-                                Data about {{ n_responses }} response{{ n_responses|pluralize }} are available.
-                                {% if can_view_regular_responses and not can_view_preview_responses %}
-                                    <span><em>(Based on your permissions, no preview responses are included.)</em></span>
-                                {% endif %}
-                                {% if not can_view_regular_responses and can_view_preview_responses %}
-                                    <span><em>(Based on your permissions, only preview responses are included.)</em></span>
-                                {% endif %}
-                            </p>
-                        {% else %}
-                            <p>
-                                There are no responses with confirmed consent yet. Once there are responses with confirmed consent, data will be available for download. Data dictionaries for the overview and child data files are available for planning analyses.
-                            </p>
-                        {% endif %}
+    <div class="row my-4 all-responses">
+        <div class="col">
+            {% if active == 'all' %}
+                <form id="data-options" method="get">
+                    {% if n_responses %}
                         <p>
-                            The following options allow you to download files with the minimal identifying information needed for your analysis. Names and birthdates are available for download as needed, but must be redacted prior to publication. Files with names, global IDs, birthdates, exact ages at participation, or "additional info" fields are marked as identifiable in the filename.
+                            Data about {{ n_responses }} response{{ n_responses|pluralize }} are available.
+                            {% if can_view_regular_responses and not can_view_preview_responses %}
+                                <span><em>(Based on your permissions, no preview responses are included.)</em></span>
+                            {% endif %}
+                            {% if not can_view_regular_responses and can_view_preview_responses %}
+                                <span><em>(Based on your permissions, only preview responses are included.)</em></span>
+                            {% endif %}
                         </p>
-                        <div class="row">
-                            <div class="col">
-                                <p>Participant data to include with responses:</p>
-                                <div class="three-column-list">{% include "studies/_data_options.html" with data_options=data_options %}</div>
+                    {% else %}
+                        <p>
+                            There are no responses with confirmed consent yet. Once there are responses with confirmed consent, data will be available for download. Data dictionaries for the overview and child data files are available for planning analyses.
+                        </p>
+                    {% endif %}
+                    <p>
+                        The following options allow you to download files with the minimal identifying information needed for your analysis. Names and birthdates are available for download as needed, but must be redacted prior to publication. Files with names, global IDs, birthdates, exact ages at participation, or "additional info" fields are marked as identifiable in the filename.
+                    </p>
+                    <div class="row">
+                        <div class="col">
+                            <p>Participant data to include with responses:</p>
+                            <div class="three-column-list">{% include "studies/_data_options.html" with data_options=data_options %}</div>
+                        </div>
+                    </div>
+                    <hr />
+                    <div class="row">
+                        <div class="col">
+                            All response data
+                            <p class="fst-italic text-muted mt-2">
+                                The true "raw" data is most naturally represented in JSON format, a
+                                structured format that allows nesting (for instance, you might see a question1 field
+                                inside formData inside parent-survey). This file contains a list of all responses to
+                                your study; each response has basic information about the participant, account, and
+                                consent coding as well as what happened during the study. Fields you uncheck above will
+                                not be included in the summary information; however, the "expData" field may still include
+                                the child's birthdate as confirmed in the exit survey.
+                            </p>
+                        </div>
+                        <div class="col">
+                            <div class="text-end my-3 download-button">
+                                Data
+                                {% if n_responses %}
+                                    {% bootstrap_button bs_icon_download|add:" JSON" button_type="submit" button_class=btn_primary_classes id="download-all-data-json" formaction=url_download_all_json %}
+                                {% else %}
+                                    {% bootstrap_button bs_icon_download|add:" JSON" button_type="submit" button_class=btn_primary_classes id="download-all-data-json" formaction=url_download_all_json disabled="disabled" %}
+                                {% endif %}
                             </div>
                         </div>
-                        <hr />
+                    </div>
+                    <hr />
+                    <div class="row">
+                        <div class="col">
+                            Response overview
+                            <p class="fst-italic text-muted mt-2">
+                                The response overview file gives high-level information about each response - the account and child IDs, consent approval information, condition assignment, and information about the child such as gender and languages spoken. There is one row per response. This can be used in conjunction with frame data (below) to avoid having to parse JSON in your analysis.
+                            </p>
+                        </div>
+                        <div class="col">
+                            <div class="text-end my-3 download-button">
+                                Data
+                                {% if n_responses %}
+                                    {% bootstrap_button bs_icon_download|add:" CSV" button_type="submit" button_class=btn_primary_classes id="download-all-data-csv" formaction=url_download_all_csv %}
+                                {% else %}
+                                    {% bootstrap_button bs_icon_download|add:" CSV" button_type="submit" button_class=btn_primary_classes id="download-all-data-csv" formaction=url_download_all_csv disabled="disabled" %}
+                                {% endif %}
+                            </div>
+                            <div class="text-end my-3 download-button">
+                                Data dictionary
+                                {% bootstrap_button bs_icon_download|add:" CSV" button_type="submit" button_class=btn_primary_classes id="download-data-dict-csv" formaction=url_download_summary_dict %}
+                            </div>
+                        </div>
+                    </div>
+                    <hr />
+                    {% if study.show_frame_data %}
                         <div class="row">
                             <div class="col">
-                                All response data
+                                Frame data
                                 <p class="fst-italic text-muted mt-2">
-                                    The true "raw" data is most naturally represented in JSON format, a
-                                    structured format that allows nesting (for instance, you might see a question1 field
-                                    inside formData inside parent-survey). This file contains a list of all responses to
-                                    your study; each response has basic information about the participant, account, and
-                                    consent coding as well as what happened during the study. Fields you uncheck above will
-                                    not be included in the summary information; however, the "expData" field may still include
-                                    the child's birthdate as confirmed in the exit survey.
+                                    The frame data files include all of the information captured by the
+                                    individual frames of your experiment: for instance, text and selections on forms,
+                                    which option a participant clicked during a forced-choice trial, and events such as
+                                    entering or leaving fullscreen, pausing the study, or pressing buttons. These data
+                                    are shown in a "long" format, with one row per datum and columns for the key and value.
+                                    Birthdates entered in the exit survey are omitted.
                                 </p>
                             </div>
                             <div class="col">
                                 <div class="text-end my-3 download-button">
-                                    Data
+                                    Data (one file per response)
                                     {% if n_responses %}
-                                        {% bootstrap_button bs_icon_download|add:" JSON" button_type="submit" button_class=btn_primary_classes id="download-all-data-json" formaction=url_download_all_json %}
+                                        {% bootstrap_button bs_icon_download|add:" ZIP, CSVs" button_class=btn_primary_classes id="download-frame-data-csv" formaction=url_download_frame_data %}
                                     {% else %}
-                                        {% bootstrap_button bs_icon_download|add:" JSON" button_type="submit" button_class=btn_primary_classes id="download-all-data-json" formaction=url_download_all_json disabled="disabled" %}
-                                    {% endif %}
-                                </div>
-                            </div>
-                        </div>
-                        <hr />
-                        <div class="row">
-                            <div class="col">
-                                Response overview
-                                <p class="fst-italic text-muted mt-2">
-                                    The response overview file gives high-level information about each response - the account and child IDs, consent approval information, condition assignment, and information about the child such as gender and languages spoken. There is one row per response. This can be used in conjunction with frame data (below) to avoid having to parse JSON in your analysis.
-                                </p>
-                            </div>
-                            <div class="col">
-                                <div class="text-end my-3 download-button">
-                                    Data
-                                    {% if n_responses %}
-                                        {% bootstrap_button bs_icon_download|add:" CSV" button_type="submit" button_class=btn_primary_classes id="download-all-data-csv" formaction=url_download_all_csv %}
-                                    {% else %}
-                                        {% bootstrap_button bs_icon_download|add:" CSV" button_type="submit" button_class=btn_primary_classes id="download-all-data-csv" formaction=url_download_all_csv disabled="disabled" %}
-                                    {% endif %}
-                                </div>
-                                <div class="text-end my-3 download-button">
-                                    Data dictionary
-                                    {% bootstrap_button bs_icon_download|add:" CSV" button_type="submit" button_class=btn_primary_classes id="download-data-dict-csv" formaction=url_download_summary_dict %}
-                                </div>
-                            </div>
-                        </div>
-                        <hr />
-                        {% if study.show_frame_data %}
-                            <div class="row">
-                                <div class="col">
-                                    Frame data
-                                    <p class="fst-italic text-muted mt-2">
-                                        The frame data files include all of the information captured by the
-                                        individual frames of your experiment: for instance, text and selections on forms,
-                                        which option a participant clicked during a forced-choice trial, and events such as
-                                        entering or leaving fullscreen, pausing the study, or pressing buttons. These data
-                                        are shown in a "long" format, with one row per datum and columns for the key and value.
-                                        Birthdates entered in the exit survey are omitted.
-                                    </p>
-                                </div>
-                                <div class="col">
-                                    <div class="text-end my-3 download-button">
-                                        Data (one file per response)
-                                        {% if n_responses %}
-                                            {% bootstrap_button bs_icon_download|add:" ZIP, CSVs" button_class=btn_primary_classes id="download-frame-data-csv" formaction=url_download_frame_data %}
-                                        {% else %}
-                                            {% bootstrap_button bs_icon_download|add:" ZIP, CSVs" button_class=btn_primary_classes id="download-frame-data-csv" formaction=url_download_frame_data disabled="disabled" %}
-                                        {% endif %}
-                                    </div>
-                                    <div class="text-end my-3 download-button">
-                                        Data dictionary
-                                        {% if n_responses %}
-                                            {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-frame-dict-csv" formaction=url_download_frame_data_dict %}
-                                        {% else %}
-                                            {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-frame-dict-csv" formaction=url_download_frame_data_dict disabled="disabled" %}
-                                        {% endif %}
-                                    </div>
-                                </div>
-                            </div>
-                            <hr />
-                        {% endif %}
-                        <div class="row">
-                            <div class="col">
-                                Child data
-                                <p class="fst-italic text-muted mt-2">
-                                    The child data files contain one row per unique child. The data available about each child is the same as is available in the response summary CSV (with the exception of age at time of participation, which depends on the response time). All child data will be included in this file, regardless of selections above; you can use it to store this identifiable data separately from the response data.
-                                </p>
-                            </div>
-                            <div class="col">
-                                <div class="text-end my-3 download-button">
-                                    Data
-                                    {% if n_responses %}
-                                        {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-child-data-csv" formaction=url_download_children_summary_data %}
-                                    {% else %}
-                                        {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-child-data-csv" formaction=url_download_children_summary_data disabled="disabled" %}
+                                        {% bootstrap_button bs_icon_download|add:" ZIP, CSVs" button_class=btn_primary_classes id="download-frame-data-csv" formaction=url_download_frame_data disabled="disabled" %}
                                     {% endif %}
                                 </div>
                                 <div class="text-end my-3 download-button">
                                     Data dictionary
                                     {% if n_responses %}
-                                        {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-child-data-dict-csv" formaction=url_download_children_summary_data_dict %}
+                                        {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-frame-dict-csv" formaction=url_download_frame_data_dict %}
                                     {% else %}
-                                        {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-child-data-dict-csv" formaction=url_download_children_summary_data_dict disabled="disabled" %}
+                                        {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-frame-dict-csv" formaction=url_download_frame_data_dict disabled="disabled" %}
                                     {% endif %}
                                 </div>
                             </div>
                         </div>
                         <hr />
+                    {% endif %}
+                    <div class="row">
+                        <div class="col">
+                            Child data
+                            <p class="fst-italic text-muted mt-2">
+                                The child data files contain one row per unique child. The data available about each child is the same as is available in the response summary CSV (with the exception of age at time of participation, which depends on the response time). All child data will be included in this file, regardless of selections above; you can use it to store this identifiable data separately from the response data.
+                            </p>
+                        </div>
+                        <div class="col">
+                            <div class="text-end my-3 download-button">
+                                Data
+                                {% if n_responses %}
+                                    {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-child-data-csv" formaction=url_download_children_summary_data %}
+                                {% else %}
+                                    {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-child-data-csv" formaction=url_download_children_summary_data disabled="disabled" %}
+                                {% endif %}
+                            </div>
+                            <div class="text-end my-3 download-button">
+                                Data dictionary
+                                {% if n_responses %}
+                                    {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-child-data-dict-csv" formaction=url_download_children_summary_data_dict %}
+                                {% else %}
+                                    {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes id="download-child-data-dict-csv" formaction=url_download_children_summary_data_dict disabled="disabled" %}
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <hr />
+                    <div class="row">
+                        <div class="col">
+                            Tool: Check for collisions
+                            <p class="fst-italic text-muted mt-2">
+                                The hashed child and account IDs are extremely likely to be unique, but not guaranteed (about a 0.1% chance of a collision after 1500 participants). Use this tool to check whether there are any duplicate hashed IDs being used. (If so, let us know - we can fix that!)
+                            </p>
+                        </div>
+                        <div class="col">
+                            <div class="text-end my-3 download-button">
+                                {% bootstrap_button "Check now" button_class=btn_primary_classes id="check-for-collisions" url=url_hashed_id_collision_check %}
+                            </div>
+                            <div class="text-end my-3" style="clear:both;">
+                                <p id="collision-indicator"></p>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+                <hr />
+                {% if can_delete_preview_data %}
+                    <form method="post"
+                          action="{% url 'exp:study-delete-preview-responses' pk=study.id %}">
+                        {% csrf_token %}
                         <div class="row">
                             <div class="col">
-                                Tool: Check for collisions
+                                Tool: Delete preview data
                                 <p class="fst-italic text-muted mt-2">
-                                    The hashed child and account IDs are extremely likely to be unique, but not guaranteed (about a 0.1% chance of a collision after 1500 participants). Use this tool to check whether there are any duplicate hashed IDs being used. (If so, let us know - we can fix that!)
+                                    This utility will delete all preview data, including video, that you have collected for this study. You may find it helpful to clear out preview data to simplify analysis.
                                 </p>
                             </div>
                             <div class="col">
                                 <div class="text-end my-3 download-button">
-                                    {% bootstrap_button "Check now" button_class=btn_primary_classes id="check-for-collisions" url=url_hashed_id_collision_check %}
+                                    {% bootstrap_button "Delete all preview data" button_type="submit" button_class=btn_primary_classes id="delete-preview-data" %}
                                 </div>
                                 <div class="text-end my-3" style="clear:both;">
-                                    <p id="collision-indicator"></p>
+                                    <p id="delete-preview-indicator"></p>
                                 </div>
                             </div>
                         </div>
                     </form>
+                {% endif %}
+            {% endif %}
+            {% if active == 'demographics' %}
+                <form id="data-options-demo" method="get">
+                    <p>Data download options:</p>
+                    <div>
+                        <input id="include-participant-global"
+                               name="demo_options"
+                               type="checkbox"
+                               value="participant__global_id"/>
+                        <label for="include-participant-global">Include participant global IDs</label>
+                    </div>
                     <hr />
-                    {% if can_delete_preview_data %}
-                        <form method="post"
-                              action="{% url 'exp:study-delete-preview-responses' pk=study.id %}">
-                            {% csrf_token %}
-                            <div class="row">
-                                <div class="col">
-                                    Tool: Delete preview data
-                                    <p class="fst-italic text-muted mt-2">
-                                        This utility will delete all preview data, including video, that you have collected for this study. You may find it helpful to clear out preview data to simplify analysis.
-                                    </p>
-                                </div>
-                                <div class="col">
-                                    <div class="text-end my-3 download-button">
-                                        {% bootstrap_button "Delete all preview data" button_type="submit" button_class=btn_primary_classes id="delete-preview-data" %}
-                                    </div>
-                                    <div class="text-end my-3" style="clear:both;">
-                                        <p id="delete-preview-indicator"></p>
-                                    </div>
-                                </div>
-                            </div>
-                        </form>
-                    {% endif %}
-                {% endif %}
-                {% if active == 'demographics' %}
-                    <form id="data-options-demo" method="get">
-                        <p>Data download options:</p>
-                        <div>
-                            <input id="include-participant-global"
-                                   name="demo_options"
-                                   type="checkbox"
-                                   value="participant__global_id"/>
-                            <label for="include-participant-global">Include participant global IDs</label>
+                    <div class="row">
+                        <div class="col">
+                            <p>
+                                {% if n_responses %}
+                                    Demographic data ({{ n_responses }} snapshot{{ n_responses|pluralize }})
+                                {% else %}
+                                    There are no responses with confirmed consent yet. Once there are responses with confirmed consent, associated demographic data will be available for download. A data dictionary is available for planning analyses.
+                                {% endif %}
+                                {% if can_view_regular_responses and not can_view_preview_responses %}
+                                    <span><em>(Based on your permissions, no snapshots from preview responses are included.)</em></span>
+                                {% endif %}
+                                {% if not can_view_regular_responses and can_view_preview_responses %}
+                                    <span><em>(Based on your permissions, only snapshots from preview responses are included.)</em></span>
+                                {% endif %}
+                            </p>
+                            <p class="fst-italic text-muted mt-2">
+                                Each response is associated with a demographic data snapshot that captures the state of the participant's demographic survey at the time of the response. You may use this data to check on demographics of your study population, for instance to check how representative your sample is with respect to parental education, and may report your findings in aggregate.
+                            </p>
+                            <p class="fst-italic text-muted mt-2">
+                                Important: this data must never be published in conjunction with study video such that it would be possible to link the two - e.g., to determine that the person pictured has an approximate family income of $50K or lives in Iowa. At minimum, this likely means redacting all response and participant identifiers from the downloaded demographic file if publishing raw data.
+                            </p>
                         </div>
-                        <hr />
-                        <div class="row">
-                            <div class="col">
-                                <p>
-                                    {% if n_responses %}
-                                        Demographic data ({{ n_responses }} snapshot{{ n_responses|pluralize }})
-                                    {% else %}
-                                        There are no responses with confirmed consent yet. Once there are responses with confirmed consent, associated demographic data will be available for download. A data dictionary is available for planning analyses.
-                                    {% endif %}
-                                    {% if can_view_regular_responses and not can_view_preview_responses %}
-                                        <span><em>(Based on your permissions, no snapshots from preview responses are included.)</em></span>
-                                    {% endif %}
-                                    {% if not can_view_regular_responses and can_view_preview_responses %}
-                                        <span><em>(Based on your permissions, only snapshots from preview responses are included.)</em></span>
-                                    {% endif %}
-                                </p>
-                                <p class="fst-italic text-muted mt-2">
-                                    Each response is associated with a demographic data snapshot that captures the state of the participant's demographic survey at the time of the response. You may use this data to check on demographics of your study population, for instance to check how representative your sample is with respect to parental education, and may report your findings in aggregate.
-                                </p>
-                                <p class="fst-italic text-muted mt-2">
-                                    Important: this data must never be published in conjunction with study video such that it would be possible to link the two - e.g., to determine that the person pictured has an approximate family income of $50K or lives in Iowa. At minimum, this likely means redacting all response and participant identifiers from the downloaded demographic file if publishing raw data.
-                                </p>
+                        <div class="col">
+                            <div class="text-end my-3 download-button">
+                                Data
+                                {% if n_responses %}
+                                    {% bootstrap_button bs_icon_download|add:" JSON" button_class=btn_primary_classes button_type="submit" id="download-all-demo-json" formaction=url_demographics_download_json %}
+                                {% else %}
+                                    {% bootstrap_button bs_icon_download|add:" JSON" button_class=btn_primary_classes button_type="submit" id="download-all-demo-json" formaction=url_demographics_download_json disabled="disabled" %}
+                                {% endif %}
                             </div>
-                            <div class="col">
-                                <div class="text-end my-3 download-button">
-                                    Data
-                                    {% if n_responses %}
-                                        {% bootstrap_button bs_icon_download|add:" JSON" button_class=btn_primary_classes button_type="submit" id="download-all-demo-json" formaction=url_demographics_download_json %}
-                                    {% else %}
-                                        {% bootstrap_button bs_icon_download|add:" JSON" button_class=btn_primary_classes button_type="submit" id="download-all-demo-json" formaction=url_demographics_download_json disabled="disabled" %}
-                                    {% endif %}
-                                </div>
-                                <div class="text-end my-3 download-button">
-                                    Data
-                                    {% if n_responses %}
-                                        {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes button_type="submit" id="download-all-demo-csv" formaction=url_demographics_download_csv %}
-                                    {% else %}
-                                        {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes button_type="submit" id="download-all-demo-csv" formaction=url_demographics_download_csv disabled="disabled" %}
-                                    {% endif %}
-                                </div>
-                                <div class="text-end my-3 download-button">
-                                    Data dictionary
-                                    {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes button_type="submit" id="download-all-demo-dict-csv" formaction=url_demographics_download_dict %}
-                                </div>
+                            <div class="text-end my-3 download-button">
+                                Data
+                                {% if n_responses %}
+                                    {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes button_type="submit" id="download-all-demo-csv" formaction=url_demographics_download_csv %}
+                                {% else %}
+                                    {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes button_type="submit" id="download-all-demo-csv" formaction=url_demographics_download_csv disabled="disabled" %}
+                                {% endif %}
+                            </div>
+                            <div class="text-end my-3 download-button">
+                                Data dictionary
+                                {% bootstrap_button bs_icon_download|add:" CSV" button_class=btn_primary_classes button_type="submit" id="download-all-demo-dict-csv" formaction=url_demographics_download_dict %}
                             </div>
                         </div>
-                    </form>
-                {% endif %}
-            </div>
+                    </div>
+                </form>
+            {% endif %}
         </div>
     </div>
 {% endblock content %}

--- a/studies/templates/studies/lab_create.html
+++ b/studies/templates/studies/lab_create.html
@@ -11,7 +11,7 @@
 {% endbreadcrumb %}
 {% endblock breadcrumb %}
 {% block content %}
-    <h1>Create Lab</h1>
+    {% page_title "Create Lab" %}
     <form action="" enctype="multipart/form-data" method="post">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/studies/templates/studies/lab_detail.html
+++ b/studies/templates/studies/lab_detail.html
@@ -21,7 +21,7 @@
         {% set_variable "<div>You have requested to join this lab.</div>" as lab_join_message %}
     {% endif %}
     {% set_variable link_edit_lab|add:link_lab_members|add:lab_join_message as page_title_right_content %}
-    {% page_title lab.name btn=page_title_right_content %}
+    {% page_title lab.name right_side_elements=page_title_right_content %}
     <div class="row">
         <div class="col-12">
             <strong>Institution</strong>

--- a/studies/templates/studies/lab_detail.html
+++ b/studies/templates/studies/lab_detail.html
@@ -11,23 +11,17 @@
 {% endbreadcrumb %}
 {% endblock breadcrumb %}
 {% block content %}
-    <div class="d-flex justify-content-between">
-        <h1>{{ lab.name }}</h1>
-        <div class="d-flex flex-column justify-content-end">
-            <a href="{% url 'exp:lab-edit' pk=lab.id %}">Edit lab</a>
-            <a href="{% url 'exp:lab-members' pk=lab.id %}">View/Manage lab members</a>
-            {% if in_this_lab %}
-                You have joined this lab.
-            {% elif requested_this_lab %}
-                You have requested to join this lab.
-            {% else %}
-                <form action="{% url 'exp:lab-request' pk=lab.id %}" method="post">
-                    {% csrf_token %}
-                    {% bootstrap_button "Request to join" %}
-                </form>
-            {% endif %}
-        </div>
-    </div>
+    {% url 'exp:lab-edit' pk=lab.id as url_lab_edit %}
+    {% url 'exp:lab-members' pk=lab.id as url_lab_members %}
+    {% set_variable '<div><a href="'|add:url_lab_edit|add:'">Edit lab</a></div>' as link_edit_lab %}
+    {% set_variable '<div><a href="'|add:url_lab_members|add:'">View/manage lab members</a></div>' as link_lab_members %}
+    {% if in_this_lab %}
+        {% set_variable "<div>You have joined this lab.</div>" as lab_join_message %}
+    {% elif requested_this_lab %}
+        {% set_variable "<div>You have requested to join this lab.</div>" as lab_join_message %}
+    {% endif %}
+    {% set_variable link_edit_lab|add:link_lab_members|add:lab_join_message as page_title_right_content %}
+    {% page_title lab.name btn=page_title_right_content %}
     <div class="row">
         <div class="col-12">
             <strong>Institution</strong>

--- a/studies/templates/studies/lab_list.html
+++ b/studies/templates/studies/lab_list.html
@@ -2,16 +2,15 @@
 {% load django_bootstrap5 %}
 {% load bootstrap_icons %}
 {% load exp_extras %}
+{% load web_extras %}
 {% block title %}
     Labs
 {% endblock title %}
 {% block content %}
-    <div class="d-flex justify-content-between align-items-center">
-        <h1>View Labs</h1>
-        <div>
-            <a class="btn btn-success" href="{% url 'exp:lab-create' %}">{% bs_icon "plus" %} Create Lab</a>
-        </div>
-    </div>
+    {% url 'exp:lab-create' as url_exp_lab_create %}
+    {% bs_icon "plus" as bs_icon_plus %}
+    {% bootstrap_button bs_icon_plus|add:"Create Lab" href=url_exp_lab_create as btn_create_lab %}
+    {% page_title "View Labs" btn=btn_create_lab %}
     <div class="my-4">
         <form method="get">
             <input id="search-labs"

--- a/studies/templates/studies/lab_list.html
+++ b/studies/templates/studies/lab_list.html
@@ -11,7 +11,7 @@
     {% bs_icon "plus" as bs_icon_plus %}
     {% button_primary_classes as btn_primary_classes %}
     {% bootstrap_button bs_icon_plus|add:"Create Lab" href=url_exp_lab_create button_class=btn_primary_classes as btn_create_lab %}
-    {% page_title "View Labs" btn=btn_create_lab %}
+    {% page_title "View Labs" right_side_elements=btn_create_lab %}
     <div class="my-4">
         <form method="get">
             <input id="search-labs"

--- a/studies/templates/studies/lab_list.html
+++ b/studies/templates/studies/lab_list.html
@@ -9,7 +9,7 @@
 {% block content %}
     {% url 'exp:lab-create' as url_exp_lab_create %}
     {% bs_icon "plus" as bs_icon_plus %}
-    {% button_primary_classes "btn-sm" as btn_primary_classes %}
+    {% button_primary_classes as btn_primary_classes %}
     {% bootstrap_button bs_icon_plus|add:"Create Lab" href=url_exp_lab_create button_class=btn_primary_classes as btn_create_lab %}
     {% page_title "View Labs" btn=btn_create_lab %}
     <div class="my-4">

--- a/studies/templates/studies/lab_update.html
+++ b/studies/templates/studies/lab_update.html
@@ -15,7 +15,7 @@
     {% url 'exp:lab-edit' pk=lab.id as url_lab_edit %}
     {% button_primary_classes as btn_primary_classes %}
     {% button_secondary_classes as btn_secondary_classes %}
-    <h1>Update Lab</h1>
+    {% page_title "Update Lab" %}
     <form action="" enctype="multipart/form-data" method="post">
         {% csrf_token %}
         {% bootstrap_form_errors form %}

--- a/studies/templates/studies/study_attachments.html
+++ b/studies/templates/studies/study_attachments.html
@@ -24,7 +24,7 @@
     {% query_transform request sort='created_at' as sort_date_up %}
     {% query_transform request sort='-created_at' as sort_date_down %}
     {% button_primary_classes "mt-3" as btn_primary_classes %}
-    <h1>Videos</h1>
+    {% page_title "Videos" %}
     <div class="row">
         <div class="col">{% include "studies/_response_nav_tabs.html" with active="attachments" %}</div>
     </div>

--- a/studies/templates/studies/study_attachments.html
+++ b/studies/templates/studies/study_attachments.html
@@ -28,83 +28,81 @@
     <div class="row">
         <div class="col">{% include "studies/_response_nav_tabs.html" with active="attachments" %}</div>
     </div>
-    <div class="container px-4">
-        <div class="row">
-            <div class="col-12">
-                <span class="text-end">
-                    <form method="post">
-                        {% csrf_token %}
-                        {% bootstrap_button "Download all videos" button_class=btn_primary_classes button_type="submit" name="all-attachments" value="all" %}
-                        {% bootstrap_button "Download all consent videos" button_class=btn_primary_classes button_type="submit" name="all-consent-videos" value="all" %}
-                    </form>
-                </span>
-            </div>
-        </div>
-        <div class="row text-center justify-content-center mt-3">
-            <div class="col-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8">
-                <form method="get">
-                    <input id="search-attachments"
-                           class="form-control form-control-sm"
-                           name="match"
-                           placeholder="Filter video name"
-                           size="50"
-                           type="text"
-                           value="{{ match }}"/>
-                    <input type="hidden" name="sort" value="{{ sort }}"/>
+    <div class="row">
+        <div class="col-12">
+            <span class="text-end">
+                <form method="post">
+                    {% csrf_token %}
+                    {% bootstrap_button "Download all videos" button_class=btn_primary_classes button_type="submit" name="all-attachments" value="all" %}
+                    {% bootstrap_button "Download all consent videos" button_class=btn_primary_classes button_type="submit" name="all-consent-videos" value="all" %}
                 </form>
-            </div>
+            </span>
         </div>
-        <div class="row mt-3">
-            <div class="col-12">
-                <div class="table-responsive">
-                    <table class="study-attachments table table-striped">
-                        <caption class="visually-hidden">Study Attachments</caption>
-                        <thead>
+    </div>
+    <div class="row text-center justify-content-center mt-3">
+        <div class="col-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8">
+            <form method="get">
+                <input id="search-attachments"
+                       class="form-control form-control-sm"
+                       name="match"
+                       placeholder="Filter video name"
+                       size="50"
+                       type="text"
+                       value="{{ match }}"/>
+                <input type="hidden" name="sort" value="{{ sort }}"/>
+            </form>
+        </div>
+    </div>
+    <div class="row mt-3">
+        <div class="col-12">
+            <div class="table-responsive">
+                <table class="study-attachments table table-striped">
+                    <caption class="visually-hidden">Study Attachments</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">
+                                Name
+                                {% with url_attachments|add:"?"|add:sort_name_up as url_sort_name_up %}
+                                    {% bootstrap_button bs_icon_up button_class="btn btn-link ps-1 pe-0" button_type="link" href=url_sort_name_up %}
+                                {% endwith %}
+                                {% with url_attachments|add:"?"|add:sort_name_down as url_sort_name_down %}
+                                    {% bootstrap_button bs_icon_down button_class="btn btn-link px-0" button_type="link" href=url_sort_name_down %}
+                                {% endwith %}
+                            </th>
+                            <th scope="col">
+                                Date
+                                {% with url_attachments|add:"?"|add:sort_date_up as url_sort_date_up %}
+                                    {% bootstrap_button bs_icon_up button_class="btn btn-link ps-1 pe-0" button_type="link" href=url_sort_date_up %}
+                                {% endwith %}
+                                {% with url_attachments|add:"?"|add:sort_date_down as url_sort_date_down %}
+                                    {% bootstrap_button bs_icon_down button_class="btn btn-link px-0" button_type="link" href=url_sort_date_down %}
+                                {% endwith %}
+                            </th>
+                            <th scope="col"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for video in video_list %}
                             <tr>
-                                <th scope="col">
-                                    Name
-                                    {% with url_attachments|add:"?"|add:sort_name_up as url_sort_name_up %}
-                                        {% bootstrap_button bs_icon_up button_class="btn btn-link ps-1 pe-0" button_type="link" href=url_sort_name_up %}
-                                    {% endwith %}
-                                    {% with url_attachments|add:"?"|add:sort_name_down as url_sort_name_down %}
-                                        {% bootstrap_button bs_icon_down button_class="btn btn-link px-0" button_type="link" href=url_sort_name_down %}
-                                    {% endwith %}
-                                </th>
-                                <th scope="col">
-                                    Date
-                                    {% with url_attachments|add:"?"|add:sort_date_up as url_sort_date_up %}
-                                        {% bootstrap_button bs_icon_up button_class="btn btn-link ps-1 pe-0" button_type="link" href=url_sort_date_up %}
-                                    {% endwith %}
-                                    {% with url_attachments|add:"?"|add:sort_date_down as url_sort_date_down %}
-                                        {% bootstrap_button bs_icon_down button_class="btn btn-link px-0" button_type="link" href=url_sort_date_down %}
-                                    {% endwith %}
-                                </th>
-                                <th scope="col"></th>
+                                <td>
+                                    <span class="small">{{ video.full_name }}</span>
+                                </td>
+                                <td>{{ video.created_at|date:"n/j/Y g:i A"|default:"N/A" }}</td>
+                                <td>
+                                    <a href="{% url 'exp:study-response-video-download' pk=study.id video=video.pk %}?mode=download"
+                                       class="{% button_primary_classes %} btn-sm"> Download </a>
+                                </td>
                             </tr>
-                        </thead>
-                        <tbody>
-                            {% for video in video_list %}
-                                <tr>
-                                    <td>
-                                        <span class="small">{{ video.full_name }}</span>
-                                    </td>
-                                    <td>{{ video.created_at|date:"n/j/Y g:i A"|default:"N/A" }}</td>
-                                    <td>
-                                        <a href="{% url 'exp:study-response-video-download' pk=study.id video=video.pk %}?mode=download"
-                                           class="{% button_primary_classes %} btn-sm"> Download </a>
-                                    </td>
-                                </tr>
-                            {% empty %}
-                                <tr>
-                                    <td colspan="3">
-                                        <em>No videos available for download.</em>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                    <div class="text-end">{% include "studies/_paginator.html" with page=page_obj %}</div>
-                </div>
+                        {% empty %}
+                            <tr>
+                                <td colspan="3">
+                                    <em>No videos available for download.</em>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div class="text-end">{% include "studies/_paginator.html" with page=page_obj %}</div>
             </div>
         </div>
     </div>

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -29,7 +29,7 @@
             defer
             data-btn-primary-classes="{{ btn_primary_classes }}"
             data-btn-secondary-classes="{{ btn_secondary_classes }}"></script>
-    <h1>{{ study.name }}</h1>
+    {% page_title study.name %}
     <div class="row">
         <div class="col-2">
             {% include "studies/_image_display.html" with object=study large=1 %}

--- a/studies/templates/studies/study_edit.html
+++ b/studies/templates/studies/study_edit.html
@@ -26,90 +26,88 @@
     {% url 'exp:preview-detail' uuid=study.uuid as url_preview_detail %}
     {% url 'exp:study-edit' pk=study.id as url_cancel %}
     {% button_secondary_classes as btn_secondary_classes %}
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-10 offset-lg-1">
-                <div class="card bg-light my-4">
-                    <div class="card-header">
-                        <h3 class="card-subtitle my-1">
-                            Study Editor
-                            <div class="float-end me-4">
-                                {% bootstrap_button bs_icon_play_circle|add:"Preview Study" href=url_preview_detail button_class=btn_secondary_classes %}
-                            </div>
-                        </h3>
-                    </div>
-                    <div class="card-body">
-                        <form id="study-details-form" enctype="multipart/form-data" method="post">
-                            {% csrf_token %}
-                            {% include "studies/_study_fields.html" with form=form study=study %}
-                            {% include "studies/_study_type.html" with types=types create=0 currentType=study.study_type.id %}
-                            <div class="me-4 float-end">
-                                {% bootstrap_button "Cancel" button_class=btn_secondary_classes href=url_cancel %}
-                                <button type="button"
-                                        class="{% button_primary_classes %}"
-                                        data-bs-target="#save-study-confirmation"
-                                        id="save-button"
-                                        data-bs-toggle="modal">
-                                    Save Changes
-                                </button>
-                            </div>
-                            <div class="modal fade"
-                                 id="save-study-confirmation"
-                                 tabindex="-1"
-                                 aria-labelledby="save-study-confirmation-title"
-                                 aria-hidden="true">
-                                <div class="modal-dialog modal-dialog-centered">
-                                    <div class="modal-content">
-                                        <div class="modal-header">
-                                            <h5 class="modal-title" id="save-study-confirmation-title">Are you sure you want to modify {{ study.name }}?</h5>
-                                            <button type="button"
-                                                    class="btn-close"
-                                                    data-bs-dismiss="modal"
-                                                    aria-label="Close"></button>
+    <div class="row">
+        <div class="col-lg-10 offset-lg-1">
+            <div class="card bg-light my-4">
+                <div class="card-header">
+                    <h3 class="card-subtitle my-1">
+                        Study Editor
+                        <div class="float-end me-4">
+                            {% bootstrap_button bs_icon_play_circle|add:"Preview Study" href=url_preview_detail button_class=btn_secondary_classes %}
+                        </div>
+                    </h3>
+                </div>
+                <div class="card-body">
+                    <form id="study-details-form" enctype="multipart/form-data" method="post">
+                        {% csrf_token %}
+                        {% include "studies/_study_fields.html" with form=form study=study %}
+                        {% include "studies/_study_type.html" with types=types create=0 currentType=study.study_type.id %}
+                        <div class="me-4 float-end">
+                            {% bootstrap_button "Cancel" button_class=btn_secondary_classes href=url_cancel %}
+                            <button type="button"
+                                    class="{% button_primary_classes %}"
+                                    data-bs-target="#save-study-confirmation"
+                                    id="save-button"
+                                    data-bs-toggle="modal">
+                                Save Changes
+                            </button>
+                        </div>
+                        <div class="modal fade"
+                             id="save-study-confirmation"
+                             tabindex="-1"
+                             aria-labelledby="save-study-confirmation-title"
+                             aria-hidden="true">
+                            <div class="modal-dialog modal-dialog-centered">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title" id="save-study-confirmation-title">Are you sure you want to modify {{ study.name }}?</h5>
+                                        <button type="button"
+                                                class="btn-close"
+                                                data-bs-dismiss="modal"
+                                                aria-label="Close"></button>
+                                    </div>
+                                    {% if study.built or save_confirmation %}
+                                        <div id="save-study-confirmation-body" class="modal-body">
+                                            {% if study.built %}
+                                                <p id="invalidate-build-warning">
+                                                    You have already built an experiment runner!
+                                                    Because you are changing the runner version, you will need to rebuild these
+                                                    before you can preview or start your study.
+                                                </p>
+                                            {% endif %}
+                                            {% if save_confirmation %}
+                                                <p>
+                                                    This study has already been
+                                                    <strong>approved</strong>. If you edit this study, the system will
+                                                    automatically give it a rejected status. You will have to resubmit
+                                                    the study so your changes can be reviewed.
+                                                </p>
+                                                <p>
+                                                    If your changes are limited to
+                                                    <ul>
+                                                        <li>whether the study is discoverable</li>
+                                                        <li>whether the preview is shared</li>
+                                                        <li>the minimum and maximum age or criteria expression</li>
+                                                        <li>the participant eligibility description</li>
+                                                        <li>
+                                                            the
+                                                            <em>formatting</em>
+                                                            of your study protocol
+                                                        </li>
+                                                    </ul>
+                                                    then your study will stay in its {{ study.state }} state.
+                                                </p>
+                                            {% endif %}
                                         </div>
-                                        {% if study.built or save_confirmation %}
-                                            <div id="save-study-confirmation-body" class="modal-body">
-                                                {% if study.built %}
-                                                    <p id="invalidate-build-warning">
-                                                        You have already built an experiment runner!
-                                                        Because you are changing the runner version, you will need to rebuild these
-                                                        before you can preview or start your study.
-                                                    </p>
-                                                {% endif %}
-                                                {% if save_confirmation %}
-                                                    <p>
-                                                        This study has already been
-                                                        <strong>approved</strong>. If you edit this study, the system will
-                                                        automatically give it a rejected status. You will have to resubmit
-                                                        the study so your changes can be reviewed.
-                                                    </p>
-                                                    <p>
-                                                        If your changes are limited to
-                                                        <ul>
-                                                            <li>whether the study is discoverable</li>
-                                                            <li>whether the preview is shared</li>
-                                                            <li>the minimum and maximum age or criteria expression</li>
-                                                            <li>the participant eligibility description</li>
-                                                            <li>
-                                                                the
-                                                                <em>formatting</em>
-                                                                of your study protocol
-                                                            </li>
-                                                        </ul>
-                                                        then your study will stay in its {{ study.state }} state.
-                                                    </p>
-                                                {% endif %}
-                                            </div>
-                                        {% endif %}
-                                        <div class="modal-footer">
-                                            {% bootstrap_button "Discard Changes" button_class=btn_secondary_classes href=url_cancel %}
-                                            {% bootstrap_button "Save" button_class="btn btn-danger" id="save_study_details_confirm" type="submit" %}
-                                        </div>
+                                    {% endif %}
+                                    <div class="modal-footer">
+                                        {% bootstrap_button "Discard Changes" button_class=btn_secondary_classes href=url_cancel %}
+                                        {% bootstrap_button "Save" button_class="btn btn-danger" id="save_study_details_confirm" type="submit" %}
                                     </div>
                                 </div>
                             </div>
-                        </form>
-                    </div>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>

--- a/studies/templates/studies/study_form.html
+++ b/studies/templates/studies/study_form.html
@@ -22,24 +22,22 @@
     {% url 'exp:study-list' as url_cancel %}
     {% button_primary_classes as btn_primary_classes %}
     {% button_secondary_classes as btn_secondary_classes %}
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-10 offset-lg-1">
-                <div class="card bg-light my-4">
-                    <div class="card-header">
-                        <h3 class="card-subtitle my-1">Create Study</h3>
-                    </div>
-                    <div class="card-body">
-                        <form id="study-details-form" enctype="multipart/form-data" method="post">
-                            {% csrf_token %}
-                            {% include "studies/_study_fields.html" with form=form %}
-                            {% include "studies/_study_type.html" with types=types create=1 %}
-                            <div class="me-4 float-end">
-                                {% bootstrap_button "Cancel" button_class=btn_secondary_classes href=url_cancel %}
-                                {% bootstrap_button bs_icon_plus|add:"Create Study" button_class=btn_primary_classes button_type="submit" id="create-study-button" %}
-                            </div>
-                        </form>
-                    </div>
+    <div class="row">
+        <div class="col-lg-10 offset-lg-1">
+            <div class="card bg-light my-4">
+                <div class="card-header">
+                    <h3 class="card-subtitle my-1">Create Study</h3>
+                </div>
+                <div class="card-body">
+                    <form id="study-details-form" enctype="multipart/form-data" method="post">
+                        {% csrf_token %}
+                        {% include "studies/_study_fields.html" with form=form %}
+                        {% include "studies/_study_type.html" with types=types create=1 %}
+                        <div class="me-4 float-end">
+                            {% bootstrap_button "Cancel" button_class=btn_secondary_classes href=url_cancel %}
+                            {% bootstrap_button bs_icon_plus|add:"Create Study" button_class=btn_primary_classes button_type="submit" id="create-study-button" %}
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -12,7 +12,7 @@
     {% button_primary_classes as btn_primary_classes %}
     {% bootstrap_button bs_icon_plus|add:"Create Study" href=url_study_create button_class=btn_primary_classes as btn_create_study %}
     {% if can_create_study %}
-        {% page_title "Manage Studies" btn=btn_create_study %}
+        {% page_title "Manage Studies" right_side_elements=btn_create_study %}
     {% else %}
         {% page_title "Manage Studies" %}
     {% endif %}

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -9,12 +9,13 @@
 {% block content %}
     {% bs_icon "plus" as bs_icon_plus %}
     {% url 'exp:study-create' as url_study_create %}
-    <div class="d-flex flex-row bd-highlight mb-4 align-items-center">
-        <h1 class="me-auto">Manage Studies</h1>
-        {% if can_create_study %}
-            <div>{% bootstrap_button bs_icon_plus|add:"Create Study" href=url_study_create %}</div>
-        {% endif %}
-    </div>
+    {% button_primary_classes as btn_primary_classes %}
+    {% bootstrap_button bs_icon_plus|add:"Create Study" href=url_study_create button_class=btn_primary_classes as btn_create_study %}
+    {% if can_create_study %}
+        {% page_title "Manage Studies" btn=btn_create_study %}
+    {% else %}
+        {% page_title "Manage Studies" %}
+    {% endif %}
     <div class="row mx-5">
         <form method="get">
             <input id="search-studies"

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -9,8 +9,6 @@
 {% block content %}
     {% bs_icon "plus" as bs_icon_plus %}
     {% url 'exp:study-create' as url_study_create %}
-    {% query_transform request page='1' as qstring %}
-    {% set_variable "?"|add:qstring as url_query_string %}
     <div class="d-flex flex-row bd-highlight mb-4 align-items-center">
         <h1 class="me-auto">Manage Studies</h1>
         {% if can_create_study %}

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -30,7 +30,7 @@
     {% query_transform request sort='-date_created' as sort_date_down %}
     {% button_primary_classes as btn_primary_classes %}
     {% button_primary_classes "float-end my-3" as btn_primary_classes_create %}
-    <h1>Individual Responses</h1>
+    {% page_title "Individual Responses" %}
     <div class="row">
         <div class="col">{% include "studies/_response_nav_tabs.html" with active="individual" %}</div>
     </div>
@@ -208,9 +208,7 @@
                                 <input type="hidden" name="response_id"/>
                                 <h5 class="card-title">Download response</h5>
                                 <p class="card-text">Include with response download:</p>
-                                <div class="two-column-list mb-3">
-                                    {% include "studies/_data_options.html" with data_options=data_options %}
-                                </div>
+                                <div class="two-column-list mb-3">{% include "studies/_data_options.html" with data_options=data_options %}</div>
                                 <p class="card-text">
                                     <label for="data-type-selector">
                                         Data Type

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -34,250 +34,248 @@
     <div class="row">
         <div class="col">{% include "studies/_response_nav_tabs.html" with active="individual" %}</div>
     </div>
-    <div class="container px-4">
-        {% if response_data %}
-            <div class="row my-4">
-                <div class="col">
-                    <div class="table-responsive my-4">
-                        <table class="table table-striped table-hover caption-top study-responses">
-                            <caption class="visually-hidden">Study Responses</caption>
-                            <thead>
-                                <tr>
-                                    <th></th>
-                                    <th>Child ID</th>
-                                    <th>Response UUID</th>
-                                    <th>
-                                        Status
-                                        {% with url_responses_list|add:"?"|add:sort_status_up as url_sort_status_up %}
-                                            {% bootstrap_button bs_icon_up button_class="btn btn-link ps-1 pe-0" button_type="link" href=url_sort_status_up %}
-                                        {% endwith %}
-                                        {% with url_responses_list|add:"?"|add:sort_status_down as url_sort_status_down %}
-                                            {% bootstrap_button bs_icon_down button_class="btn btn-link px-0" button_type="link" href=url_sort_status_down %}
-                                        {% endwith %}
-                                    </th>
-                                    <th>
-                                        Date
-                                        {% with url_responses_list|add:"?"|add:sort_date_up as url_sort_date_up %}
-                                            {% bootstrap_button bs_icon_up button_class="btn btn-link ps-1 pe-0" button_type="link" href=url_sort_date_up %}
-                                        {% endwith %}
-                                        {% with url_responses_list|add:"?"|add:sort_date_down as url_sort_date_down %}
-                                            {% bootstrap_button bs_icon_down button_class="btn btn-link px-0" button_type="link" href=url_sort_date_down %}
-                                        {% endwith %}
-                                    </th>
+    {% if response_data %}
+        <div class="row my-4">
+            <div class="col">
+                <div class="table-responsive my-4">
+                    <table class="table table-striped table-hover caption-top study-responses">
+                        <caption class="visually-hidden">Study Responses</caption>
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>Child ID</th>
+                                <th>Response UUID</th>
+                                <th>
+                                    Status
+                                    {% with url_responses_list|add:"?"|add:sort_status_up as url_sort_status_up %}
+                                        {% bootstrap_button bs_icon_up button_class="btn btn-link ps-1 pe-0" button_type="link" href=url_sort_status_up %}
+                                    {% endwith %}
+                                    {% with url_responses_list|add:"?"|add:sort_status_down as url_sort_status_down %}
+                                        {% bootstrap_button bs_icon_down button_class="btn btn-link px-0" button_type="link" href=url_sort_status_down %}
+                                    {% endwith %}
+                                </th>
+                                <th>
+                                    Date
+                                    {% with url_responses_list|add:"?"|add:sort_date_up as url_sort_date_up %}
+                                        {% bootstrap_button bs_icon_up button_class="btn btn-link ps-1 pe-0" button_type="link" href=url_sort_date_up %}
+                                    {% endwith %}
+                                    {% with url_responses_list|add:"?"|add:sort_date_down as url_sort_date_down %}
+                                        {% bootstrap_button bs_icon_down button_class="btn btn-link px-0" button_type="link" href=url_sort_date_down %}
+                                    {% endwith %}
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for response in response_data %}
+                                <tr class="selectable-participant {% if response.response__is_preview %} preview-row{% endif %}"
+                                    id="response-participant-{{ forloop.counter }}"
+                                    data-response-id="{{ response.response__id }}"
+                                    data-response-uuid="{{ response.response__uuid }}">
+                                    <td>
+                                        {% if response.response__is_preview %}P{% endif %}
+                                    </td>
+                                    <td>{{ response.child__hashed_id }}</td>
+                                    <td>{{ response.response__uuid|truncatechars:9 }}</td>
+                                    <td>
+                                        {% if response.response__completed %}
+                                            Complete
+                                        {% else %}
+                                            Incomplete
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ response.response__date_created|date:"n/j/Y g:i A"|default:"N/A" }}</td>
                                 </tr>
-                            </thead>
-                            <tbody>
-                                {% for response in response_data %}
-                                    <tr class="selectable-participant {% if response.response__is_preview %} preview-row{% endif %}"
-                                        id="response-participant-{{ forloop.counter }}"
-                                        data-response-id="{{ response.response__id }}"
-                                        data-response-uuid="{{ response.response__uuid }}">
-                                        <td>
-                                            {% if response.response__is_preview %}P{% endif %}
-                                        </td>
-                                        <td>{{ response.child__hashed_id }}</td>
-                                        <td>{{ response.response__uuid|truncatechars:9 }}</td>
-                                        <td>
-                                            {% if response.response__completed %}
-                                                Complete
-                                            {% else %}
-                                                Incomplete
-                                            {% endif %}
-                                        </td>
-                                        <td>{{ response.response__date_created|date:"n/j/Y g:i A"|default:"N/A" }}</td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                        {% if can_view_regular_responses and not can_view_preview_responses %}
-                            <p class="text-center">
-                                <em>Based on your permissions, no preview responses are shown.</em>
-                            </p>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if can_view_regular_responses and not can_view_preview_responses %}
+                        <p class="text-center">
+                            <em>Based on your permissions, no preview responses are shown.</em>
+                        </p>
+                    {% endif %}
+                    {% if not can_view_regular_responses and can_view_preview_responses %}
+                        <p class="text-center">
+                            <em>Based on your permissions, only preview responses are shown.</em>
+                        </p>
+                    {% endif %}
+                    {% if not can_view_regular_responses and not can_view_preview_responses %}
+                        <p class="text-center">
+                            <em>You do not have permission to view responses.</em>
+                        </p>
+                    {% endif %}
+                    <div class="text-end">{% include "studies/_paginator.html" with page=page_obj %}</div>
+                </div>
+                <div class="card bg-light my-4">
+                    <div class="card-body">
+                        {% if can_edit_feedback %}
+                            <form class="feedback"
+                                  method="post"
+                                  action="{% url 'exp:study-response-submit-feedback' pk=study.id %}">
+                                {% csrf_token %}
+                                <h5 class="card-title">New Feedback</h5>
+                                <section class="form-group">
+                                    <label class="visually-hidden" for="response-feedback">Response feedback</label>
+                                    <textarea id="response-feedback"
+                                              class="form-control"
+                                              name="comment"
+                                              rows="4"
+                                              cols="50"></textarea>
+                                    <input type="hidden" name="response_id"/>
+                                    {% bootstrap_button "Create" button_type="submit" button_class=btn_primary_classes_create %}
+                                    <br />
+                                </section>
+                            </form>
                         {% endif %}
-                        {% if not can_view_regular_responses and can_view_preview_responses %}
-                            <p class="text-center">
-                                <em>Based on your permissions, only preview responses are shown.</em>
-                            </p>
-                        {% endif %}
-                        {% if not can_view_regular_responses and not can_view_preview_responses %}
-                            <p class="text-center">
-                                <em>You do not have permission to view responses.</em>
-                            </p>
-                        {% endif %}
-                        <div class="text-end">{% include "studies/_paginator.html" with page=page_obj %}</div>
+                        <section class="my-3">
+                            <h5 class="card-title">Existing Feedback:</h5>
+                            {% for response in response_list %}
+                                <div id="feedback-list-for-{{ response.id }}" class="feedback-list">
+                                    {% for feedback in response.feedback.all %}
+                                        {% if can_edit_feedback %}
+                                            <form method="post"
+                                                  class="small"
+                                                  action="{% url 'exp:study-response-submit-feedback' pk=study.id %}">
+                                                {% csrf_token %}
+                                                <div class="form-group">
+                                                    <label class="visually-hidden" for="feedback-edit-{{ feedback.id }}">
+                                                        <strong>Edit Feedback</strong>
+                                                    </label>
+                                                    <textarea id="feedback-edit-{{ feedback.id }}"
+                                                              class="form-control"
+                                                              name="comment"
+                                                              rows="2"
+                                                              cols="50">{{ feedback.comment }}</textarea>
+                                                    <input type="hidden" name="feedback_id" value="{{ feedback.id }}" />
+                                                    {% bootstrap_button "Update" button_type="submit" button_class="btn btn-warning float-end mt-3" %}
+                                                    <footer class="py-2">
+                                                        Added by: {{ feedback.researcher.get_full_name }}
+                                                    </footer>
+                                                </div>
+                                            </form>
+                                        {% else %}
+                                            <p class="card-text">{{ feedback.comment }}</p>
+                                            <footer class="py-2">
+                                                {{ feedback.researcher.get_full_name }}
+                                            </footer>
+                                        {% endif %}
+                                    {% empty %}
+                                        <em class="my-2">No feedback</em>
+                                    {% endfor %}
+                                </div>
+                            {% endfor %}
+                        </section>
                     </div>
+                </div>
+                {% if study.show_videos %}
                     <div class="card bg-light my-4">
                         <div class="card-body">
-                            {% if can_edit_feedback %}
-                                <form class="feedback"
-                                      method="post"
-                                      action="{% url 'exp:study-response-submit-feedback' pk=study.id %}">
-                                    {% csrf_token %}
-                                    <h5 class="card-title">New Feedback</h5>
-                                    <section class="form-group">
-                                        <label class="visually-hidden" for="response-feedback">Response feedback</label>
-                                        <textarea id="response-feedback"
-                                                  class="form-control"
-                                                  name="comment"
-                                                  rows="4"
-                                                  cols="50"></textarea>
-                                        <input type="hidden" name="response_id"/>
-                                        {% bootstrap_button "Create" button_type="submit" button_class=btn_primary_classes_create %}
-                                        <br />
-                                    </section>
-                                </form>
-                            {% endif %}
-                            <section class="my-3">
-                                <h5 class="card-title">Existing Feedback:</h5>
-                                {% for response in response_list %}
-                                    <div id="feedback-list-for-{{ response.id }}" class="feedback-list">
-                                        {% for feedback in response.feedback.all %}
-                                            {% if can_edit_feedback %}
-                                                <form method="post"
-                                                      class="small"
-                                                      action="{% url 'exp:study-response-submit-feedback' pk=study.id %}">
-                                                    {% csrf_token %}
-                                                    <div class="form-group">
-                                                        <label class="visually-hidden" for="feedback-edit-{{ feedback.id }}">
-                                                            <strong>Edit Feedback</strong>
-                                                        </label>
-                                                        <textarea id="feedback-edit-{{ feedback.id }}"
-                                                                  class="form-control"
-                                                                  name="comment"
-                                                                  rows="2"
-                                                                  cols="50">{{ feedback.comment }}</textarea>
-                                                        <input type="hidden" name="feedback_id" value="{{ feedback.id }}" />
-                                                        {% bootstrap_button "Update" button_type="submit" button_class="btn btn-warning float-end mt-3" %}
-                                                        <footer class="py-2">
-                                                            Added by: {{ feedback.researcher.get_full_name }}
-                                                        </footer>
-                                                    </div>
-                                                </form>
-                                            {% else %}
-                                                <p class="card-text">{{ feedback.comment }}</p>
-                                                <footer class="py-2">
-                                                    {{ feedback.researcher.get_full_name }}
-                                                </footer>
-                                            {% endif %}
-                                        {% empty %}
-                                            <em class="my-2">No feedback</em>
-                                        {% endfor %}
-                                    </div>
-                                {% endfor %}
-                            </section>
+                            <h5 class="card-title">Videos</h5>
+                            {% for response in response_data %}
+                                <div class="response-attachments"
+                                     id="resp-attachment-{{ forloop.counter }}"
+                                     style="display:none">
+                                    {% for video in response.videos %}
+                                        <div class="row pt-1">
+                                            <div class="col-12 col-md-8">{{ video.display_name|wordwrap:45 }}</div>
+                                            <div class="col-12 col-md-4">
+                                                <a target="_blank"
+                                                   rel="noreferrer noopener"
+                                                   href="{% url 'exp:study-response-video-download' pk=study.id video=video.pk %}?mode=view"
+                                                   class="{% button_primary_classes %} btn-sm"> View </a>
+                                                <a href="{% url 'exp:study-response-video-download' pk=study.id video=video.pk %}?mode=download"
+                                                   class="{% button_primary_classes %} btn-sm"> Download </a>
+                                            </div>
+                                        </div>
+                                    {% empty %}
+                                        <p class="card-text">
+                                            <em class="my-2">Expect a delay of a few minutes for videos to be available for download.</em>
+                                        </p>
+                                    {% endfor %}
+                                </div>
+                            {% endfor %}
                         </div>
                     </div>
-                    {% if study.show_videos %}
-                        <div class="card bg-light my-4">
-                            <div class="card-body">
-                                <h5 class="card-title">Videos</h5>
-                                {% for response in response_data %}
-                                    <div class="response-attachments"
-                                         id="resp-attachment-{{ forloop.counter }}"
-                                         style="display:none">
-                                        {% for video in response.videos %}
-                                            <div class="row pt-1">
-                                                <div class="col-12 col-md-8">{{ video.display_name|wordwrap:45 }}</div>
-                                                <div class="col-12 col-md-4">
-                                                    <a target="_blank"
-                                                       rel="noreferrer noopener"
-                                                       href="{% url 'exp:study-response-video-download' pk=study.id video=video.pk %}?mode=view"
-                                                       class="{% button_primary_classes %} btn-sm"> View </a>
-                                                    <a href="{% url 'exp:study-response-video-download' pk=study.id video=video.pk %}?mode=download"
-                                                       class="{% button_primary_classes %} btn-sm"> Download </a>
-                                                </div>
-                                            </div>
-                                        {% empty %}
-                                            <p class="card-text">
-                                                <em class="my-2">Expect a delay of a few minutes for videos to be available for download.</em>
-                                            </p>
-                                        {% endfor %}
-                                    </div>
-                                {% endfor %}
+                {% endif %}
+            </div>
+            <div class="col">
+                <form class="download"
+                      method="get"
+                      action="{% url "exp:study-responses-single-download" pk=study.pk %}">
+                    {% csrf_token %}
+                    <div class="card bg-light my-4">
+                        <div class="card-body">
+                            <input type="hidden" name="response_id"/>
+                            <h5 class="card-title">Download response</h5>
+                            <p class="card-text">Include with response download:</p>
+                            <div class="two-column-list mb-3">{% include "studies/_data_options.html" with data_options=data_options %}</div>
+                            <p class="card-text">
+                                <label for="data-type-selector">
+                                    Data Type
+                                </label>
+                            </p>
+                            <div class="input-group">
+                                <select class="form-select"
+                                        id="data-type-selector"
+                                        name="data-type-selector"
+                                        aria-label="Select data type">
+                                    <option value="json">
+                                        JSON
+                                    </option>
+                                    <option value="csv">
+                                        CSV summary
+                                    </option>
+                                    <option value="framedata">
+                                        CSV frame data
+                                    </option>
+                                </select>
+                                <span class="input-group-btn">
+                                    {% bootstrap_button "Download response" button_type="submit" button_class=btn_primary_classes name="download-individual-data" %}
+                                </span>
                             </div>
                         </div>
-                    {% endif %}
-                </div>
-                <div class="col">
-                    <form class="download"
-                          method="get"
-                          action="{% url "exp:study-responses-single-download" pk=study.pk %}">
-                        {% csrf_token %}
-                        <div class="card bg-light my-4">
-                            <div class="card-body">
-                                <input type="hidden" name="response_id"/>
-                                <h5 class="card-title">Download response</h5>
-                                <p class="card-text">Include with response download:</p>
-                                <div class="two-column-list mb-3">{% include "studies/_data_options.html" with data_options=data_options %}</div>
-                                <p class="card-text">
-                                    <label for="data-type-selector">
-                                        Data Type
-                                    </label>
-                                </p>
-                                <div class="input-group">
-                                    <select class="form-select"
-                                            id="data-type-selector"
-                                            name="data-type-selector"
-                                            aria-label="Select data type">
-                                        <option value="json">
-                                            JSON
-                                        </option>
-                                        <option value="csv">
-                                            CSV summary
-                                        </option>
-                                        <option value="framedata">
-                                            CSV frame data
-                                        </option>
-                                    </select>
-                                    <span class="input-group-btn">
-                                        {% bootstrap_button "Download response" button_type="submit" button_class=btn_primary_classes name="download-individual-data" %}
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </form>
-                    {% for response in response_data %}
-                        <div class="card bg-light my-4 response-summary"
-                             id="response-summary-{{ forloop.counter }}"
-                             style="display:none">
-                            <div class="card-body">
-                                <h5 class="card-title">
-                                    Response details
-                                </h5>
-                                <table class="table table-sm table-hover response-details">
-                                    <caption class="visually-hidden">Response Details</caption>
-                                    <thead>
-                                        <tr>
-                                            <th>
-                                                Name
-                                            </th>
-                                            <th>
-                                                Value
-                                            </th>
+                    </div>
+                </form>
+                {% for response in response_data %}
+                    <div class="card bg-light my-4 response-summary"
+                         id="response-summary-{{ forloop.counter }}"
+                         style="display:none">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                Response details
+                            </h5>
+                            <table class="table table-sm table-hover response-details">
+                                <caption class="visually-hidden">Response Details</caption>
+                                <thead>
+                                    <tr>
+                                        <th>
+                                            Name
+                                        </th>
+                                        <th>
+                                            Value
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for pair in response.summary %}
+                                        <tr class="{% if pair.name == 'Video privacy level' %} {% if pair.value == 'public' %} list-group-item-success {% elif pair.value == 'scientific' %} list-group-item-warning {% else %} list-group-item-danger {% endif %} {% endif %}">
+                                            <td tabindex="0" title="{{ pair.description }}">
+                                                {{ pair.name }}
+                                            </td>
+                                            <td>
+                                                {{ pair.value }}
+                                            </td>
                                         </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for pair in response.summary %}
-                                            <tr class="{% if pair.name == 'Video privacy level' %} {% if pair.value == 'public' %} list-group-item-success {% elif pair.value == 'scientific' %} list-group-item-warning {% else %} list-group-item-danger {% endif %} {% endif %}">
-                                                <td tabindex="0" title="{{ pair.description }}">
-                                                    {{ pair.name }}
-                                                </td>
-                                                <td>
-                                                    {{ pair.value }}
-                                                </td>
-                                            </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
-                            </div>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
                         </div>
-                    {% endfor %}
-                </div>
+                    </div>
+                {% endfor %}
             </div>
-        {% else %}
-            <div class="row">
-                <em class="my-3 text-center">No responses with confirmed consent.</em>
-            </div>
-        {% endif %}
-    </div>
+        </div>
+    {% else %}
+        <div class="row">
+            <em class="my-3 text-center">No responses with confirmed consent.</em>
+        </div>
+    {% endif %}
 {% endblock content %}

--- a/studies/templates/studies/study_responses_consent_ruling.html
+++ b/studies/templates/studies/study_responses_consent_ruling.html
@@ -25,7 +25,7 @@
 {% endbreadcrumb %}
 {% endblock breadcrumb %}
 {% block content %}
-    <h1>Consent Manager</h1>
+    {% page_title "Consent Manager" %}
     <div class="row">
         <div class="col">
             <div class="card">
@@ -179,9 +179,7 @@
                 <div class="card-body">
                     <ul class="list-group">
                         <li class="list-group-item list-group-item-warning d-flex justify-content-between align-items-center">
-                            <div class="fw-bold">
-                                Pending Responses
-                            </div>
+                            <div class="fw-bold">Pending Responses</div>
                             <span class="badge bg-secondary rounded-pill">{{ summary_statistics.responses.pending }}</span>
                         </li>
                         <li class="list-group-item list-group-item-success d-flex justify-content-between align-items-center">

--- a/web/static/js/resources.js
+++ b/web/static/js/resources.js
@@ -630,6 +630,8 @@ const chsLink = document.createElement('a')
 const labList = document.querySelector('#lab-list');
 
 let stateOption = document.createElement('option');
+stateOption.value = "";
+stateOption.innerHTML = "Select a state";
 let labListItem;
 let labLink;
 

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -112,10 +112,10 @@
             {% block nav %}
                 {% include "web/_navigation.html" %}
             {% endblock nav %}
-            {% block breadcrumb %}
-            {% endblock breadcrumb %}
-            {% bootstrap_messages %}
             <div class="container my-4">
+                {% block breadcrumb %}
+                {% endblock breadcrumb %}
+                {% bootstrap_messages %}
                 {% block content %}
                 {% endblock content %}
             </div>

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -113,8 +113,10 @@
                 {% include "web/_navigation.html" %}
             {% endblock nav %}
             {% bootstrap_messages %}
-            {% block content %}
-            {% endblock content %}
+            <div class="container my-4">
+                {% block content %}
+                {% endblock content %}
+            </div>
             {% block footer %}
                 {% include "web/_footer.html" %}
             {% endblock footer %}

--- a/web/templates/web/contact.html
+++ b/web/templates/web/contact.html
@@ -6,33 +6,31 @@
     Contact Us
 {% endblock title %}
 {% block content %}
-    <div class="{% main_content_container_classes %}">
-        <h1 class="{% main_heading_classes %}">Contact</h1>
-        <h3 class="{% subheading_classes %}">{% trans "Technical difficulties" %}</h3>
-        <div class="m-4">
-            <p>
-                {% trans "To report any technical difficulties during participation, please contact our team by email at " %}
-                <a href='mailto:lookit-tech@mit.edu'>lookit-tech@mit.edu</a>{% trans "." %}
-            </p>
-        </div>
-        <h3 class="{% subheading_classes %}">{% trans "Questions about the studies" %}</h3>
-        <div class="m-4">
-            <p>
-                {% trans "If you have any questions or concerns about the studies, please first check our FAQ. With any additional questions, please contact us at " %}<a href='mailto:lookit@mit.edu'>lookit@mit.edu</a>{% trans "." %}
-            </p>
-        </div>
-        <h3 class="{% subheading_classes %}">{% trans "For researchers" %}</h3>
-        <div class="m-4">
-            <p>
-                {% trans "Lookit is available to all developmental researchers, and the code is entirely open- To learn more about running your own studies or contributing, please check out the " %}
-                <a href='https://lookit.readthedocs.io/en/develop'
-                   target="_blank"
-                   rel="noopener">{% trans "documentation" %}</a>{% trans "." %}
-            </p>
-            <p>
-                {% trans "Several initial test studies of a prototype Lookit platform were completed in 2015; you can read about the results, and strengths and limitations of the platform, in " %}
-                <a href='https://direct.mit.edu/opmi/issue/1/1'>{% trans "these papers" %}</a>{% trans "." %}
-            </p>
-        </div>
+    {% page_title "Contact" %}
+    <h3 class="{% subheading_classes %}">{% trans "Technical difficulties" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "To report any technical difficulties during participation, please contact our team by email at " %}
+            <a href='mailto:lookit-tech@mit.edu'>lookit-tech@mit.edu</a>{% trans "." %}
+        </p>
+    </div>
+    <h3 class="{% subheading_classes %}">{% trans "Questions about the studies" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "If you have any questions or concerns about the studies, please first check our FAQ. With any additional questions, please contact us at " %}<a href='mailto:lookit@mit.edu'>lookit@mit.edu</a>{% trans "." %}
+        </p>
+    </div>
+    <h3 class="{% subheading_classes %}">{% trans "For researchers" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "Lookit is available to all developmental researchers, and the code is entirely open- To learn more about running your own studies or contributing, please check out the " %}
+            <a href='https://lookit.readthedocs.io/en/develop'
+               target="_blank"
+               rel="noopener">{% trans "documentation" %}</a>{% trans "." %}
+        </p>
+        <p>
+            {% trans "Several initial test studies of a prototype Lookit platform were completed in 2015; you can read about the results, and strengths and limitations of the platform, in " %}
+            <a href='https://direct.mit.edu/opmi/issue/1/1'>{% trans "these papers" %}</a>{% trans "." %}
+        </p>
     </div>
 {% endblock content %}

--- a/web/templates/web/contact.html
+++ b/web/templates/web/contact.html
@@ -1,26 +1,27 @@
 {% extends "web/base.html" %}
 {% load django_bootstrap5 %}
 {% load i18n %}
+{% load web_extras %}
 {% block title %}
     Contact Us
 {% endblock title %}
 {% block content %}
-    <div class="container m-4">
-        <h2 class="mx-4 my-5">Contact</h2>
-        <h3 class="m-4">{% trans "Technical difficulties" %}</h3>
+    <div class="{% main_content_container_classes %}">
+        <h1 class="{% main_heading_classes %}">Contact</h1>
+        <h3 class="{% subheading_classes %}">{% trans "Technical difficulties" %}</h3>
         <div class="m-4">
             <p>
                 {% trans "To report any technical difficulties during participation, please contact our team by email at " %}
                 <a href='mailto:lookit-tech@mit.edu'>lookit-tech@mit.edu</a>{% trans "." %}
             </p>
         </div>
-        <h3 class="m-4">{% trans "Questions about the studies" %}</h3>
+        <h3 class="{% subheading_classes %}">{% trans "Questions about the studies" %}</h3>
         <div class="m-4">
             <p>
                 {% trans "If you have any questions or concerns about the studies, please first check our FAQ. With any additional questions, please contact us at " %}<a href='mailto:lookit@mit.edu'>lookit@mit.edu</a>{% trans "." %}
             </p>
         </div>
-        <h3 class="m-4">{% trans "For researchers" %}</h3>
+        <h3 class="{% subheading_classes %}">{% trans "For researchers" %}</h3>
         <div class="m-4">
             <p>
                 {% trans "Lookit is available to all developmental researchers, and the code is entirely open- To learn more about running your own studies or contributing, please check out the " %}

--- a/web/templates/web/faq.html
+++ b/web/templates/web/faq.html
@@ -2,13 +2,14 @@
 {% load static %}
 {% load django_bootstrap5 %}
 {% load i18n %}
+{% load web_extras %}
 {% block title %}
     FAQ
 {% endblock title %}
 {% block content %}
-    <div class="container m-4">
-        <h2 class="mx-4 my-5">{% trans "Frequently Asked Questions" %}</h2>
-        <h3 class="m-4">{% trans "Participation" %}</h3>
+    <div class="{% main_content_container_classes %}">
+        <h1 class="{% main_heading_classes %}">{% trans "Frequently Asked Questions" %}</h1>
+        <h3 class="{% subheading_classes %}">{% trans "Participation" %}</h3>
         <div class="accordion m-4" id="faq-accordion-participation">
             <div class="accordion-item">
                 <h2 class="accordion-header" id="heading-1">
@@ -634,7 +635,7 @@
                 </div>
             </div>
         </div>
-        <h3 class="m-4">
+        <h3 class="{% subheading_classes %}">
             {% trans "Technical" %}
         </h3>
         <div class="accordion m-4" id="faq-accordion-technical">
@@ -729,7 +730,7 @@
                 </div>
             </div>
         </div>
-        <h3 class="m-4">
+        <h3 class="{% subheading_classes %}">
             {% trans "For Researchers" %}
         </h3>
         <div class="accordion m-4" id="faq-accordion-for-researchers">

--- a/web/templates/web/faq.html
+++ b/web/templates/web/faq.html
@@ -7,27 +7,27 @@
     FAQ
 {% endblock title %}
 {% block content %}
-    <div class="{% main_content_container_classes %}">
-        <h1 class="{% main_heading_classes %}">{% trans "Frequently Asked Questions" %}</h1>
-        <h3 class="{% subheading_classes %}">{% trans "Participation" %}</h3>
-        <div class="accordion m-4" id="faq-accordion-participation">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-1">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-1"
-                            aria-expanded="false"
-                            aria-controls="collapse-1">
-                        {% trans "What is a 'study' about cognitive development?" %}
-                    </button>
-                </h2>
-                <div id="collapse-1"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-1"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+    {% trans "Frequently Asked Questions" as trans_faq %}
+    {% page_title trans_faq %}
+    <h3 class="{% subheading_classes %}">{% trans "Participation" %}</h3>
+    <div class="accordion m-4" id="faq-accordion-participation">
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-1">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-1"
+                        aria-expanded="false"
+                        aria-controls="collapse-1">
+                    {% trans "What is a 'study' about cognitive development?" %}
+                </button>
+            </h2>
+            <div id="collapse-1"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-1"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Cognitive development is the science of what kids understand and how they learn. Researchers in cognitive development are interested in questions like...</p>
                 <ul>
                     <li>What knowledge and abilities infants are born with, and what they have to learn from experience</li>
@@ -36,26 +36,26 @@
                 </ul>
                 <p>A study is meant to answer a very specific question about how children learn or what they know: for instance, 'Do three-month-olds recognize their parents' faces?'</p>
 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-2">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-2"
-                            aria-expanded="false"
-                            aria-controls="collapse-2">
-                        {% trans "Why participate in developmental research?" %}
-                    </button>
-                </h2>
-                <div id="collapse-2"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-2"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate%}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-2">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-2"
+                        aria-expanded="false"
+                        aria-controls="collapse-2">
+                    {% trans "Why participate in developmental research?" %}
+                </button>
+            </h2>
+            <div id="collapse-2"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-2"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate%}
                 <p>Lots of reasons! Here are three:</p>
                 <ul>
                     <li>Researchers work hard to make the studies engaging for children and families. We hope the study is fun for you and your child!</li>
@@ -63,26 +63,26 @@
                     <li>While research studies aren't usually designed to affect outcomes for individual children, the more we understand about children, the more effective we can be in building a world where they learn and thrive. Your participation helps all of us!</li>
                 </ul>
 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-3">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-3"
-                            aria-expanded="false"
-                            aria-controls="collapse-3">
-                        {% trans "What happens when my child participates in a research study?" %}
-                    </button>
-                </h2>
-                <div id="collapse-3"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-3"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate%}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-3">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-3"
+                        aria-expanded="false"
+                        aria-controls="collapse-3">
+                    {% trans "What happens when my child participates in a research study?" %}
+                </button>
+            </h2>
+            <div id="collapse-3"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-3"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate%}
                             <p>If you have a child and would like to participate, create an account [LINK] and take a look at what we have available for your child's age range.  Some studies can be done at any time, and some involve a scheduled video chat with a university-based researcher. Most studies require a laptop/desktop with a webcam. The study description will tell you if you need any other supplies (such as a marker and paper, or a high chair for your baby to sit in.)</p>
                             <p>Each study will begin in the same way: you and your child will learn what the research is about, and you can then decide whether or not you want to do it. In most cases you'll be asked to read a consent form and record yourself stating that you and your child agree to participate. In other cases, you may electronically sign a form. In addition to permission from their parent or guardian, older children will also be asked directly if they want to participate.</p>
                             <p>Individual studies vary widely- we encourage you to try lots of different ones! Depending on your child's age, your child may answer questions directly or we may be looking for indirect signs of what she thinks is going on--like how long she looks at a surprising outcome. Some things that may happen in studies include:</p>
@@ -94,72 +94,72 @@
                             </ul>
                             <p>Some portions of the study will be automatically recorded using your webcam and sent securely to the Lookit platform. Trained researchers will watch the video and record your child's responses--for instance, which way he pointed, or how long she looked at each image. We'll put these together with responses from lots of other children to learn more about how kids think!</p>
 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-4">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-4"
-                            aria-expanded="false"
-                            aria-controls="collapse-4">
-                        {% trans "Who creates the studies?" %}
-                    </button>
-                </h2>
-                <div id="collapse-4"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-4"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% url "web:termsofuse" as termsofuse %}
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-4">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-4"
+                        aria-expanded="false"
+                        aria-controls="collapse-4">
+                    {% trans "Who creates the studies?" %}
+                </button>
+            </h2>
+            <div id="collapse-4"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-4"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% url "web:termsofuse" as termsofuse %}
+                    {% blocktranslate %}
                 <p>All of the research conducted on the website is created by scientists to learn about child development, leading to articles in scientific journals. These publications can help inform other scientists, parents, educators, and policy-makers. Usually, these scientists work at colleges, universities, or hospitals. Rarely, a scientist who works at a nonprofit or a company might also do a study that fits this goal. If a study is meant to publish results in scientific journals for everyone to see (instead of just for one nonprofit or company), then it is possible it would appear on this website.</p>
                 <p>If a scientist wants to use this platform, their institution has to sign a contract with MIT where they agree to the <a href="{{ termsofuse }}">Terms of Use</a> and certify that their studies will be reviewed and approved by an institutional review board. Studies are also subject to review and approval by Lookit/Children Helping Science. As of January 2022, we have agreements with over 50 universities, including institutions in the United States, Canada, the United Kingdom, and European Union.</p>
 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-7">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-7"
-                            aria-expanded="false"
-                            aria-controls="collapse-7">
-                        {% trans "Who will my child and I meet when we do a study involving a scheduled video chat?" %}
-                    </button>
-                </h2>
-                <div id="collapse-7"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-7"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-7">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-7"
+                        aria-expanded="false"
+                        aria-controls="collapse-7">
+                    {% trans "Who will my child and I meet when we do a study involving a scheduled video chat?" %}
+                </button>
+            </h2>
+            <div id="collapse-7"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-7"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>The studies hosted on our site come from universities all around the world. For studies that involve a scheduled video chat, you will meet a researcher from the lab associated with the university doing the study. These researchers work as part of a team that always includes a "principal investigator" -- the supervisor (usually a professor) who is in charge of the lab). Studies will be conducted by someone under the direct supervision of that principal investigator (e.g., a lab manager, research assistant, or a postdoctoral, graduate, or undergraduate researcher in training).</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-8">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-8"
-                            aria-expanded="false"
-                            aria-controls="collapse-8">
-                        {% trans "Why are you running studies online instead of in person?" %}
-                    </button>
-                </h2>
-                <div id="collapse-8"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-8"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-8">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-8"
+                        aria-expanded="false"
+                        aria-controls="collapse-8">
+                    {% trans "Why are you running studies online instead of in person?" %}
+                </button>
+            </h2>
+            <div id="collapse-8"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-8"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Traditionally, developmental studies happen in a quiet room in a university lab. Researchers call or email local parents to see if they'd like to take part and schedule an appointment for them to come visit the lab.</p>
                 <p>While researchers have been exploring online studies with children for several years, the COVID pandemic in 2020 forced most developmental labs to stop in-person visits entirely. Some studies will always need to take place in a lab, but some work very well online, and we have found these studies have a number of benefits for both families and scientists.</p>
                 <p>Why complement these in-lab studies with online ones? We're hoping to...</p>
@@ -174,83 +174,83 @@
                     <li>Communicate with families about the research we're doing and what we can learn from it</li>
                 </ul>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-9">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-9"
-                            aria-expanded="false"
-                            aria-controls="collapse-9">
-                        {% trans "How do we provide consent to participate?" %}
-                    </button>
-                </h2>
-                <div id="collapse-9"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-9"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-9">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-9"
+                        aria-expanded="false"
+                        aria-controls="collapse-9">
+                    {% trans "How do we provide consent to participate?" %}
+                </button>
+            </h2>
+            <div id="collapse-9"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-9"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Rather than having the parent or legal guardian sign a form, we ask that you read aloud (or sign in ASL) a statement of consent which is recorded using your webcam. This statement holds the same weight as a signed form, but should be less hassle for you. It also lets us verify that you understand written English and that you understand you're being videotaped.</p>
                 <p>Researchers watch these consent videos on a special page of the researcher interface, and record for each one whether the video shows informed consent. They cannot view other video or download data from a session unless they have confirmed that you consented to participate! If they see a consent video that does NOT clearly demonstrate informed consent--for instance, there was a technical problem and there's no audio--they may contact you to check, depending on your email settings.</p>
                 {% endblocktranslate %}
-                        <div class="d-flex justify-content-center">
-                            <video controls preload="metadata">
-                                <source src="{% static 'videos/consent.mp4' %}" type="video/mp4"/>
-                                <track label="English"
-                                       kind="captions"
-                                       srclang="en"
-                                       src="{% static 'videos/english/consent.vtt' %}"/>
-                            </video>
-                        </div>
+                    <div class="d-flex justify-content-center">
+                        <video controls preload="metadata">
+                            <source src="{% static 'videos/consent.mp4' %}" type="video/mp4"/>
+                            <track label="English"
+                                   kind="captions"
+                                   srclang="en"
+                                   src="{% static 'videos/english/consent.vtt' %}"/>
+                        </video>
                     </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-10">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-10"
-                            aria-expanded="false"
-                            aria-controls="collapse-10">
-                        {% trans "How is our information kept secure and confidential?" %}
-                    </button>
-                </h2>
-                <div id="collapse-10"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-10"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-10">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-10"
+                        aria-expanded="false"
+                        aria-controls="collapse-10">
+                    {% trans "How is our information kept secure and confidential?" %}
+                </button>
+            </h2>
+            <div id="collapse-10"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-10"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Researchers using Lookit agree to uphold a common set of standards about how data is protected and shared. For instance, they never publish children's names or birthdates, or information that could be used to calculate a birthdate.</p>
                 <p>The Lookit researcher interface is designed with participant data protection as the top priority. For instance, a special interface lets researchers confirm consent videos before they are able to download any other data from your session. Research groups can control who has access to what data in a very fine-grained way, for instance allowing an assistant to confirm consent and send gift cards, but not download study data.</p>
                 <p>All of your data, including video, is transmitted over a secure HTTPS connection to Lookit storage, and is encrypted at rest. We take security very seriously; in addition to making sure any software we use is up-to-date, cloud servers are configured securely, and unit tests cover checking that accessing data requires correct permissions, we conducted a risk assessment and detailed manual penetration testing with a security contractor prior to our 2020 launch.</p>
                 <p>See also 'Who will see our video?'</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-11">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-11"
-                            aria-expanded="false"
-                            aria-controls="collapse-11">
-                        {% trans "Who will see our video?" %}
-                    </button>
-                </h2>
-                <div id="collapse-11"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-11"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-11">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-11"
+                        aria-expanded="false"
+                        aria-controls="collapse-11">
+                    {% trans "Who will see our video?" %}
+                </button>
+            </h2>
+            <div id="collapse-11"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-11"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Lookit staff at MIT will have access to your video and other data in order to improve and promote the platform and help with troubleshooting. The researchers running the study you participated in will also have access to your video and other data (like responses to questions during the study, and information you fill out when registering a child) for research purposes. They will watch the video segments you send to mark down information specific to the study--for instance, what your child said, or how long he/she looked to the left versus the right of the screen. This research group may be at MIT or at another institution. All studies run on Lookit must be approved by an Institutional Review Board (IRB) that ensures participants' rights and welfare are protected. All researchers using Lookit also agree to Terms of Use that govern what data they can share and what sorts of studies are okay to run on Lookit; these rules are sometimes stricter than their own institution might be.  </p>
                 <p>Whether anyone else may view the video depends on the privacy settings you select at the end of the study. There are two decisions to make: whether to share your data with Databrary, and how to allow your video clips to be used by the researchers you have selected.</p>
                 <p>First, we ask if you would like to share your data (including video) with authorized users fo the secure data library Databrary. Data sharing will lead to faster progress in research on human development and behavior. Researchers who are granted access to the Databrary library must agree to treat the data with the same high standard of care they would use in their own laboratories. Learn more about Databrary's <a href="https://databrary.org/about.html">mission</a> or the <a href="https://databrary.org/about/agreement.html">requirements for authorized users</a>.</p>
@@ -262,523 +262,522 @@
                 </ul>
                 <p>If for some reason you do not select a privacy level, we treat the data as 'Private' and do not share with Databrary. Participants also have the option to withdraw all video besides consent at the end of the study if necessary (for instance, because someone was discussing state secrets in the background), and in this case it is automatically deleted. Privacy settings for completed sessions cannot automatically be changed retroactively. If you have any questions or concerns about privacy, please contact our team at <a href="mailto:lookit@mit.edu">lookit@mit.edu</a>.</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-12">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-12"
-                            aria-expanded="false"
-                            aria-controls="collapse-12">
-                        {% trans "What information do researchers use from our video?" %}
-                    </button>
-                </h2>
-                <div id="collapse-12"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-12"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        <p>
-                            {% trans "For children under about two years old, we usually design our studies to let their eyes do the talking! We're interested in where on the screen your child looks and/or how long your child looks at the screen rather than looking away. Our calibration videos (example shown below) help us get an idea of what it looks like when your child is looking to the right or the left, so we can code the rest of the video." %}
-                        </p>
-                        <div class="d-flex justify-content-center">
-                            <video controls preload="metadata">
-                                <source src="{% static 'videos/attentiongrabber.mp4' %}" type="video/mp4"/>
-                                <track label="English"
-                                       kind="captions"
-                                       srclang="en"
-                                       src="{% static 'videos/english/attentiongrabber.vtt' %}"/>
-                            </video>
-                        </div>
-                        <p>
-                            {% trans "Here's an example of a few children watching our calibration video--it's easy to see that they look to one side and then the other." %}
-                        </p>
-                        <div class="d-flex justify-content-center">
-                            <video controls preload="metadata">
-                                <source src="{% static 'videos/spinningball.mp4' %}" type="video/mp4"/>
-                                <track label="English"
-                                       kind="captions"
-                                       srclang="en"
-                                       src="{% static 'videos/english/spinningball.vtt' %}"/>
-                            </video>
-                        </div>
-                        <p>
-                            {% trans "Your child's decisions about where to look can give us lots of information about what he or she understands. Here are some of the techniques labs use to learn more about how children learn." %}
-                        </p>
-                        <h4>
-                            {% trans "Habituation" %}
-                        </h4>
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-12">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-12"
+                        aria-expanded="false"
+                        aria-controls="collapse-12">
+                    {% trans "What information do researchers use from our video?" %}
+                </button>
+            </h2>
+            <div id="collapse-12"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-12"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    <p>
+                        {% trans "For children under about two years old, we usually design our studies to let their eyes do the talking! We're interested in where on the screen your child looks and/or how long your child looks at the screen rather than looking away. Our calibration videos (example shown below) help us get an idea of what it looks like when your child is looking to the right or the left, so we can code the rest of the video." %}
+                    </p>
+                    <div class="d-flex justify-content-center">
+                        <video controls preload="metadata">
+                            <source src="{% static 'videos/attentiongrabber.mp4' %}" type="video/mp4"/>
+                            <track label="English"
+                                   kind="captions"
+                                   srclang="en"
+                                   src="{% static 'videos/english/attentiongrabber.vtt' %}"/>
+                        </video>
+                    </div>
+                    <p>
+                        {% trans "Here's an example of a few children watching our calibration video--it's easy to see that they look to one side and then the other." %}
+                    </p>
+                    <div class="d-flex justify-content-center">
+                        <video controls preload="metadata">
+                            <source src="{% static 'videos/spinningball.mp4' %}" type="video/mp4"/>
+                            <track label="English"
+                                   kind="captions"
+                                   srclang="en"
+                                   src="{% static 'videos/english/spinningball.vtt' %}"/>
+                        </video>
+                    </div>
+                    <p>
+                        {% trans "Your child's decisions about where to look can give us lots of information about what he or she understands. Here are some of the techniques labs use to learn more about how children learn." %}
+                    </p>
+                    <h4>
+                        {% trans "Habituation" %}
+                    </h4>
+                    {% blocktranslate %}
                 <p>In a habituation study, we first show infants many examples of one type of object or event, and they lose interest over time. Infants typically look for a long time at the first pictures, but then they start to look away more quickly. Once their looking times are much less than they were initially, we show either a picture from a new category or a new picture from the familiar category. If infants now look longer to the novel example, we can tell that they understood--and got bored of--the category we showed initially.</p> <p>Habituation requires waiting for each individual infant to achieve some threshold of "boredness"--for instance, looking half as long at a picture as he or she did initially. Sometimes this is impractical, and we use familiarization instead. In a familiarization study, we show all babies the same number of examples, and then see how interested they are in the familiar versus a new category. Younger infants and those who have seen few examples tend to show a familiarity preference--they look longer at images similar to what they have seen before. Older infants and those who have seen many examples tend to show a novelty preference--they look longer at images that are different from the ones they saw before. You probably notice the same phenomenon when you hear a new song on the radio: initially you don't recognize it; after it's played several times you may like it and sing along; after it's played hundreds of times you would choose to listen to anything else.</p>
                 {% endblocktranslate %}
-                        <h4>
-                            {% trans "Violation of expectation" %}
-                        </h4>
-                        <p>
-                            {% trans "Infants and children already have rich expectations about how events work. Children (and adults for that matter) tend to look longer at things they find surprising, so in some cases, we can take their looking times as a measure of how surprised they are." %}
-                        </p>
-                        <h4>
-                            {% trans "Preferential looking" %}
-                        </h4>
-                        <p>
-                            {% trans "Even when they seem to be passive observers, children are making lots of decisions about where to look and what to pay attention to. In this technique, we present children with a choice between two side-by-side images or videos, and see if children spend more time looking at one of them. We may additionally play audio that matches one of the videos. The video below shows a participant looking to her left when asked to 'find clapping'; the display she's watching is shown at the top." %}
-                        </p>
-                        <div class="d-flex justify-content-center">
-                            <video controls preload="metadata">
-                                <source src="{% static 'videos/clapping.mp4' %}" type="video/mp4"/>
-                                <track label="English"
-                                       kind="captions"
-                                       srclang="en"
-                                       src="{% static 'videos/english/clapping.vtt' %}"/>
-                            </video>
-                        </div>
-                        <h4>
-                            {% trans "Predictive looking" %}
-                        </h4>
-                        <p>
-                            {% trans "Children can often make sophisticated predictions about what they expect to see or hear next. One way we can see those predictions in young children is to look at their eye movements. For example, if a child sees a ball roll behind a barrier, she may look to the other edge of the barrier, expecting the ball to emerge there. We may also set up artificial predictive relationships--for instance, the syllable 'da' means a toy will appear at the left of the screen, and 'ba' means a toy will appear at the right. Then we can see whether children learn these relationships, and how they generalize, by watching where they look when they hear a syllable." %}
-                        </p>
-                        <p>
-                            {% trans "Older children may simply be able to answer spoken questions about what they think is happening. For instance, in a recent study, two women called an object two different made-up names, and children were asked which is the correct name for the object." %}
-                        </p>
-                        <div class="d-flex justify-content-center">
-                            <video controls preload="metadata">
-                                <source src="{% static 'videos/causal_ex2.mp4' %}" type="video/mp4"/>
-                                <track label="English"
-                                       kind="captions"
-                                       srclang="en"
-                                       src="{% static 'videos/english/causal_ex2.vtt' %}"/>
-                            </video>
-                        </div>
-                        <p>
-                            {% trans "Another way we can learn about how older children (and adults) think is to measure their reaction times. For instance, we might ask you to help your child learn to press one key when a circle appears and another key when a square appears, and then look at factors that influence how quickly they press a key." %}
-                        </p>
+                    <h4>
+                        {% trans "Violation of expectation" %}
+                    </h4>
+                    <p>
+                        {% trans "Infants and children already have rich expectations about how events work. Children (and adults for that matter) tend to look longer at things they find surprising, so in some cases, we can take their looking times as a measure of how surprised they are." %}
+                    </p>
+                    <h4>
+                        {% trans "Preferential looking" %}
+                    </h4>
+                    <p>
+                        {% trans "Even when they seem to be passive observers, children are making lots of decisions about where to look and what to pay attention to. In this technique, we present children with a choice between two side-by-side images or videos, and see if children spend more time looking at one of them. We may additionally play audio that matches one of the videos. The video below shows a participant looking to her left when asked to 'find clapping'; the display she's watching is shown at the top." %}
+                    </p>
+                    <div class="d-flex justify-content-center">
+                        <video controls preload="metadata">
+                            <source src="{% static 'videos/clapping.mp4' %}" type="video/mp4"/>
+                            <track label="English"
+                                   kind="captions"
+                                   srclang="en"
+                                   src="{% static 'videos/english/clapping.vtt' %}"/>
+                        </video>
                     </div>
+                    <h4>
+                        {% trans "Predictive looking" %}
+                    </h4>
+                    <p>
+                        {% trans "Children can often make sophisticated predictions about what they expect to see or hear next. One way we can see those predictions in young children is to look at their eye movements. For example, if a child sees a ball roll behind a barrier, she may look to the other edge of the barrier, expecting the ball to emerge there. We may also set up artificial predictive relationships--for instance, the syllable 'da' means a toy will appear at the left of the screen, and 'ba' means a toy will appear at the right. Then we can see whether children learn these relationships, and how they generalize, by watching where they look when they hear a syllable." %}
+                    </p>
+                    <p>
+                        {% trans "Older children may simply be able to answer spoken questions about what they think is happening. For instance, in a recent study, two women called an object two different made-up names, and children were asked which is the correct name for the object." %}
+                    </p>
+                    <div class="d-flex justify-content-center">
+                        <video controls preload="metadata">
+                            <source src="{% static 'videos/causal_ex2.mp4' %}" type="video/mp4"/>
+                            <track label="English"
+                                   kind="captions"
+                                   srclang="en"
+                                   src="{% static 'videos/english/causal_ex2.vtt' %}"/>
+                        </video>
+                    </div>
+                    <p>
+                        {% trans "Another way we can learn about how older children (and adults) think is to measure their reaction times. For instance, we might ask you to help your child learn to press one key when a circle appears and another key when a square appears, and then look at factors that influence how quickly they press a key." %}
+                    </p>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-13">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-13"
-                            aria-expanded="false"
-                            aria-controls="collapse-13">
-                        {% trans "My child wasn't paying attention, or we were interrupted. Can we try the study again?" %}
-                    </button>
-                </h2>
-                <div id="collapse-13"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-13"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        <p>
-                            {% trans "Certainly--thanks for your dedication! You may see a warning that you have already participated in the study when you go to try it again, but you can ignore it. You don't need to tell us that you tried the study before; we'll have a record of your previous participation." %}
-                        </p>
-                    </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-13">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-13"
+                        aria-expanded="false"
+                        aria-controls="collapse-13">
+                    {% trans "My child wasn't paying attention, or we were interrupted. Can we try the study again?" %}
+                </button>
+            </h2>
+            <div id="collapse-13"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-13"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    <p>
+                        {% trans "Certainly--thanks for your dedication! You may see a warning that you have already participated in the study when you go to try it again, but you can ignore it. You don't need to tell us that you tried the study before; we'll have a record of your previous participation." %}
+                    </p>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-14">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-14"
-                            aria-expanded="false"
-                            aria-controls="collapse-14">
-                        {% trans "My child is outside the age range. Can he/she still participate in this study?" %}
-                    </button>
-                </h2>
-                <div id="collapse-14"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-14"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        <p>
-                            {% trans "Sure! We may not be able to use his or her data in our research directly, but if you're curious you're welcome to try the study anyway. (Sometimes big siblings really want their own turn!) If your child is just below the minimum age for a study, however, we encourage you to wait so that we'll be able to use the data." %}
-                        </p>
-                    </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-14">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-14"
+                        aria-expanded="false"
+                        aria-controls="collapse-14">
+                    {% trans "My child is outside the age range. Can he/she still participate in this study?" %}
+                </button>
+            </h2>
+            <div id="collapse-14"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-14"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    <p>
+                        {% trans "Sure! We may not be able to use his or her data in our research directly, but if you're curious you're welcome to try the study anyway. (Sometimes big siblings really want their own turn!) If your child is just below the minimum age for a study, however, we encourage you to wait so that we'll be able to use the data." %}
+                    </p>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-15">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-15"
-                            aria-expanded="false"
-                            aria-controls="collapse-15">
-                        {% trans "My child was born prematurely. Should we use his/her adjusted age?" %}
-                    </button>
-                </h2>
-                <div id="collapse-15"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-15"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        <p>
-                            {% trans "For study eligibility, we usually use the child's chronological age (time since birth), even for premature babies. If adjusted age is important for a particular study, we will make that clear in the study eligibility criteria." %}
-                        </p>
-                    </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-15">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-15"
+                        aria-expanded="false"
+                        aria-controls="collapse-15">
+                    {% trans "My child was born prematurely. Should we use his/her adjusted age?" %}
+                </button>
+            </h2>
+            <div id="collapse-15"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-15"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    <p>
+                        {% trans "For study eligibility, we usually use the child's chronological age (time since birth), even for premature babies. If adjusted age is important for a particular study, we will make that clear in the study eligibility criteria." %}
+                    </p>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-16">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-16"
-                            aria-expanded="false"
-                            aria-controls="collapse-16">
-                        {% trans "Our family speaks a language other than English at home. Can my child participate?" %}
-                    </button>
-                </h2>
-                <div id="collapse-16"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-16"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        <p>
-                            {% trans "Sure! Right now, instructions for children and parents are written only in English, so some of them may be confusing to a child who does not hear English regularly. However, you're welcome to try any of the studies and translate for your child if you can. If it matters for the study whether your child speaks any languages besides English, we'll ask specifically. You can also indicate the languages your child speaks or is learning to speak on your demographic survey." %}
-                        </p>
-                    </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-16">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-16"
+                        aria-expanded="false"
+                        aria-controls="collapse-16">
+                    {% trans "Our family speaks a language other than English at home. Can my child participate?" %}
+                </button>
+            </h2>
+            <div id="collapse-16"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-16"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    <p>
+                        {% trans "Sure! Right now, instructions for children and parents are written only in English, so some of them may be confusing to a child who does not hear English regularly. However, you're welcome to try any of the studies and translate for your child if you can. If it matters for the study whether your child speaks any languages besides English, we'll ask specifically. You can also indicate the languages your child speaks or is learning to speak on your demographic survey." %}
+                    </p>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-17">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-17"
-                            aria-expanded="false"
-                            aria-controls="collapse-17">
-                        {% trans "My child has been diagnosed with a developmental disorder or has special needs. Can he/she still participate?" %}
-                    </button>
-                </h2>
-                <div id="collapse-17"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-17"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-17">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-17"
+                        aria-expanded="false"
+                        aria-controls="collapse-17">
+                    {% trans "My child has been diagnosed with a developmental disorder or has special needs. Can he/she still participate?" %}
+                </button>
+            </h2>
+            <div id="collapse-17"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-17"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Of course! We're interested in how all children learn and grow. If you'd like, you can make a note of any developmental disorders in the comments section at the end of the study. We are excited that in the future, online studies may help more families participate in research to better understand their own children's diagnoses.</p>
                 <p>One note: most of our studies include both images and sound, and may be hard to understand if your child is blind or deaf. If you can, please feel free to help out by describing images or signing.</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-18">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-18"
-                            aria-expanded="false"
-                            aria-controls="collapse-18">
-                        {% trans "I have multiple children in the age range for a study. Can they participate together?" %}
-                    </button>
-                </h2>
-                <div id="collapse-18"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-18"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        <p>
-                            {% trans "If possible, we ask that each child participate separately. When children participate together they generally influence each other. That's a fascinating subject in its own right but usually not the focus of our research." %}
-                        </p>
-                    </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-18">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-18"
+                        aria-expanded="false"
+                        aria-controls="collapse-18">
+                    {% trans "I have multiple children in the age range for a study. Can they participate together?" %}
+                </button>
+            </h2>
+            <div id="collapse-18"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-18"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    <p>
+                        {% trans "If possible, we ask that each child participate separately. When children participate together they generally influence each other. That's a fascinating subject in its own right but usually not the focus of our research." %}
+                    </p>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-19">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-19"
-                            aria-expanded="false"
-                            aria-controls="collapse-19">
-                        {% trans "But I've heard that young children should avoid 'screen time.'" %}
-                    </button>
-                </h2>
-                <div id="collapse-19"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-19"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-19">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-19"
+                        aria-expanded="false"
+                        aria-controls="collapse-19">
+                    {% trans "But I've heard that young children should avoid 'screen time.'" %}
+                </button>
+            </h2>
+            <div id="collapse-19"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-19"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>We agree with the American Academy of Pediatrics <a href="https://pediatrics.aappublications.org/content/138/5/e20162591" target="_blank" rel="noopener">advice</a> that children learn best from people, not screens! However, our studies are not intended to educate children, but to learn from them.</p>
                 <p>As part of a child's limited screen time, we hope that our studies will foster family conversation and engagement with science that offsets the few minutes spent watching a video instead of playing. And we do "walk the walk"--our own young children provide lots of feedback on our studies!</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-20">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-20"
-                            aria-expanded="false"
-                            aria-controls="collapse-20">
-                        {% trans "Will we be paid for our participation?" %}
-                    </button>
-                </h2>
-                <div id="collapse-20"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-20"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        <p>
-                            {% trans "Some research groups provide gift cards or other compensation for completing their studies, and others rely on volunteers. (This often depends on the rules of the university that's doing the research.) This information will be listed on the study description page." %}
-                        </p>
-                    </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-20">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-20"
+                        aria-expanded="false"
+                        aria-controls="collapse-20">
+                    {% trans "Will we be paid for our participation?" %}
+                </button>
+            </h2>
+            <div id="collapse-20"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-20"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    <p>
+                        {% trans "Some research groups provide gift cards or other compensation for completing their studies, and others rely on volunteers. (This often depends on the rules of the university that's doing the research.) This information will be listed on the study description page." %}
+                    </p>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-21">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-21"
-                            aria-expanded="false"
-                            aria-controls="collapse-21">
-                        {% trans "Can I learn the results of the research my child does?" %}
-                    </button>
-                </h2>
-                <div id="collapse-21"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-21"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-21">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-21"
+                        aria-expanded="false"
+                        aria-controls="collapse-21">
+                    {% trans "Can I learn the results of the research my child does?" %}
+                </button>
+            </h2>
+            <div id="collapse-21"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-21"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>You should expect to get an explanation about the purpose of every study you participate in when you consent to the study. At the end of the study, especially when it is a video chat, you should have a chance to ask any questions you like.</p>
                 <p>In general though, the goal of research studies is to learn about children in general, not any particular child. Thus, the information we get is usually not appropriate for making diagnoses or assessing the performance of individuals. For instance, while it might be interesting to learn that your child looked 70% of the time at videos where things fell up versus falling down today, we won't be able to tell you whether this means your child is going to be especially good at physics.</p>
                 <p>If you're interested in getting individual results right away, please see our <a href='resources'>Resources</a> section for fun at-home activities you can try with your child.</p>
                 <p>Researchers usually aim to share the general results of studies in scientific journals (e.g., “The majority of three-year-olds chose option A; the majority of five-year-olds chose option B."). You can click <a href = "https://childrenhelpingscience.com/publications">here</a> to see some examples of scientific research published with data collected online with children.</p>
                 <p>There can be a long lag between conducting a study and publication -- your five-year-olds might be eight-year-olds before the results are in press! So in addition to scientific publications, many of the labs that post studies on this website have ways for parents to sign up to receive updates. You can also set your communication preferences to be notified by Lookit when we have results from studies you participated in.</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-22">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-22"
-                            aria-expanded="false"
-                            aria-controls="collapse-22">
-                        {% trans "I love this. How do I share this site?" %}
-                    </button>
-                </h2>
-                <div id="collapse-22"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-22"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-22">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-22"
+                        aria-expanded="false"
+                        aria-controls="collapse-22">
+                    {% trans "I love this. How do I share this site?" %}
+                </button>
+            </h2>
+            <div id="collapse-22"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-22"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Become a parent ambassador! One of the biggest challenges in developmental research is reaching families like you. With more children, we can also answer more sophisticated questions -- including questions about individual differences, the ways many different factors can interact to affect outcomes. Families like yours can help us make our science more representative and more reliable. </p>
                 <p>If you like what you are doing, please share this website (<a href = "https://lookit.mit.edu">https://lookit.mit.edu</a>), with our sincere thanks. Research on child development would be impossible without the support of parents like you.</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-23">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-23"
-                            aria-expanded="false"
-                            aria-controls="collapse-23">
-                        {% trans "What is the Parent Researcher Collaborative (PaRC)?" %}
-                    </button>
-                </h2>
-                <div id="collapse-23"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-23"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-23">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-23"
+                        aria-expanded="false"
+                        aria-controls="collapse-23">
+                    {% trans "What is the Parent Researcher Collaborative (PaRC)?" %}
+                </button>
+            </h2>
+            <div id="collapse-23"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-23"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>If you are a parent who has participated with your child in a study on this website, or a university-based researcher who has posted a study on this website, then we consider you a member of the Parent Researcher Collaborative!</p>
                 <p>If you are asking who runs this website, the answer is that we are a collaboration between two projects for online studies with children, Lookit and Children Helping Science. Lookit was founded by <a href = "https://kimberscott.github.io/">Kim Scott</a> and <a href = "http://eccl.mit.edu/">Laura Schulz</a> at MIT, and is now lead by Executive Director <a href = "http://www.melissaklinestruhl.com/">Melissa Kline Struhl</a>.  The original Children Helping Science website was created by <a href = "https://projects.iq.harvard.edu/ccdlab">Elizabeth Bonawitz</a> at Harvard, <a href = "http://sll.stanford.edu/">Hyowon Gweon</a> at Stanford, <a href = "https://compdevlab.yale.edu/">Julian Jara-Ettinger</a> at Yale, <a href = "https://www.utdallas.edu/thinklab/">Candice Mills</a> at UT Dallas, <a href = "http://eccl.mit.edu/">Laura Schulz</a> at MIT, and <a href = "https://www.minerva.kgi.edu/people/mark-sheskin-phd/">Mark Sheskin</a> at Minerva University. Mark did the web development (based on an initial design by Junyi Chu, a student in Laura's lab) and the logo was designed by Natalia Vélez, a student in Hyowon's lab. </p>
                 <p>We decided it would be nice for there to be one place online where parents and researchers could go to connect with each other to support research into child development!</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-24">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-24"
-                            aria-expanded="false"
-                            aria-controls="collapse-24">
-                        {% trans "How can I contact you?" %}
-                    </button>
-                </h2>
-                <div id="collapse-24"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-24"
-                     data-bs-parent="#faq-accordion-participation">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-24">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-24"
+                        aria-expanded="false"
+                        aria-controls="collapse-24">
+                    {% trans "How can I contact you?" %}
+                </button>
+            </h2>
+            <div id="collapse-24"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-24"
+                 data-bs-parent="#faq-accordion-participation">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>For information about individual studies, please see the "study details" page, which will always include contact information for the lab running that study. </p>
                 <p>If you want to get in touch with the researchers organizing this website, you can reach us by email at <a href="mailto:lookit@mit.edu">lookit@mit.edu</a>.</p>
                 <p>To report any technical difficulties during participation, please contact our team by email at <a href="mailto:lookit-tech@mit.edu">lookit@mit.edu</a>.</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
         </div>
-        <h3 class="{% subheading_classes %}">
-            {% trans "Technical" %}
-        </h3>
-        <div class="accordion m-4" id="faq-accordion-technical">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-25">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-25"
-                            aria-expanded="false"
-                            aria-controls="collapse-25">
-                        {% trans "What browsers are supported?" %}
-                    </button>
-                </h2>
-                <div id="collapse-25"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-25"
-                     data-bs-parent="#faq-accordion-technical">
-                    <div class="accordion-body">
-                        <p>
-                            {% trans "Lookit supports recent versions of Chrome and Firefox. We are not currently able to support Internet Explorer or Safari." %}
-                        </p>
-                    </div>
+    </div>
+    <h3 class="{% subheading_classes %}">
+        {% trans "Technical" %}
+    </h3>
+    <div class="accordion m-4" id="faq-accordion-technical">
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-25">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-25"
+                        aria-expanded="false"
+                        aria-controls="collapse-25">
+                    {% trans "What browsers are supported?" %}
+                </button>
+            </h2>
+            <div id="collapse-25"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-25"
+                 data-bs-parent="#faq-accordion-technical">
+                <div class="accordion-body">
+                    <p>
+                        {% trans "Lookit supports recent versions of Chrome and Firefox. We are not currently able to support Internet Explorer or Safari." %}
+                    </p>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-26">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-26"
-                            aria-expanded="false"
-                            aria-controls="collapse-26">
-                        {% trans "Can we do a study on my phone or tablet?" %}
-                    </button>
-                </h2>
-                <div id="collapse-26"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-26"
-                     data-bs-parent="#faq-accordion-technical">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-26">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-26"
+                        aria-expanded="false"
+                        aria-controls="collapse-26">
+                    {% trans "Can we do a study on my phone or tablet?" %}
+                </button>
+            </h2>
+            <div id="collapse-26"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-26"
+                 data-bs-parent="#faq-accordion-technical">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Most studies require a laptop or desktop with a webcam. Because we're measuring kids' looking patterns, we need a reasonably stable view of their eyes and a big enough screen that we can tell whether they're looking at the left or the right side of it. We're excited about the potential for touchscreen studies that allow us to observe infants and toddlers exploring, though!</p>
                 <p>Some studies, especially surveys meant for older children and teens, may work on your phone or tablet - the study description should mention this if so.</p>
                 {% endblocktranslate %}
-                    </div>
-                </div>
-            </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-27">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-27"
-                            aria-expanded="false"
-                            aria-controls="collapse-27">
-                        {% trans "My study isn't working, what can I do?" %}
-                    </button>
-                </h2>
-                <div id="collapse-27"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-27"
-                     data-bs-parent="#faq-accordion-technical">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
-                <p>If you are trying to participate in a study and having difficulties, please start by contacting the researchers who made that specific study.  If you still need help, you can also reach the Lookit team for help at <a href="mailto:lookit-tech@mit.edu">lookit-tech@mit.edu</a>.</p>
-                <p>If you are a researcher working on creating a study, you can find help in our <a href="https://lookit.readthedocs.io/en/develop/index.html">documentation</a>, and in our <a href = "https://docs.google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/viewform">Slack community</a>.</p>
-                {% endblocktranslate %}
-                    </div>
-                </div>
-            </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-28">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-28"
-                            aria-expanded="false"
-                            aria-controls="collapse-28">
-                        {% trans "What security measures do you implement?" %}
-                    </button>
-                </h2>
-                <div id="collapse-28"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-28"
-                     data-bs-parent="#faq-accordion-technical">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
-                <p>Here at Lookit we are very concerned about protecting your and your children's data, and our software is designed to take advantage of up-to-date security measures. You can read a bit about how we do this in our <a href = "https://lookit.readthedocs.io/en/develop/community-irb-and-legal-information.html#sub-processors-and-information-about-gdpr-compliance-dpas">documentation</a>, and an updated HECVAT is available by emailing <a href="mailto:lookit@mit.edu">lookit@mit.edu</a>.</p>
-                {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
         </div>
-        <h3 class="{% subheading_classes %}">
-            {% trans "For Researchers" %}
-        </h3>
-        <div class="accordion m-4" id="faq-accordion-for-researchers">
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-29">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-29"
-                            aria-expanded="false"
-                            aria-controls="collapse-29">
-                        {% trans "How can I list my study?" %}
-                    </button>
-                </h2>
-                <div id="collapse-29"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-29"
-                     data-bs-parent="#faq-accordion-for-researchers">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-27">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-27"
+                        aria-expanded="false"
+                        aria-controls="collapse-27">
+                    {% trans "My study isn't working, what can I do?" %}
+                </button>
+            </h2>
+            <div id="collapse-27"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-27"
+                 data-bs-parent="#faq-accordion-technical">
+                <div class="accordion-body">
+                    {% blocktranslate %}
+                <p>If you are trying to participate in a study and having difficulties, please start by contacting the researchers who made that specific study.  If you still need help, you can also reach the Lookit team for help at <a href="mailto:lookit-tech@mit.edu">lookit-tech@mit.edu</a>.</p>
+                <p>If you are a researcher working on creating a study, you can find help in our <a href="https://lookit.readthedocs.io/en/develop/index.html">documentation</a>, and in our <a href = "https://docs.google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/viewform">Slack community</a>.</p>
+                {% endblocktranslate %}
+                </div>
+            </div>
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-28">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-28"
+                        aria-expanded="false"
+                        aria-controls="collapse-28">
+                    {% trans "What security measures do you implement?" %}
+                </button>
+            </h2>
+            <div id="collapse-28"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-28"
+                 data-bs-parent="#faq-accordion-technical">
+                <div class="accordion-body">
+                    {% blocktranslate %}
+                <p>Here at Lookit we are very concerned about protecting your and your children's data, and our software is designed to take advantage of up-to-date security measures. You can read a bit about how we do this in our <a href = "https://lookit.readthedocs.io/en/develop/community-irb-and-legal-information.html#sub-processors-and-information-about-gdpr-compliance-dpas">documentation</a>, and an updated HECVAT is available by emailing <a href="mailto:lookit@mit.edu">lookit@mit.edu</a>.</p>
+                {% endblocktranslate %}
+                </div>
+            </div>
+        </div>
+    </div>
+    <h3 class="{% subheading_classes %}">
+        {% trans "For Researchers" %}
+    </h3>
+    <div class="accordion m-4" id="faq-accordion-for-researchers">
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-29">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-29"
+                        aria-expanded="false"
+                        aria-controls="collapse-29">
+                    {% trans "How can I list my study?" %}
+                </button>
+            </h2>
+            <div id="collapse-29"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-29"
+                 data-bs-parent="#faq-accordion-for-researchers">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>In order to list your study on this website, you first will need to have your institution sign a contract with MIT where they agree to the <a href="https://lookit.mit.edu/termsofuse">Terms of Use</a> and certify that their studies will be reviewed and approved by an institutional review board. You will also need to edit your IRB protocol to include online testing, or submit a new protocol for your proposed online study.</p>
                 <p>As of January 2022, we have agreements with over 50 universities, including institutions in the United States, Canada, the United Kingdom, and European Union. Please email <a href="mailto:lookit-tech@mit.edu">lookit@mit.edu</a> if you are not sure whether your institution already has an agreement, or if you need any help at all getting your paperwork in order.</p>
                 <p>While you are completing these steps, you can get started on Lookit by creating a lab account, creating your first study, and getting it peer reviewed by our researcher community. A step-by-step guide to getting started is available <a href="https://lookit.readthedocs.io/en/develop/researchers-start-here.html">here</a>.</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
-            <div class="accordion-item">
-                <h2 class="accordion-header" id="heading-30">
-                    <button class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-30"
-                            aria-expanded="false"
-                            aria-controls="collapse-30">
-                        {% trans "Where can I discuss best practices for online research with other researchers?" %}
-                    </button>
-                </h2>
-                <div id="collapse-30"
-                     class="accordion-collapse collapse"
-                     aria-labelledby="heading-30"
-                     data-bs-parent="#faq-accordion-for-researchers">
-                    <div class="accordion-body">
-                        {% blocktranslate %}
+        </div>
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="heading-30">
+                <button class="accordion-button collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapse-30"
+                        aria-expanded="false"
+                        aria-controls="collapse-30">
+                    {% trans "Where can I discuss best practices for online research with other researchers?" %}
+                </button>
+            </h2>
+            <div id="collapse-30"
+                 class="accordion-collapse collapse"
+                 aria-labelledby="heading-30"
+                 data-bs-parent="#faq-accordion-for-researchers">
+                <div class="accordion-body">
+                    {% blocktranslate %}
                 <p>Lookit has a <a href = "https://docs.google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/viewform">Slack community</a> for researchers to ask for help, conduct peer review, and discuss online research methods.</p>
                 <p>The Society for Research in Child Development also has a <a href = "https://commons.srcd.org/communities/community-home/digestviewer/viewthread?CommunityKey=bd3d326e-b7db-49bf-abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-b8e4-54ecda9de9d8&ReturnUrl=%2Fcommunities%2Fcommunity-home%2Fdigestviewer%3Fcommunitykey%3Dbd3d326e-b7db-49bf-abbb-73642ac0576c%26tab%3Ddigestviewer&tab=digestviewer">discussion forum</a> you might check out!</p>
                 {% endblocktranslate %}
-                    </div>
                 </div>
             </div>
         </div>

--- a/web/templates/web/lab-studies-list.html
+++ b/web/templates/web/lab-studies-list.html
@@ -1,21 +1,19 @@
 {% extends "web/studies-list.html" %}
 {% block content %}
-    <div class="panel-default">
-        {% if lab.banner %}
-            <image class="img-responsive" src="{{ lab.banner.url }}"/>
-        {% elif lab.badge %}
-            <div class="row">
-                <div class="col-md-3">
-                    <image class="img-responsive" src="{{ lab.badge.url }}"/>
-                </div>
-                <div class="col-md-9">
-                    <h1>{{ lab.name }}</h1>
-                </div>
+    {% if lab.banner %}
+        <image class="img-fluid" src="{{ lab.banner.url }}"/>
+    {% elif lab.badge %}
+        <div class="row">
+            <div class="col-3">
+                <image class="img-fluid" src="{{ lab.badge.url }}"/>
             </div>
-        {% else %}
-            <h1>{{ lab.name }}</h1>
-        {% endif %}
-        {{ lab.description|linebreaks }}
-    </div>
+            <div class="col-9">
+                <h1>{{ lab.name }}</h1>
+            </div>
+        </div>
+    {% else %}
+        <h1>{{ lab.name }}</h1>
+    {% endif %}
+    {{ lab.description|linebreaks }}
     {{ block.super }}
 {% endblock content %}

--- a/web/templates/web/lab-studies-list.html
+++ b/web/templates/web/lab-studies-list.html
@@ -1,4 +1,5 @@
 {% extends "web/studies-list.html" %}
+{% load web_extras %}
 {% block content %}
     {% if lab.banner %}
         <image class="img-fluid" src="{{ lab.banner.url }}"/>
@@ -12,7 +13,7 @@
             </div>
         </div>
     {% else %}
-        <h1>{{ lab.name }}</h1>
+        {% page_title lab.name %}
     {% endif %}
     {{ lab.description|linebreaks }}
     {{ block.super }}

--- a/web/templates/web/privacy.html
+++ b/web/templates/web/privacy.html
@@ -6,31 +6,31 @@
     Privacy
 {% endblock title %}
 {% block content %}
-    <div class="{% main_content_container_classes %}">
-        <h1 class="{% main_heading_classes %}">{% trans "Privacy statement" %}</h1>
-        <h3 class="{% subheading_classes %}">{% trans "Introduction" %}</h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}Lookit is committed to supporting the privacy of individuals who enroll on our Platform to conduct
+    {% trans "Privacy statement" as trans_priv_statement %}
+    {% page_title trans_priv_statement %}
+    <h3 class="{% subheading_classes %}">{% trans "Introduction" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}Lookit is committed to supporting the privacy of individuals who enroll on our Platform to conduct
         research or serve as research subjects. This Privacy Statement explains how we handle and use the
     personal information we collect about our researchers and research participant community.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="{% subheading_classes %}">{% trans "For participants" %}</h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}Lookit is a platform that many different researchers use to conduct studies about how children learn and
+        </p>
+    </div>
+    <h3 class="{% subheading_classes %}">{% trans "For participants" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}Lookit is a platform that many different researchers use to conduct studies about how children learn and
         develop. It is run by the MIT Early Childhood Cognition Lab, which has access to all of the data
         collected on Lookit. Researchers using Lookit to conduct studies only access your personal information
     if you choose to participate in their study.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
-        <div class="m-4">
-            <p>{% trans "We collect the following kinds of personal information:" %}</p>
-        </div>
-        <div class="m-4">
-            {% blocktranslate %}<ul>
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
+    <div class="m-4">
+        <p>{% trans "We collect the following kinds of personal information:" %}</p>
+    </div>
+    <div class="m-4">
+        {% blocktranslate %}<ul>
         <li>Account data: basic contact information that may include your email address, nickname, mailing
             address, and contact preferences.</li>
         <li>Child data: basic biographical information about your child(ren), including nickname, date of birth,
@@ -41,57 +41,57 @@
             video of your family participating in the study, text entered in forms, the particular images that
             were shown, the timing of progression through the study, etc.</li>
         </ul>{% endblocktranslate %}
-        </div>
-        <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}The information we collect and maintain about you is the information you provide to us when registering
+    </div>
+    <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}The information we collect and maintain about you is the information you provide to us when registering
         for a Lookit account, registering your children, updating your account or your children’s profiles,
         completing or updating surveys, or participating in individual Lookit studies.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">{% trans "When we share your personal information" %}</h3>
-        <div class="m-4">
-            <p>
-                {% trans "When you participate in a Lookit study, we share the following information with the research group conducting the study:" %}
-            </p>
-        </div>
-        <div class="m-4">
-            {% blocktranslate %}
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "When we share your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "When you participate in a Lookit study, we share the following information with the research group conducting the study:" %}
+        </p>
+    </div>
+    <div class="m-4">
+        {% blocktranslate %}
         <ul>
             <li>Your account data</li>
             <li>The child data for the child who is participating</li>
             <li>Your demographic data</i>
             <li>The study data for this particular study session</li>
         </ul>{% endblocktranslate %}
-            <p>
-                {% trans "Your email address is not shared directly with the research group, although they can contact you via Lookit in accordance with your contact preferences." %}
-            </p>
-            <p>
-                {% blocktranslate %}Researchers may publish the results of a study, including individual responses. However, although they
+        <p>
+            {% trans "Your email address is not shared directly with the research group, although they can contact you via Lookit in accordance with your contact preferences." %}
+        </p>
+        <p>
+            {% blocktranslate %}Researchers may publish the results of a study, including individual responses. However, although they
         may publish the ages of participants, they may not publish participant birthdates (or information that
     could be used to calculate birthdates).{% endblocktranslate %}
-            </p>
-            <p>
-                {% blocktranslate %}We and/or the researchers responsible for a study may share video of your family’s participation for
+        </p>
+        <p>
+            {% blocktranslate %}We and/or the researchers responsible for a study may share video of your family’s participation for
         scientific, educational, and/or publicity purposes, but only if you choose at the conclusion of a study
         to allow such usage. Researchers may also share your video and other data with Databrary if you choose
         at the conclusion of a study to allow that. We don’t publish video of participants such that it can be
         linked to individual demographic data (e.g., household income or number of parents/guardians), and
     researchers must also agree not to do so in order to use Lookit.{% endblocktranslate %}
-            </p>
-            <p>
-                {% blocktranslate %}We don’t share, sell, publish, or otherwise disclose your contact information (email and/or mailing
+        </p>
+        <p>
+            {% blocktranslate %}We don’t share, sell, publish, or otherwise disclose your contact information (email and/or mailing
         address) to anyone but the researchers involved in a study. Researchers must also agree not to disclose
         your contact information in order to use Lookit.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
-        <div class="m-4">
-            <p>
-                {% trans "We may use your personal information (account, child, demographic, and study data) for a variety of purposes, including to:" %}
-            </p>
-            {% blocktranslate %}<ul>
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "We may use your personal information (account, child, demographic, and study data) for a variety of purposes, including to:" %}
+        </p>
+        {% blocktranslate %}<ul>
         <li>Provide you with the research studies you have enrolled in, and information about which studies your
             children are eligible for</li>
         <li>Send you information about studies you may be interested in, reminders to participate in multi-part
@@ -109,33 +109,33 @@
             having fun – ONLY if you have chosen to allow use of the video for publicity)</li>
         </ul>
         {% endblocktranslate %}
-            <p>
-                {% blocktranslate %}Researchers use the data collected in their studies to address particular scientific questions. It may
+        <p>
+            {% blocktranslate %}Researchers use the data collected in their studies to address particular scientific questions. It may
             also turn out that data collected for one study can help to answer a related question later on. If
             researchers are using any additional information about you in their study, beyond what is collected on
             Lookit – for instance, if you are participating in a follow-up online session for an in-person study –
             they must tell you that in the study consent form.{% endblocktranslate %}
-            </p>
-            <p>
-                {% trans "There are some basic rules about how personal information may be used that all Lookit researchers agree to, including:" %}
-            </p>
-            {% blocktranslate %}
+        </p>
+        <p>
+            {% trans "There are some basic rules about how personal information may be used that all Lookit researchers agree to, including:" %}
+        </p>
+        {% blocktranslate %}
         <ul>
             <li>They may not use usernames, child nicknames, or contact information as a subject of research.</li>
             <li>They may contact families by postal mail only in order to send compensation for study participation
                 or materials needed for participation.</li>
         </ul>
         {% endblocktranslate %}
-            <p>
-                {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
+        <p>
+            {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
         dataprotection@mit.edu. We will always respect a request by you to stop processing your personal
         information (subject to our legal obligations).{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">{% trans "How your information is stored and secured" %}</h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How your information is stored and secured" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
         that you may provide. We also periodically monitor our system for possible vulnerabilities and attacks,
         consistent with industry standards. Only authenticated users with specific permissions may access the
         data. All data is transmitted via a secure https connection, and all video data is encrypted at rest on
@@ -145,66 +145,66 @@
         disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial safeguards.
         It's your responsibility to protect the security of your account details, including your username and
         password.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">{% trans "How long we keep your personal information" %}</h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How long we keep your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
         a record for you until such time as you tell us that you no longer wish us to keep in touch. If you wish
         to remove your account, we will retain a core set of information about you to fulfill administrative
         tasks and legal obligations. If you have participated in Lookit studies, the personal information
         already shared with those researchers may not generally be ‘taken back,’ as it is part of a scientific
     dataset and removing your data could affect already published findings.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="{% subheading_classes %}">{% trans "For researchers" %}</h3>
-        <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}We may collect basic biographic/contact information about you and your representative organization,
+        </p>
+    </div>
+    <h3 class="{% subheading_classes %}">{% trans "For researchers" %}</h3>
+    <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We may collect basic biographic/contact information about you and your representative organization,
     including name, title, business addresses, phone numbers, and email addresses.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}The information we collect and maintain about you is that which you have provided to us when registering
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How we collect personal information about you" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}The information we collect and maintain about you is that which you have provided to us when registering
         to use Lookit, updating your profile, or creating or editing a study.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
-        <div class="m-4">
-            <p>
-                {% trans "We use your personal information for a number of legitimate purposes, including the performance of contractual obligations. Specifically, we use your personal information to:" %}
-            </p>
-            {% blocktranslate %}<ul>
+        </p>
+    </div>
+    <h3 class="m-4">{% trans "How we use your personal information" %}</h3>
+    <div class="m-4">
+        <p>
+            {% trans "We use your personal information for a number of legitimate purposes, including the performance of contractual obligations. Specifically, we use your personal information to:" %}
+        </p>
+        {% blocktranslate %}<ul>
             <li>Provide you with the research services for which you have enrolled.</li>
             <li>Perform administrative tasks and for internal record keeping purposes.</li>
             <li>Create and analyze aggregated (fully anonymized) information about our users for statistical
                 research purposes in support of our mission.</li>
         </ul>
         {% endblocktranslate %}
-            <p>
-                {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
+        <p>
+            {% blocktranslate %}If you have concerns about any of these purposes, or how we communicate with you, please contact us at
         dataprotection@mit.edu. We will always respect a request by you to stop processing your personal
         information (subject to our legal obligations).{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">
-            {% trans "When we share your personal information" %}
-        </h3>
-        <div class="m-4">
-            <p>
-                {% trans "We do not share your personal information with any third parties." %}
-            </p>
-        </div>
-        <h3 class="m-4">
-            {% trans "How your information is stored and secured" %}
-        </h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
+        </p>
+    </div>
+    <h3 class="m-4">
+        {% trans "When we share your personal information" %}
+    </h3>
+    <div class="m-4">
+        <p>
+            {% trans "We do not share your personal information with any third parties." %}
+        </p>
+    </div>
+    <h3 class="m-4">
+        {% trans "How your information is stored and secured" %}
+    </h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We have implemented industry-standard security safeguards designed to protect the personal information
         that you may provide. We also periodically monitor our system for possible vulnerabilities and attacks,
         consistent with industry standards. Only authenticated users with specific permissions may access the
         data. All data is transmitted via a secure https connection. You should be aware, however, that since
@@ -212,35 +212,35 @@
         accessed, disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial
         safeguards. It's your responsibility to protect the security of your account details, including your
         username and password.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="m-4">
-            {% trans "How long we keep your personal information" %}
-        </h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
+        </p>
+    </div>
+    <h3 class="m-4">
+        {% trans "How long we keep your personal information" %}
+    </h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We consider our relationship with our research community to be lifelong. This means that we will maintain
         a record for you until such time as you tell us that you no longer wish us to keep in touch. If you no
         longer wish to hear from Lookit, we will retain a core set of information about you to fulfill
         administrative tasks and legal obligations.{% endblocktranslate %}
-            </p>
-        </div>
-        <h3 class="{% subheading_classes %}">
-            {% trans "For everyone" %}
-        </h3>
-        <h3 class="m-4">
-            {% trans "Rights for individuals in the European Economic Area" %}
-        </h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}You have the right in certain circumstances to (1) access your personal information; (2) to correct or
+        </p>
+    </div>
+    <h3 class="{% subheading_classes %}">
+        {% trans "For everyone" %}
+    </h3>
+    <h3 class="m-4">
+        {% trans "Rights for individuals in the European Economic Area" %}
+    </h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}You have the right in certain circumstances to (1) access your personal information; (2) to correct or
         erase information; (3) restrict processing; and (4) object to communications, direct marketing, or
         profiling. To the extent applicable, the EU’s General Data Protection Regulation provides further
         information about your rights. You also have the right to lodge complaints with your national or
         regional data protection authority.{% endblocktranslate %}
-            </p>
-            <p>
-                {% blocktranslate %}If you are inclined to exercise these rights, we request an opportunity to discuss with you any concerns
+        </p>
+        <p>
+            {% blocktranslate %}If you are inclined to exercise these rights, we request an opportunity to discuss with you any concerns
         you may have. To protect the personal information we hold, we may also request further information to
         verify your identify when exercising these rights. Upon a request to erase information, we will maintain
         a core set of personal data to ensure we do not contact you inadvertently in the future, as well as any
@@ -248,31 +248,30 @@
         legal purposes, including US IRS compliance. In the event of an actual or threatened legal claim, we may
         retain your information for purposes of establishing, defending against or exercising our rights with
         respect to such claim.{% endblocktranslate %}
-            </p>
-            <p>
-                {% blocktranslate %}By providing information directly to Lookit, you consent to the transfer of your personal information
+        </p>
+        <p>
+            {% blocktranslate %}By providing information directly to Lookit, you consent to the transfer of your personal information
         outside of the European Economic Area to the United States. You understand that the current laws and
         regulations of the United States may not provide the same level of protection as the data and privacy
         laws and regulations of the EEA.{% endblocktranslate %}
-            </p>
-            <p>
-                {% trans "You are under no statutory or contractual obligation to provide any personal data to us." %}
-            </p>
-        </div>
-        <h3 class="m-4">
-            {% trans "Additional Information" %}
-        </h3>
-        <div class="m-4">
-            <p>
-                {% blocktranslate %}We may change this Privacy Statement from time to time. If we make any significant changes in the way we
+        </p>
+        <p>
+            {% trans "You are under no statutory or contractual obligation to provide any personal data to us." %}
+        </p>
+    </div>
+    <h3 class="m-4">
+        {% trans "Additional Information" %}
+    </h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}We may change this Privacy Statement from time to time. If we make any significant changes in the way we
         treat your personal information we will make this clear on our website or by contacting you directly.{% endblocktranslate %}
-            </p>
-            <p>
-                {% trans "The controller for your personal information is MIT. We can be contacted at dataprotection@mit.edu." %}
-            </p>
-            <p class="text-center fst-italic">
-                {% trans "This policy was last updated in June 2018." %}
-            </p>
-        </div>
+        </p>
+        <p>
+            {% trans "The controller for your personal information is MIT. We can be contacted at dataprotection@mit.edu." %}
+        </p>
+        <p class="text-center fst-italic">
+            {% trans "This policy was last updated in June 2018." %}
+        </p>
     </div>
 {% endblock content %}

--- a/web/templates/web/privacy.html
+++ b/web/templates/web/privacy.html
@@ -1,13 +1,14 @@
 {% extends "web/base.html" %}
 {% load django_bootstrap5 %}
 {% load i18n %}
+{% load web_extras %}
 {% block title %}
     Privacy
 {% endblock title %}
 {% block content %}
-    <div class="container m-4">
-        <h2 class="mx-4 my-5">{% trans "Privacy statement" %}</h2>
-        <h2 class="m-4">{% trans "Introduction" %}</h2>
+    <div class="{% main_content_container_classes %}">
+        <h1 class="{% main_heading_classes %}">{% trans "Privacy statement" %}</h1>
+        <h3 class="{% subheading_classes %}">{% trans "Introduction" %}</h3>
         <div class="m-4">
             <p>
                 {% blocktranslate %}Lookit is committed to supporting the privacy of individuals who enroll on our Platform to conduct
@@ -15,7 +16,7 @@
     personal information we collect about our researchers and research participant community.{% endblocktranslate %}
             </p>
         </div>
-        <h2 class="m-4">{% trans "For participants" %}</h2>
+        <h3 class="{% subheading_classes %}">{% trans "For participants" %}</h3>
         <div class="m-4">
             <p>
                 {% blocktranslate %}Lookit is a platform that many different researchers use to conduct studies about how children learn and
@@ -157,7 +158,7 @@
     dataset and removing your data could affect already published findings.{% endblocktranslate %}
             </p>
         </div>
-        <h2 class="m-4">{% trans "For researchers" %}</h2>
+        <h3 class="{% subheading_classes %}">{% trans "For researchers" %}</h3>
         <h3 class="m-4">{% trans "What personal information we collect" %}</h3>
         <div class="m-4">
             <p>
@@ -224,9 +225,9 @@
         administrative tasks and legal obligations.{% endblocktranslate %}
             </p>
         </div>
-        <h2 class="m-4">
+        <h3 class="{% subheading_classes %}">
             {% trans "For everyone" %}
-        </h2>
+        </h3>
         <h3 class="m-4">
             {% trans "Rights for individuals in the European Economic Area" %}
         </h3>

--- a/web/templates/web/resources.html
+++ b/web/templates/web/resources.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load i18n %}
 {% load static %}
+{% load web_extras %}
 {% block head %}
     <script src="{% static 'js/resources.js' %}" defer></script>
 {% endblock head %}
@@ -9,84 +10,96 @@
     Resources
 {% endblock title %}
 {% block content %}
-    <h1 class="pt-5 text-center">Resources</h1>
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Find a developmental lab near you</h2>
-    <p>
-        Interested in participating in research in person? Find a list of labs that study child
-        development
-        in
-        your state.
-    </p>
-    <p>
-        Did we miss your lab, or one you know about? Our apologies, and please let us know at <a href="mailto:lookit-ed@mit.edu">lookit-ed@mit.edu</a>
-    </p>
-    <div class="row bg-light py-3">
-        <div class="col-4">
-            <select id="state-select">
-            </select>
+    <div class="{% main_content_container_classes %}">
+        <h1 class="{% main_heading_classes %}">Resources</h1>
+        <h3 class="{% subheading_classes %}">Find a developmental lab near you</h3>
+        <div class="m-4">
+            <p>
+                Interested in participating in research in person? Find a list of labs that study child
+                development
+                in
+                your state.
+            </p>
+            <p>
+                Did we miss your lab, or one you know about? Our apologies, and please let us know at <a href="mailto:lookit-ed@mit.edu">lookit-ed@mit.edu</a>
+            </p>
         </div>
-        <div class="col-8">
-            <strong class="selected-state"></strong>
-            <p id="nothing-to-show"></p>
-            <ul id="lab-list">
-            </ul>
+        <div class="row bg-light py-3 m-4 text-center">
+            <div class="col-4">
+                <select id="state-select">
+                </select>
+            </div>
+            <div class="col-8">
+                <strong class="selected-state"></strong>
+                <p id="nothing-to-show"></p>
+                <ul id="lab-list">
+                </ul>
+            </div>
+        </div>
+        <h3 class="{% subheading_classes %}">Other ways to participate from home</h3>
+        <div class="m-4">
+            <p>
+                Visit
+                <a href="https://childrenhelpingscience.com/"
+                   target="_blank"
+                   rel="noopener">Children Helping Science</a>
+                for an extensive list of other opportunities to participate in research about child development!
+            </p>
+            <p>
+                To contribute to other scientific research as a family, check out <a href="https://scistarter.org/">SciStarter</a>, which has many citizen
+                science projects
+                suitable for elementary school children and up!
+            </p>
+        </div>
+        <h3 class="{% subheading_classes %}">Activities to try at home</h3>
+        <div class="m-4">
+            <p>
+                Want to learn more about cognitive development? Here are some activities that may give you some insight
+                into your own child's developing mind. Instead of studies our lab is running, these are "at home labs"
+                for parents to try on their own--but please feel free to contact us with any questions!
+            </p>
+        </div>
+        <h4 class="mt-5 mb-3 mx-4">Learning about other minds: your child's developing theory of mind</h4>
+        <div class="m-4">
+            <div>
+                <iframe allowfullscreen
+                        height="315"
+                        src="https://www.youtube.com/embed/uxyVYATX9-M"
+                        width="560"
+                        title="YouTube Video"></iframe>
+            </div>
+            <p>
+                <strong>Age range</strong>: 2.5 to 5 years
+            </p>
+            <p>
+                <strong>What you'll need</strong>: For the "Maxi and the chocolate" story, any props you'd like (you can try drawing a picture or acting out the story). For the word-learning task, two containers to hold two objects your child doesn't know a name for (weird kitchen tools, bike parts, etc.).
+            </p>
+            <p>
+                In this lab, you'll see how your child thinks about what other people are thinking.
+                Children under
+                about
+                four years old tend to have trouble expressing what's going on when someone else knows
+                less than
+                they
+                do. They will often insist that everyone knows what they themselves know!
+            </p>
+        </div>
+        <h4 class="mt-5 mb-3 mx-4">Learning to count: measuring your child's N-knower level</h4>
+        <div class="m-4">
+            <div>
+                <iframe allowfullscreen
+                        height="315"
+                        src="https://www.youtube.com/embed/i0q6H8MRXo8"
+                        width="560"
+                        title="YouTube Video">></iframe>
+            </div>
+            <p>
+                <strong>Age range</strong>: 1 to 5 years
+            </p>
+            <p>
+                <strong>What you'll need</strong>:
+                At least ten small objects your child can pick up, like pegs or Cheerios.
+            </p>
         </div>
     </div>
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Other ways to participate from home</h2>
-    <p>
-        Visit
-        <a href="https://childrenhelpingscience.com/"
-           target="_blank"
-           rel="noopener">Children Helping Science</a>
-        for an extensive list of other opportunities to participate in research about child development!
-    </p>
-    <p>
-        To contribute to other scientific research as a family, check out <a href="https://scistarter.org/">SciStarter</a>, which has many citizen
-        science projects
-        suitable for elementary school children and up!
-    </p>
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Activities to try at home</h2>
-    <p>
-        Want to learn more about cognitive development? Here are some activities that may give you some insight
-        into your own child's developing mind. Instead of studies our lab is running, these are "at home labs"
-        for parents to try on their own--but please feel free to contact us with any questions!
-    </p>
-    <h4 class="mt-5 mb-3">Learning about other minds: your child's developing theory of mind</h4>
-    <div>
-        <iframe allowfullscreen
-                height="315"
-                src="https://www.youtube.com/embed/uxyVYATX9-M"
-                width="560"
-                title="YouTube Video"></iframe>
-    </div>
-    <p>
-        <strong>Age range</strong>: 2.5 to 5 years
-    </p>
-    <p>
-        <strong>What you'll need</strong>: For the "Maxi and the chocolate" story, any props you'd like (you can try drawing a picture or acting out the story). For the word-learning task, two containers to hold two objects your child doesn't know a name for (weird kitchen tools, bike parts, etc.).
-    </p>
-    <p>
-        In this lab, you'll see how your child thinks about what other people are thinking.
-        Children under
-        about
-        four years old tend to have trouble expressing what's going on when someone else knows
-        less than
-        they
-        do. They will often insist that everyone knows what they themselves know!
-    </p>
-    <h4 class="mt-5 mb-3">Learning to count: measuring your child's N-knower level</h4>
-    <div>
-        <iframe allowfullscreen
-                height="315"
-                src="https://www.youtube.com/embed/i0q6H8MRXo8"
-                width="560"
-                title="YouTube Video">></iframe>
-    </div>
-    <p>
-        <strong>Age range</strong>: 1 to 5 years
-    </p>
-    <p>
-        <strong>What you'll need</strong>:
-        At least ten small objects your child can pick up, like pegs or Cheerios.
-    </p>
 {% endblock content %}

--- a/web/templates/web/resources.html
+++ b/web/templates/web/resources.html
@@ -10,96 +10,94 @@
     Resources
 {% endblock title %}
 {% block content %}
-    <div class="{% main_content_container_classes %}">
-        <h1 class="{% main_heading_classes %}">Resources</h1>
-        <h3 class="{% subheading_classes %}">Find a developmental lab near you</h3>
-        <div class="m-4">
-            <p>
-                Interested in participating in research in person? Find a list of labs that study child
-                development
-                in
-                your state.
-            </p>
-            <p>
-                Did we miss your lab, or one you know about? Our apologies, and please let us know at <a href="mailto:lookit-ed@mit.edu">lookit-ed@mit.edu</a>
-            </p>
+    {% page_title "Resources" %}
+    <h3 class="{% subheading_classes %}">Find a developmental lab near you</h3>
+    <div class="m-4">
+        <p>
+            Interested in participating in research in person? Find a list of labs that study child
+            development
+            in
+            your state.
+        </p>
+        <p>
+            Did we miss your lab, or one you know about? Our apologies, and please let us know at <a href="mailto:lookit-ed@mit.edu">lookit-ed@mit.edu</a>
+        </p>
+    </div>
+    <div class="row bg-light py-3 m-4 text-center">
+        <div class="col-4">
+            <select id="state-select">
+            </select>
         </div>
-        <div class="row bg-light py-3 m-4 text-center">
-            <div class="col-4">
-                <select id="state-select">
-                </select>
-            </div>
-            <div class="col-8">
-                <strong class="selected-state"></strong>
-                <p id="nothing-to-show"></p>
-                <ul id="lab-list">
-                </ul>
-            </div>
+        <div class="col-8">
+            <strong class="selected-state"></strong>
+            <p id="nothing-to-show"></p>
+            <ul id="lab-list">
+            </ul>
         </div>
-        <h3 class="{% subheading_classes %}">Other ways to participate from home</h3>
-        <div class="m-4">
-            <p>
-                Visit
-                <a href="https://childrenhelpingscience.com/"
-                   target="_blank"
-                   rel="noopener">Children Helping Science</a>
-                for an extensive list of other opportunities to participate in research about child development!
-            </p>
-            <p>
-                To contribute to other scientific research as a family, check out <a href="https://scistarter.org/">SciStarter</a>, which has many citizen
-                science projects
-                suitable for elementary school children and up!
-            </p>
+    </div>
+    <h3 class="{% subheading_classes %}">Other ways to participate from home</h3>
+    <div class="m-4">
+        <p>
+            Visit
+            <a href="https://childrenhelpingscience.com/"
+               target="_blank"
+               rel="noopener">Children Helping Science</a>
+            for an extensive list of other opportunities to participate in research about child development!
+        </p>
+        <p>
+            To contribute to other scientific research as a family, check out <a href="https://scistarter.org/">SciStarter</a>, which has many citizen
+            science projects
+            suitable for elementary school children and up!
+        </p>
+    </div>
+    <h3 class="{% subheading_classes %}">Activities to try at home</h3>
+    <div class="m-4">
+        <p>
+            Want to learn more about cognitive development? Here are some activities that may give you some insight
+            into your own child's developing mind. Instead of studies our lab is running, these are "at home labs"
+            for parents to try on their own--but please feel free to contact us with any questions!
+        </p>
+    </div>
+    <h4 class="mt-5 mb-3 mx-4">Learning about other minds: your child's developing theory of mind</h4>
+    <div class="m-4">
+        <div>
+            <iframe allowfullscreen
+                    height="315"
+                    src="https://www.youtube.com/embed/uxyVYATX9-M"
+                    width="560"
+                    title="YouTube Video"></iframe>
         </div>
-        <h3 class="{% subheading_classes %}">Activities to try at home</h3>
-        <div class="m-4">
-            <p>
-                Want to learn more about cognitive development? Here are some activities that may give you some insight
-                into your own child's developing mind. Instead of studies our lab is running, these are "at home labs"
-                for parents to try on their own--but please feel free to contact us with any questions!
-            </p>
+        <p>
+            <strong>Age range</strong>: 2.5 to 5 years
+        </p>
+        <p>
+            <strong>What you'll need</strong>: For the "Maxi and the chocolate" story, any props you'd like (you can try drawing a picture or acting out the story). For the word-learning task, two containers to hold two objects your child doesn't know a name for (weird kitchen tools, bike parts, etc.).
+        </p>
+        <p>
+            In this lab, you'll see how your child thinks about what other people are thinking.
+            Children under
+            about
+            four years old tend to have trouble expressing what's going on when someone else knows
+            less than
+            they
+            do. They will often insist that everyone knows what they themselves know!
+        </p>
+    </div>
+    <h4 class="mt-5 mb-3 mx-4">Learning to count: measuring your child's N-knower level</h4>
+    <div class="m-4">
+        <div>
+            <iframe allowfullscreen
+                    height="315"
+                    src="https://www.youtube.com/embed/i0q6H8MRXo8"
+                    width="560"
+                    title="YouTube Video">></iframe>
         </div>
-        <h4 class="mt-5 mb-3 mx-4">Learning about other minds: your child's developing theory of mind</h4>
-        <div class="m-4">
-            <div>
-                <iframe allowfullscreen
-                        height="315"
-                        src="https://www.youtube.com/embed/uxyVYATX9-M"
-                        width="560"
-                        title="YouTube Video"></iframe>
-            </div>
-            <p>
-                <strong>Age range</strong>: 2.5 to 5 years
-            </p>
-            <p>
-                <strong>What you'll need</strong>: For the "Maxi and the chocolate" story, any props you'd like (you can try drawing a picture or acting out the story). For the word-learning task, two containers to hold two objects your child doesn't know a name for (weird kitchen tools, bike parts, etc.).
-            </p>
-            <p>
-                In this lab, you'll see how your child thinks about what other people are thinking.
-                Children under
-                about
-                four years old tend to have trouble expressing what's going on when someone else knows
-                less than
-                they
-                do. They will often insist that everyone knows what they themselves know!
-            </p>
-        </div>
-        <h4 class="mt-5 mb-3 mx-4">Learning to count: measuring your child's N-knower level</h4>
-        <div class="m-4">
-            <div>
-                <iframe allowfullscreen
-                        height="315"
-                        src="https://www.youtube.com/embed/i0q6H8MRXo8"
-                        width="560"
-                        title="YouTube Video">></iframe>
-            </div>
-            <p>
-                <strong>Age range</strong>: 1 to 5 years
-            </p>
-            <p>
-                <strong>What you'll need</strong>:
-                At least ten small objects your child can pick up, like pegs or Cheerios.
-            </p>
-        </div>
+        <p>
+            <strong>Age range</strong>: 1 to 5 years
+        </p>
+        <p>
+            <strong>What you'll need</strong>:
+            At least ten small objects your child can pick up, like pegs or Cheerios.
+        </p>
     </div>
 {% endblock content %}

--- a/web/templates/web/scientists.html
+++ b/web/templates/web/scientists.html
@@ -7,19 +7,18 @@
     Scientists
 {% endblock title %}
 {% block content %}
-    <div class="{% main_content_container_classes %}">
-        <h1 class="{% main_heading_classes %}">{% trans "Meet the Lookit team" %}</h1>
-        <h2 class="{% subheading_classes %}">Core Lookit Team</h2>
-        {% include "web/scientists/core-team.html" %}
-        <h2 class="{% subheading_classes %}">Parent Researcher Collaborative</h2>
-        {% include "web/scientists/parent-researcher-collaborative.html" %}
-        <h2 class="{% subheading_classes %}">Affiliated Universities and Researchers</h2>
-        {% include "web/scientists/affiliated-universities-and-researchers.html" %}
-        <h2 class="{% subheading_classes %}">Working Groups</h2>
-        {% include "web/scientists/working-groups.html" %}
-        <h2 class="{% subheading_classes %}">Staff alumni</h2>
-        {% include "web/scientists/staff-alumni.html" %}
-        <h2 class="{% subheading_classes %}">Undergraduate student alumni</h2>
-        {% include "web/scientists/undergrade-student-alumni.html" %}
-    </div>
+    {% trans "Meet the Lookit team" as trans_meet_scientists %}
+    {% page_title trans_meet_scientists %}
+    <h2 class="{% subheading_classes %}">Core Lookit Team</h2>
+    {% include "web/scientists/core-team.html" %}
+    <h2 class="{% subheading_classes %}">Parent Researcher Collaborative</h2>
+    {% include "web/scientists/parent-researcher-collaborative.html" %}
+    <h2 class="{% subheading_classes %}">Affiliated Universities and Researchers</h2>
+    {% include "web/scientists/affiliated-universities-and-researchers.html" %}
+    <h2 class="{% subheading_classes %}">Working Groups</h2>
+    {% include "web/scientists/working-groups.html" %}
+    <h2 class="{% subheading_classes %}">Staff alumni</h2>
+    {% include "web/scientists/staff-alumni.html" %}
+    <h2 class="{% subheading_classes %}">Undergraduate student alumni</h2>
+    {% include "web/scientists/undergrade-student-alumni.html" %}
 {% endblock content %}

--- a/web/templates/web/scientists.html
+++ b/web/templates/web/scientists.html
@@ -2,21 +2,24 @@
 {% load django_bootstrap5 %}
 {% load i18n %}
 {% load static %}
+{% load web_extras %}
 {% block title %}
     Scientists
 {% endblock title %}
 {% block content %}
-    <h1 class="pt-5 text-center">{% trans "Meet the Lookit team" %}</h1>
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Core Lookit Team</h2>
-    {% include "web/scientists/core-team.html" %}
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Parent Researcher Collaborative</h2>
-    {% include "web/scientists/parent-researcher-collaborative.html" %}
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Affiliated Universities and Researchers</h2>
-    {% include "web/scientists/affiliated-universities-and-researchers.html" %}
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Working Groups</h2>
-    {% include "web/scientists/working-groups.html" %}
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Staff alumni</h2>
-    {% include "web/scientists/staff-alumni.html" %}
-    <h2 class="border-bottom pb-2 pt-5 mb-4">Undergraduate student alumni</h2>
-    {% include "web/scientists/undergrade-student-alumni.html" %}
+    <div class="{% main_content_container_classes %}">
+        <h1 class="{% main_heading_classes %}">{% trans "Meet the Lookit team" %}</h1>
+        <h2 class="{% subheading_classes %}">Core Lookit Team</h2>
+        {% include "web/scientists/core-team.html" %}
+        <h2 class="{% subheading_classes %}">Parent Researcher Collaborative</h2>
+        {% include "web/scientists/parent-researcher-collaborative.html" %}
+        <h2 class="{% subheading_classes %}">Affiliated Universities and Researchers</h2>
+        {% include "web/scientists/affiliated-universities-and-researchers.html" %}
+        <h2 class="{% subheading_classes %}">Working Groups</h2>
+        {% include "web/scientists/working-groups.html" %}
+        <h2 class="{% subheading_classes %}">Staff alumni</h2>
+        {% include "web/scientists/staff-alumni.html" %}
+        <h2 class="{% subheading_classes %}">Undergraduate student alumni</h2>
+        {% include "web/scientists/undergrade-student-alumni.html" %}
+    </div>
 {% endblock content %}

--- a/web/templates/web/termsofuse.html
+++ b/web/templates/web/termsofuse.html
@@ -1,494 +1,493 @@
 {% extends "web/base.html" %}
 {% load django_bootstrap5 %}
 {% load i18n %}
+{% load web_extras %}
 {% block title %}
     Terms of Use
 {% endblock title %}
 {% block content %}
-    <div class="container m-4">
-        <h2 class="mx-4 my-5">Terms of Use</h2>
-        <div class="m-4">
+    {% page_title "Terms of Use" %}
+    <div class="m-4">
+        <p>
+            Welcome to the Lookit Platform, an online platform for developmental research studies. You
+            should read and understand these terms and conditions, which govern your use of the Lookit
+            Platform. Researchers may be especially interested in the sections not in italic when first
+            learning about the Platform.
+        </p>
+    </div>
+    <h3 class="m-4">Overview</h3>
+    <div class="m-4">
+        <em>
             <p>
-                Welcome to the Lookit Platform, an online platform for developmental research studies. You
-                should read and understand these terms and conditions, which govern your use of the Lookit
-                Platform. Researchers may be especially interested in the sections not in italic when first
-                learning about the Platform.
-            </p>
-        </div>
-        <h3 class="m-4">Overview</h3>
-        <div class="m-4">
-            <em>
-                <p>
-                    These Terms of Service, with our Privacy Policy, are a resource for you to get a deeper
-                    understanding of your obligations and rights with respect to the Lookit Platform
-                    including how we use information and data we collect from you. We may modify these Terms
-                    of Service from time to time as we deem appropriate, so you should check back in
-                    frequently to confirm the terms upon which you may use the Lookit Platform. We will
-                    notify you of any modifications to these Terms by posting them on the Lookit Platform.
-                    Use of the Lookit Platform after the effective date of the updated Terms constitutes
-                    your agreement to the updated Terms.
-                </p>
-                <p>
-                    The terms "we", "us" "our" and similar terms refer to Lookit. The terms “you,” “your,”
-                    “Researcher” and similar terms refer to users of our Platform. The term “Platform”
-                    refers to the online Lookit Platform. “Terms” or “Agreement” refers to these Terms of
-                    Service, as may be amended from time to time by us.
-                </p>
-            </em>
-            <p>
-                A study "posted on Lookit" refers to any study which has been submitted for and received
-                approval to appear on the Lookit website.
+                These Terms of Service, with our Privacy Policy, are a resource for you to get a deeper
+                understanding of your obligations and rights with respect to the Lookit Platform
+                including how we use information and data we collect from you. We may modify these Terms
+                of Service from time to time as we deem appropriate, so you should check back in
+                frequently to confirm the terms upon which you may use the Lookit Platform. We will
+                notify you of any modifications to these Terms by posting them on the Lookit Platform.
+                Use of the Lookit Platform after the effective date of the updated Terms constitutes
+                your agreement to the updated Terms.
             </p>
             <p>
-                A study "conducted on Lookit" refers to studies which, additionally, perform all consent
-                procedures and data collection without leaving the Lookit web domain.
+                The terms "we", "us" "our" and similar terms refer to Lookit. The terms “you,” “your,”
+                “Researcher” and similar terms refer to users of our Platform. The term “Platform”
+                refers to the online Lookit Platform. “Terms” or “Agreement” refers to these Terms of
+                Service, as may be amended from time to time by us.
             </p>
-            <p>There are several types of data collected on the Lookit Platform. These comprise:</p>
-            <ol>
-                <li>
-                    Account data: information about a Lookit account holder, representing an adult
-                    participant or family: e.g., contact information, email preferences
-                </li>
-                <li>
-                    Child data: information about a Lookit participant, representing a child associated with
-                    a particular Lookit account: e.g., birthdate, gender, gestational age at birth, medical
-                    diagnoses
-                </li>
-                <li>
-                    Demographic survey data: responses to a demographic survey associated with a Lookit
-                    account: e.g., approximate geographic location, household income, parental education
-                </li>
-                <li>
-                    Study data, including video: responses collected during a child’s participation in a
-                    particular Lookit study: webcam video of the child and parent as well as text data
-                    including form responses, on-screen selections, which stimuli were shown, etc.
-                </li>
-            </ol>
+        </em>
+        <p>
+            A study "posted on Lookit" refers to any study which has been submitted for and received
+            approval to appear on the Lookit website.
+        </p>
+        <p>
+            A study "conducted on Lookit" refers to studies which, additionally, perform all consent
+            procedures and data collection without leaving the Lookit web domain.
+        </p>
+        <p>There are several types of data collected on the Lookit Platform. These comprise:</p>
+        <ol>
+            <li>
+                Account data: information about a Lookit account holder, representing an adult
+                participant or family: e.g., contact information, email preferences
+            </li>
+            <li>
+                Child data: information about a Lookit participant, representing a child associated with
+                a particular Lookit account: e.g., birthdate, gender, gestational age at birth, medical
+                diagnoses
+            </li>
+            <li>
+                Demographic survey data: responses to a demographic survey associated with a Lookit
+                account: e.g., approximate geographic location, household income, parental education
+            </li>
+            <li>
+                Study data, including video: responses collected during a child’s participation in a
+                particular Lookit study: webcam video of the child and parent as well as text data
+                including form responses, on-screen selections, which stimuli were shown, etc.
+            </li>
+        </ol>
+        <p>
+            In addition, the term "External data" refers to video, text, or other data, including consent
+            records, collected from participants in a study posted (but not conducted) on Lookit. this
+            includes data from studies which are conducted asynchronously on another web platform as
+            well those which are collected at a scheduled session (online or in person.)
+        </p>
+        <em>
+            <p>Other capitalized terms may be defined below in these Terms.</p>
+        </em>
+    </div>
+    <h3 class="m-4">Acceptance of Terms of Service</h3>
+    <div class="m-4">
+        <em>
             <p>
-                In addition, the term "External data" refers to video, text, or other data, including consent
-                records, collected from participants in a study posted (but not conducted) on Lookit. this
-                includes data from studies which are conducted asynchronously on another web platform as
-                well those which are collected at a scheduled session (online or in person.)
+                These Terms, which include our Privacy Policy, are a binding legal agreement and govern
+                your use of the Platform, including all features and functionalities, applications,
+                updates, notifications and our user interfaces, and all content and software associated
+                therewith. By checking the “I accept the Terms & Conditions” box during the account set
+                up or by downloading, using, visiting, or browsing the Platform, you accept and agree to
+                be bound by these Terms as amended from time to time. If you do not agree to these
+                Terms, you are not authorized to use, and you should not use, the Platform.
             </p>
-            <em>
-                <p>Other capitalized terms may be defined below in these Terms.</p>
-            </em>
-        </div>
-        <h3 class="m-4">Acceptance of Terms of Service</h3>
-        <div class="m-4">
-            <em>
-                <p>
-                    These Terms, which include our Privacy Policy, are a binding legal agreement and govern
-                    your use of the Platform, including all features and functionalities, applications,
-                    updates, notifications and our user interfaces, and all content and software associated
-                    therewith. By checking the “I accept the Terms & Conditions” box during the account set
-                    up or by downloading, using, visiting, or browsing the Platform, you accept and agree to
-                    be bound by these Terms as amended from time to time. If you do not agree to these
-                    Terms, you are not authorized to use, and you should not use, the Platform.
-                </p>
-            </em>
-        </div>
-        <h3 class="m-4">Use of the Platform</h3>
-        <div class="m-4">
-            <em>
-                <p>
-                    Account Registration. In order to use the Platform, you will need to provide to us
-                    certain basic information such as your name, institution, and email address. You agree
-                    that all information you provide to us will be complete, true and correct and that you
-                    will keep it up-to-date. During the registration process, you will choose a user name
-                    and password for your use of the Platform. You will be responsible for securing your
-                    user name and password and for all use of the Platform using your email address or
-                    password. You will be solely liable for any use of the Platform under your account and
-                    password. You agree to notify us promptly of any unauthorized use or disclosure of your
-                    password. We reserve the right to refuse use of or revoke use of any username in our
-                    discretion.
-                    Basic use of the Platform is offered free of charge. However, we reserve the right to
-                    establish fees for use of the Platform at any time or to charge additional fees for
-                    premium services, data access or additional functionality.
-                </p>
-                <p>
-                    Researcher Obligations. Your use of the Platform and of external data generated by Lookit
-                    participants shall be solely for your own educational and academic use. You will comply
-                    with all applicable laws in connection with your use of the Platform and resulting
-                    external data, as well as all applicable policies of your Institution. You will not
-                    attempt to circumnavigate or violate any security feature of the Platform, including
-                    accessing any Platform features, interactive areas, information or profiles for which
-                    you do not have permission or other content or information not intended for you.
-                </p>
-            </em>
+        </em>
+    </div>
+    <h3 class="m-4">Use of the Platform</h3>
+    <div class="m-4">
+        <em>
             <p>
-                All Researchers are responsible for their own use of the Platform, and for their use of
-                external data generated by Lookit participants. Researchers also assume responsibility for
-                any adverse events associated with participation in their studies. As part of your use of
-                the Platform and resulting external data, you agree that you:
+                Account Registration. In order to use the Platform, you will need to provide to us
+                certain basic information such as your name, institution, and email address. You agree
+                that all information you provide to us will be complete, true and correct and that you
+                will keep it up-to-date. During the registration process, you will choose a user name
+                and password for your use of the Platform. You will be responsible for securing your
+                user name and password and for all use of the Platform using your email address or
+                password. You will be solely liable for any use of the Platform under your account and
+                password. You agree to notify us promptly of any unauthorized use or disclosure of your
+                password. We reserve the right to refuse use of or revoke use of any username in our
+                discretion.
+                Basic use of the Platform is offered free of charge. However, we reserve the right to
+                establish fees for use of the Platform at any time or to charge additional fees for
+                premium services, data access or additional functionality.
             </p>
-            <ol>
-                <li>
-                    Will not use account or child nicknames, email addresses, or mailing addresses of Lookit
-                    participants, accessed via Researchers’ use of the Lookit platform, as a subject of
-                    research.
+            <p>
+                Researcher Obligations. Your use of the Platform and of external data generated by Lookit
+                participants shall be solely for your own educational and academic use. You will comply
+                with all applicable laws in connection with your use of the Platform and resulting
+                external data, as well as all applicable policies of your Institution. You will not
+                attempt to circumnavigate or violate any security feature of the Platform, including
+                accessing any Platform features, interactive areas, information or profiles for which
+                you do not have permission or other content or information not intended for you.
+            </p>
+        </em>
+        <p>
+            All Researchers are responsible for their own use of the Platform, and for their use of
+            external data generated by Lookit participants. Researchers also assume responsibility for
+            any adverse events associated with participation in their studies. As part of your use of
+            the Platform and resulting external data, you agree that you:
+        </p>
+        <ol>
+            <li>
+                Will not use account or child nicknames, email addresses, or mailing addresses of Lookit
+                participants, accessed via Researchers’ use of the Lookit platform, as a subject of
+                research.
+            </li>
+            <li>
+                Will not share, sell, publish, or otherwise disclose participant contact information
+                (email or mailing addresses) obtained as a result of their use of the Lookit platform.
+                For instance, participant contact information may not be added to a lab participant
+                database that is used for local recruitment.
+            </li>
+            <li>
+                May contact families by email, through the Lookit Platform, only in accordance with
+                those families’ email preferences, and only for communication related to their Lookit
+                studies.
+            </li>
+            <li>
+                May contact families by postal mail only to send payment/prizes for participation or
+                materials needed to participate in a study (e.g., a book to read together), and not for
+                any other communication.
+            </li>
+            <li>
+                Subject to any applicable institutional review, may study relationships between the same
+                child’s behavior in the same study (some studies may comprise multiple sessions, for
+                instance to look at individual differences, test-retest reliability, or the effects of
+                an intervention); between the same child’s behavior in different studies run by the
+                Researcher; and between siblings’ behavior on the same study or different studies run by
+                the Researcher.
+            </li>
+            <li>
+                Subject to any applicable institutional review, may combine data with another Lookit
+                Researcher to examine relationships among the same child’s or siblings’ behavior on
+                studies run by the Researcher in conjunction with studies run by another Researcher.
+            </li>
+            <li>
+                <strong>Will not publish either individual participant birthdates or information that
+                    could be combined to calculate participant birthdates </strong> (for instance, the
+                    participant’s age in days at time of testing plus the test date).
                 </li>
                 <li>
-                    Will not share, sell, publish, or otherwise disclose participant contact information
-                    (email or mailing addresses) obtained as a result of their use of the Lookit platform.
-                    For instance, participant contact information may not be added to a lab participant
-                    database that is used for local recruitment.
+                    May use parent and child nicknames only for communication with participants, and may not
+                    publish individual child or account nicknames stored in child and account records. Child
+                    names may be incidentally included in video recordings or parent comments that are
+                    published, although we encourage researchers to redact child names when possible from
+                    written comments.
                 </li>
                 <li>
-                    May contact families by email, through the Lookit Platform, only in accordance with
-                    those families’ email preferences, and only for communication related to their Lookit
-                    studies.
+                    With the exception of linking external data to corresponding Lookit data for studies
+                    posted on Lookit, will not use video or other data in order to link outside information
+                    available about a specific participant to an associated child, account, or experimental
+                    session, without specific IRB approval to do so. Any other planned integration of
+                    outside data must be reported to Lookit at the time the study is submitted.
                 </li>
                 <li>
-                    May contact families by postal mail only to send payment/prizes for participation or
-                    materials needed to participate in a study (e.g., a book to read together), and not for
-                    any other communication.
-                </li>
-                <li>
-                    Subject to any applicable institutional review, may study relationships between the same
-                    child’s behavior in the same study (some studies may comprise multiple sessions, for
-                    instance to look at individual differences, test-retest reliability, or the effects of
-                    an intervention); between the same child’s behavior in different studies run by the
-                    Researcher; and between siblings’ behavior on the same study or different studies run by
-                    the Researcher.
-                </li>
-                <li>
-                    Subject to any applicable institutional review, may combine data with another Lookit
-                    Researcher to examine relationships among the same child’s or siblings’ behavior on
-                    studies run by the Researcher in conjunction with studies run by another Researcher.
-                </li>
-                <li>
-                    <strong>Will not publish either individual participant birthdates or information that
-                        could be combined to calculate participant birthdates </strong> (for instance, the
-                        participant’s age in days at time of testing plus the test date).
+                    <strong>Will not publish the "global ID" fields for account, child, or demographic
+                        survey records.</strong> These fields can be accessed by all researchers using the
+                        Lookit platform, so publication could lead to unintentional linkage of data from the
+                        same individuals. Researchers receive access to the global IDs in case necessary; for
+                        instance, to facilitate financial record-keeping and any necessary linking of accounts
+                        and children across studies. The 5-character account, child, and demographic "ID" fields
+                        provided for download may be published; these are specific to the study. Researchers
+                        wishing to publish persistent identifiers for data from multiple connected studies must
+                        either create a table linking IDs across studies, or generate their own random IDs.
                     </li>
                     <li>
-                        May use parent and child nicknames only for communication with participants, and may not
-                        publish individual child or account nicknames stored in child and account records. Child
-                        names may be incidentally included in video recordings or parent comments that are
-                        published, although we encourage researchers to redact child names when possible from
-                        written comments.
+                        <strong>Will not publish video of Lookit participants such that it can be matched with
+                            individual demographic survey data (e.g., household income, number of
+                        parents/guardians). </strong>
                     </li>
                     <li>
-                        With the exception of linking external data to corresponding Lookit data for studies
-                        posted on Lookit, will not use video or other data in order to link outside information
-                        available about a specific participant to an associated child, account, or experimental
-                        session, without specific IRB approval to do so. Any other planned integration of
-                        outside data must be reported to Lookit at the time the study is submitted.
-                    </li>
-                    <li>
-                        <strong>Will not publish the "global ID" fields for account, child, or demographic
-                            survey records.</strong> These fields can be accessed by all researchers using the
-                            Lookit platform, so publication could lead to unintentional linkage of data from the
-                            same individuals. Researchers receive access to the global IDs in case necessary; for
-                            instance, to facilitate financial record-keeping and any necessary linking of accounts
-                            and children across studies. The 5-character account, child, and demographic "ID" fields
-                            provided for download may be published; these are specific to the study. Researchers
-                            wishing to publish persistent identifiers for data from multiple connected studies must
-                            either create a table linking IDs across studies, or generate their own random IDs.
-                        </li>
-                        <li>
-                            <strong>Will not publish video of Lookit participants such that it can be matched with
-                                individual demographic survey data (e.g., household income, number of
-                            parents/guardians). </strong>
-                        </li>
-                        <li>
-                            <strong>Will not collect external data from studies posted on Lookit with the intent to
-                            circumvent the terms of this agreement.</strong>
-                        </li>
-                    </ol>
-                </div>
-                <h3 class="m-4">Use and Storage of Data By Lookit and Researchers</h3>
-                <div class="m-4">
-                    <p>
-                        <em>The following guidelines pertain to the use and storage of Lookit data.</em>
-                    </p>
-                    <ol>
-                        <li>
-                            Researchers may download local copies of their Lookit data, including study data and
-                            video, and account, child, and demographic survey data from Lookit participants who have
-                            participated in their studies. Lookit may also keep copies of this data, including study
-                            data and video, indefinitely.
-                        </li>
-                        <li>
-                            Lookit assumes no responsibility for losses incurred by the Researchers in the event
-                            that data stored by Lookit, including study design information, is lost or corrupted.
-                        </li>
-                        <li>Researchers retain ownership of study data, including video, for their own studies.</li>
-                        <li>
-                            Lookit retains ownership of account, child, and demographic survey response data
-                            collected on Lookit.
-                        </li>
-                        <li>
-                            <strong>Lookit reserves the right to use any data collected on the Lookit platform,
-                                including account, child, demographic, and study data, for the following purposes:
-                            </strong>
-                            <ol>
-                                <li>
-                                    To improve the Lookit platform: e.g., detect and fix technical problems or
-                                    identify new features that would be helpful
-                                </li>
-                                <li>
-                                    To develop data analysis tools for Lookit researchers, including automated gaze
-                                    coding
-                                </li>
-                                <li>To provide technical support to study researchers</li>
-                                <li>
-                                    To assess the quality of data collected on the platform (for instance, how well
-                                    an observer can tell which direction children are looking)
-                                </li>
-                                <li>To evaluate recruitment and family engagement efforts</li>
-                                <li>To recruit participants or researchers to use Lookit</li>
-                            </ol>
-                        </li>
-                        <li>Lookit may publish the results of the above described methodological research.</li>
-                    </ol>
-                </div>
-                <h3 class="m-4">Restrictions on Data Collection on Lookit</h3>
-                <div class="m-4">
-                    <p>
-                        <em>The following guidelines pertain to the use and storage of Lookit data, and apply to all
-                            studies posted on the Lookit platform, whether they are also conducted there or are
-                        conducted using an external platform or scheduled session.</em>
-                    </p>
-                    <ol>
-                        <li>
-                            Researchers must provide accurate contact information to be posted along with all
-                            studies they conduct on Lookit, <strong>and must respond promptly to parent
-                        communication. </strong>
-                    </li>
-                    <li>
-                        Researchers agree to accurately represent the procedures and goals of their studies. In
-                        addition to obtaining approval from any appropriate institutional review board,
-                        researchers agree to notify Lookit of deception involved in any study designs, at the
-                        time the study is submitted for Lookit review. <strong>Deception that must be disclosed
-                        to Lookit includes deliberate omission of information or presentation of any
-                        misleading information to either the parent or the child, either in the course of
-                        the study itself or regarding the study’s purpose and procedures. </strong>Examples
-                        include telling the child that he or she performed better or worse than peers when
-                        children were in fact assigned randomly to receive such feedback; telling a parent that
-                        researchers expect to observe a particular behavior that is not actually expected, in
-                        order to avoid parental bias; or failing to disclose in a study about child-parent
-                        interaction that the researchers are primarily interested in gender differences in
-                        interaction styles.
-                    </li>
-                    <li>
-                        In all study designs, the child must remain in the same room with his or her parent at
-                        all times. No infancy study session (for children 0 - 12 months) may be designed to last
-                        longer than 30 minutes, and no experiment session may be designed to last longer than 90
-                        minutes. Purely observational periods may extend longer if approved by Lookit--for
-                        instance, if the goal of a study is to observe conversation during a family meal or
-                        independent child play.
-                    </li>
-                    <li>
-                        In all study designs, the parent must be able to end the study session at any point.
-                        This functionality is built into Lookit and may not be altered. Equivalent functionality
-                        must be available in any study posted on Lookit and conducted elsewhere. Parents must be
-                        informed of this option at the beginning of every study.
-                    </li>
-                    <li>
-                        Researchers acknowledge that all studies are subject to review and final approval by
-                        Lookit. Lookit reserves the right to reject a study and/or request revisions for any
-                        reason. However, Lookit approval is not based on a complete review of research practices
-                        and does not constitute endorsement of a study. Researchers still hold ultimate
-                        responsibility for their study design and ethical compliance.
-                    </li>
-                    <li>
-                        Researchers agree to post studies and collect data from participants only on the Lookit
-                        production platform (https://lookit.mit.edu). Researchers granted access to a Lookit
-                        staging site may use this only for study development and usability testing, and may not
-                        obtain parental consent via this site.
+                        <strong>Will not collect external data from studies posted on Lookit with the intent to
+                        circumvent the terms of this agreement.</strong>
                     </li>
                 </ol>
             </div>
-            <h3 class="m-4">Informed Consent Guidelines</h3>
-            <div class="m-4">
-                <em>
-                    <p>
-                        Studies which are posted on Lookit but conducted elsewhere must use informed consent
-                        procedures as required by the Researcher's institutional review board. Lookit reserves
-                        the right to require any studies posted on the Lookit platform to conduct informed
-                        consent procedures on Lookit.
-                    </p>
-                    <p>
-                        The remainder of this section applies only to those studies which are both posted and
-                        conducted on lookit.
-                    </p>
-                </em>
-                <p>
-                    Researchers may study participants from birth through seventeen years of age (i.e., until the
-                    eighteenth birthday) and their parents or legal guardians on Lookit. Researchers may also
-                    study adult participants. For studies with only adult participants, researchers agree to
-                    record a statement of informed consent from the participant. <strong>For studies with child
-                    participants, researchers agree to record a statement of informed consent from a child
-                    participant’s parent or legal guardian at the start of any Lookit study, and to
-                    additionally record a statement of assent from any child participant aged eight years or
-                    older.</strong>Parents and guardians of all ages may consent to participation on behalf
-                    of themselves and their children (that is, if the parent is a minor, his or her own parent’s
-                    consent is not additionally required).
-                </p>
-                <p>
-                    If only parental consent is obtained, data from child participants eight years of age and
-                    older must be treated as if valid consent was not obtained. Researchers may at their own
-                    discretion and/or based on their own institution’s policies record an assent statement from
-                    children under eight years as well.
-                </p>
-                <p>
-                    Consent/assent may occur after a webcam setup/configuration step but must precede any other
-                    Lookit study elements. Researchers must use the standard Lookit consent and, if applicable,
-                    assent form element(s) for this section, providing additional text relevant to the
-                    particular study which will be inserted in the spaces indicated. No translations or
-                    adaptations of these elements may be used without the approval of both the Researchers’
-                    institutional review board and Lookit. For studies that involve any webcam access, a verbal
-                    (or ASL) statement of consent (and assent if applicable) must be recorded via webcam. For
-                    studies that do not involve any webcam or audio recording (e.g., that consist entirely of a
-                    survey), Lookit’s non-webcam form elements may be used.
-                </p>
-                <p>
-                    Researchers agree that they will view the consent recording before viewing any other video
-                    data collected during the same session and that they will check that the recording
-                    demonstrates informed adult consent and child assent if applicable. If the statement(s) is
-                    audible (or a signed statement in ASL is interpretable), appropriate study measures may then
-                    be coded by the researcher and the data may be used for research purposes. If a technical
-                    issue (e.g. lack of audio recording) prevented collection of informed consent from the
-                    parent, and the parent has set communication preferences to allow researchers to email with
-                    questions about their participation, Researchers may instead confirm consent by emailing the
-                    account holder and receiving back a reply that contains the statement “Yes, I am this
-                    child's parent or legal guardian and we both agreed to participate in this study” or text
-                    equivalent in meaning.
-                </p>
-                <p>
-                    Unless parental consent and, if applicable, child assent are confirmed, Researchers may not
-                    view any other video associated with this study session, and may not use any other data from
-                    the session in their analysis, although the number of such records and aggregate data about
-                    the associated accounts (e.g., how many unique children, how many were in the age range) may
-                    be reported. Researchers are responsible for storing and maintaining any necessary records
-                    of confirmation of consent/assent.
-                </p>
-            </div>
-            <h3 class="m-4">Video Privacy</h3>
+            <h3 class="m-4">Use and Storage of Data By Lookit and Researchers</h3>
             <div class="m-4">
                 <p>
-                    Researchers agree to solicit selections for the privacy level of video data at the end of any
-                    Lookit study that is conducted on the Lookit platform. Researchers must use the standard
-                    Lookit exit survey element for this section, providing additional text relevant to the
-                    particular study which will be inserted in the spaces indicated. Parents must have the
-                    option to withdraw their video from the study at this point. Language may be modified,
-                    subject to approval by Lookit, as required by Researchers’ institutional review board (for
-                    instance, to add more detail about Databrary).
+                    <em>The following guidelines pertain to the use and storage of Lookit data.</em>
                 </p>
-                <p>
-                    If video is withdrawn for a session, any video other than the consent recording will be
-                    automatically made unavailable by Lookit. In the event that Researchers download data during
-                    an ongoing study session and video is later withdrawn, and in the event of any discrepancy
-                    between withdrawal information and Lookit's automatic removal of video, Researchers agree to
-                    delete without viewing any associated session video they have downloaded other than the
-                    consent recording.
-                </p>
-                <p>
-                    Researchers may share video and other session data, account data, child data, and demographic
-                    data on Databrary for sessions where parents opt to allow this usage, subject to approval of
-                    the appropriate institutional review board. Researchers agree to share video data only in
-                    accordance with the parent’s privacy selections. If privacy selections are missing, video
-                    must be treated either as if withdrawn or as if the parent had selected ‘private’ use, and
-                    data must not be shared with Databrary.
-                </p>
+                <ol>
+                    <li>
+                        Researchers may download local copies of their Lookit data, including study data and
+                        video, and account, child, and demographic survey data from Lookit participants who have
+                        participated in their studies. Lookit may also keep copies of this data, including study
+                        data and video, indefinitely.
+                    </li>
+                    <li>
+                        Lookit assumes no responsibility for losses incurred by the Researchers in the event
+                        that data stored by Lookit, including study design information, is lost or corrupted.
+                    </li>
+                    <li>Researchers retain ownership of study data, including video, for their own studies.</li>
+                    <li>
+                        Lookit retains ownership of account, child, and demographic survey response data
+                        collected on Lookit.
+                    </li>
+                    <li>
+                        <strong>Lookit reserves the right to use any data collected on the Lookit platform,
+                            including account, child, demographic, and study data, for the following purposes:
+                        </strong>
+                        <ol>
+                            <li>
+                                To improve the Lookit platform: e.g., detect and fix technical problems or
+                                identify new features that would be helpful
+                            </li>
+                            <li>
+                                To develop data analysis tools for Lookit researchers, including automated gaze
+                                coding
+                            </li>
+                            <li>To provide technical support to study researchers</li>
+                            <li>
+                                To assess the quality of data collected on the platform (for instance, how well
+                                an observer can tell which direction children are looking)
+                            </li>
+                            <li>To evaluate recruitment and family engagement efforts</li>
+                            <li>To recruit participants or researchers to use Lookit</li>
+                        </ol>
+                    </li>
+                    <li>Lookit may publish the results of the above described methodological research.</li>
+                </ol>
             </div>
-            <h3 class="m-4">Participant Payment</h3>
+            <h3 class="m-4">Restrictions on Data Collection on Lookit</h3>
             <div class="m-4">
                 <p>
-                    Researchers may choose whether to pay participants, and the form of payment, subject to any
-                    applicable IRB review at their own institutions. The purpose of payment must be to
-                    compensate participants for their time and effort, and must not be coercive. Lookit may set
-                    guidelines for acceptable payment ranges. Payment may include: money or gift certificates,
-                    or physical prizes (e.g., an age-appropriate book or game), either emailed or sent via
-                    postal mail. Future payment options may include Lookit points, redeemable on the Lookit
-                    Platform for gift certificates and other prizes, and may be pooled across studies.
+                    <em>The following guidelines pertain to the use and storage of Lookit data, and apply to all
+                        studies posted on the Lookit platform, whether they are also conducted there or are
+                    conducted using an external platform or scheduled session.</em>
+                </p>
+                <ol>
+                    <li>
+                        Researchers must provide accurate contact information to be posted along with all
+                        studies they conduct on Lookit, <strong>and must respond promptly to parent
+                    communication. </strong>
+                </li>
+                <li>
+                    Researchers agree to accurately represent the procedures and goals of their studies. In
+                    addition to obtaining approval from any appropriate institutional review board,
+                    researchers agree to notify Lookit of deception involved in any study designs, at the
+                    time the study is submitted for Lookit review. <strong>Deception that must be disclosed
+                    to Lookit includes deliberate omission of information or presentation of any
+                    misleading information to either the parent or the child, either in the course of
+                    the study itself or regarding the study’s purpose and procedures. </strong>Examples
+                    include telling the child that he or she performed better or worse than peers when
+                    children were in fact assigned randomly to receive such feedback; telling a parent that
+                    researchers expect to observe a particular behavior that is not actually expected, in
+                    order to avoid parental bias; or failing to disclose in a study about child-parent
+                    interaction that the researchers are primarily interested in gender differences in
+                    interaction styles.
+                </li>
+                <li>
+                    In all study designs, the child must remain in the same room with his or her parent at
+                    all times. No infancy study session (for children 0 - 12 months) may be designed to last
+                    longer than 30 minutes, and no experiment session may be designed to last longer than 90
+                    minutes. Purely observational periods may extend longer if approved by Lookit--for
+                    instance, if the goal of a study is to observe conversation during a family meal or
+                    independent child play.
+                </li>
+                <li>
+                    In all study designs, the parent must be able to end the study session at any point.
+                    This functionality is built into Lookit and may not be altered. Equivalent functionality
+                    must be available in any study posted on Lookit and conducted elsewhere. Parents must be
+                    informed of this option at the beginning of every study.
+                </li>
+                <li>
+                    Researchers acknowledge that all studies are subject to review and final approval by
+                    Lookit. Lookit reserves the right to reject a study and/or request revisions for any
+                    reason. However, Lookit approval is not based on a complete review of research practices
+                    and does not constitute endorsement of a study. Researchers still hold ultimate
+                    responsibility for their study design and ethical compliance.
+                </li>
+                <li>
+                    Researchers agree to post studies and collect data from participants only on the Lookit
+                    production platform (https://lookit.mit.edu). Researchers granted access to a Lookit
+                    staging site may use this only for study development and usability testing, and may not
+                    obtain parental consent via this site.
+                </li>
+            </ol>
+        </div>
+        <h3 class="m-4">Informed Consent Guidelines</h3>
+        <div class="m-4">
+            <em>
+                <p>
+                    Studies which are posted on Lookit but conducted elsewhere must use informed consent
+                    procedures as required by the Researcher's institutional review board. Lookit reserves
+                    the right to require any studies posted on the Lookit platform to conduct informed
+                    consent procedures on Lookit.
                 </p>
                 <p>
-                    Information about payment must be included in the study description submitted to Lookit and
-                    is subject to Lookit approval. This information must include when, how, how much, and under
-                    what conditions participants will be paid.
-                    <strong>
-                        Without prior approval by Lookit, payment
-                        may not depend on the child’s behavior or performance, even if that behavior renders
-                        data unusable (e.g., if an infant fusses and his parent ends the session
-                        early).
-                    </strong>
-                    Payment may not depend on the parent’s video privacy selections.
+                    The remainder of this section applies only to those studies which are both posted and
+                    conducted on lookit.
+                </p>
+            </em>
+            <p>
+                Researchers may study participants from birth through seventeen years of age (i.e., until the
+                eighteenth birthday) and their parents or legal guardians on Lookit. Researchers may also
+                study adult participants. For studies with only adult participants, researchers agree to
+                record a statement of informed consent from the participant. <strong>For studies with child
+                participants, researchers agree to record a statement of informed consent from a child
+                participant’s parent or legal guardian at the start of any Lookit study, and to
+                additionally record a statement of assent from any child participant aged eight years or
+                older.</strong>Parents and guardians of all ages may consent to participation on behalf
+                of themselves and their children (that is, if the parent is a minor, his or her own parent’s
+                consent is not additionally required).
+            </p>
+            <p>
+                If only parental consent is obtained, data from child participants eight years of age and
+                older must be treated as if valid consent was not obtained. Researchers may at their own
+                discretion and/or based on their own institution’s policies record an assent statement from
+                children under eight years as well.
+            </p>
+            <p>
+                Consent/assent may occur after a webcam setup/configuration step but must precede any other
+                Lookit study elements. Researchers must use the standard Lookit consent and, if applicable,
+                assent form element(s) for this section, providing additional text relevant to the
+                particular study which will be inserted in the spaces indicated. No translations or
+                adaptations of these elements may be used without the approval of both the Researchers’
+                institutional review board and Lookit. For studies that involve any webcam access, a verbal
+                (or ASL) statement of consent (and assent if applicable) must be recorded via webcam. For
+                studies that do not involve any webcam or audio recording (e.g., that consist entirely of a
+                survey), Lookit’s non-webcam form elements may be used.
+            </p>
+            <p>
+                Researchers agree that they will view the consent recording before viewing any other video
+                data collected during the same session and that they will check that the recording
+                demonstrates informed adult consent and child assent if applicable. If the statement(s) is
+                audible (or a signed statement in ASL is interpretable), appropriate study measures may then
+                be coded by the researcher and the data may be used for research purposes. If a technical
+                issue (e.g. lack of audio recording) prevented collection of informed consent from the
+                parent, and the parent has set communication preferences to allow researchers to email with
+                questions about their participation, Researchers may instead confirm consent by emailing the
+                account holder and receiving back a reply that contains the statement “Yes, I am this
+                child's parent or legal guardian and we both agreed to participate in this study” or text
+                equivalent in meaning.
+            </p>
+            <p>
+                Unless parental consent and, if applicable, child assent are confirmed, Researchers may not
+                view any other video associated with this study session, and may not use any other data from
+                the session in their analysis, although the number of such records and aggregate data about
+                the associated accounts (e.g., how many unique children, how many were in the age range) may
+                be reported. Researchers are responsible for storing and maintaining any necessary records
+                of confirmation of consent/assent.
+            </p>
+        </div>
+        <h3 class="m-4">Video Privacy</h3>
+        <div class="m-4">
+            <p>
+                Researchers agree to solicit selections for the privacy level of video data at the end of any
+                Lookit study that is conducted on the Lookit platform. Researchers must use the standard
+                Lookit exit survey element for this section, providing additional text relevant to the
+                particular study which will be inserted in the spaces indicated. Parents must have the
+                option to withdraw their video from the study at this point. Language may be modified,
+                subject to approval by Lookit, as required by Researchers’ institutional review board (for
+                instance, to add more detail about Databrary).
+            </p>
+            <p>
+                If video is withdrawn for a session, any video other than the consent recording will be
+                automatically made unavailable by Lookit. In the event that Researchers download data during
+                an ongoing study session and video is later withdrawn, and in the event of any discrepancy
+                between withdrawal information and Lookit's automatic removal of video, Researchers agree to
+                delete without viewing any associated session video they have downloaded other than the
+                consent recording.
+            </p>
+            <p>
+                Researchers may share video and other session data, account data, child data, and demographic
+                data on Databrary for sessions where parents opt to allow this usage, subject to approval of
+                the appropriate institutional review board. Researchers agree to share video data only in
+                accordance with the parent’s privacy selections. If privacy selections are missing, video
+                must be treated either as if withdrawn or as if the parent had selected ‘private’ use, and
+                data must not be shared with Databrary.
+            </p>
+        </div>
+        <h3 class="m-4">Participant Payment</h3>
+        <div class="m-4">
+            <p>
+                Researchers may choose whether to pay participants, and the form of payment, subject to any
+                applicable IRB review at their own institutions. The purpose of payment must be to
+                compensate participants for their time and effort, and must not be coercive. Lookit may set
+                guidelines for acceptable payment ranges. Payment may include: money or gift certificates,
+                or physical prizes (e.g., an age-appropriate book or game), either emailed or sent via
+                postal mail. Future payment options may include Lookit points, redeemable on the Lookit
+                Platform for gift certificates and other prizes, and may be pooled across studies.
+            </p>
+            <p>
+                Information about payment must be included in the study description submitted to Lookit and
+                is subject to Lookit approval. This information must include when, how, how much, and under
+                what conditions participants will be paid.
+                <strong>
+                    Without prior approval by Lookit, payment
+                    may not depend on the child’s behavior or performance, even if that behavior renders
+                    data unusable (e.g., if an infant fusses and his parent ends the session
+                    early).
+                </strong>
+                Payment may not depend on the parent’s video privacy selections.
+            </p>
+            <p>
+                Even if payment is to be sent via postal mail, families may not be required to provide a
+                mailing address in order to participate. When practical, families should be offered the
+                opportunity to select alternate compensation in this case.
+            </p>
+            <p>
+                Researchers are responsible for verifying participation and sending payment or recording the
+                number of Lookit points participants should receive. Researchers are responsible for the
+                cost of all participant payment, including reimbursing Lookit for Lookit points based on a
+                price agreed upon at the start of the study. Lookit may, at its discretion, also choose to
+                itself offer Lookit points for study participation. Researchers are not responsible for the
+                costs of such compensation.
+            </p>
+        </div>
+        <h3 class="m-4">Copyright Violation</h3>
+        <div class="m-4">
+            <em>
+                <p>
+                    It is MIT’s policy to respond to notices of alleged copyright infringement that comply
+                    with the Digital Millennium Copyright Act. Copyright owners who believe their material
+                    has been infringed on the Platform should contact MIT's designated copyright agent at
+                    dcma-agent@mit.edu, or at 77 Massachusetts Ave., Cambridge, MA 02138-4307 Attention: MIT
+                    DMCA Agent, W92-263A.
                 </p>
                 <p>
-                    Even if payment is to be sent via postal mail, families may not be required to provide a
-                    mailing address in order to participate. When practical, families should be offered the
-                    opportunity to select alternate compensation in this case.
+                    Notification must include: (a) identification of the copyrighted work, or, in the case of
+                    multiple works at the same location, a representative list of such works at that site;
+                    (b) identification of the material that is claimed to be infringing or to be the subject
+                    of infringing activity; (c) information for us to be able to contact the complaining
+                    party (e.g., email address, phone number); (d) a statement that the complaining party
+                    believes that the use of the material has not been authorized by the copyright owner or
+                    an authorized agent; and (e) a statement that the information in the notification is
+                    accurate and that the complaining party is authorized to act on behalf of the copyright
+                    owner.
                 </p>
+            </em>
+        </div>
+        <h3 class="m-4">Entire Agreement</h3>
+        <div class="m-4">
+            <em>
                 <p>
-                    Researchers are responsible for verifying participation and sending payment or recording the
-                    number of Lookit points participants should receive. Researchers are responsible for the
-                    cost of all participant payment, including reimbursing Lookit for Lookit points based on a
-                    price agreed upon at the start of the study. Lookit may, at its discretion, also choose to
-                    itself offer Lookit points for study participation. Researchers are not responsible for the
-                    costs of such compensation.
+                    These terms and conditions constitute the entire agreement between you and MIT with
+                    respect to your use of the Platform, superseding any prior agreements between you and
+                    MIT regarding your use of the Platform. The failure of MIT to exercise or enforce any
+                    right or provision of the terms and conditions shall not constitute a waiver of such
+                    right or provision. If any provision of the terms and conditions is found by a court of
+                    competent jurisdiction to be invalid, the parties nevertheless agree that the court
+                    should endeavor to give effect to the parties' intentions as reflected in the provision,
+                    and the other provisions of the terms and conditions remain in full force and effect.
                 </p>
-            </div>
-            <h3 class="m-4">Copyright Violation</h3>
-            <div class="m-4">
-                <em>
-                    <p>
-                        It is MIT’s policy to respond to notices of alleged copyright infringement that comply
-                        with the Digital Millennium Copyright Act. Copyright owners who believe their material
-                        has been infringed on the Platform should contact MIT's designated copyright agent at
-                        dcma-agent@mit.edu, or at 77 Massachusetts Ave., Cambridge, MA 02138-4307 Attention: MIT
-                        DMCA Agent, W92-263A.
-                    </p>
-                    <p>
-                        Notification must include: (a) identification of the copyrighted work, or, in the case of
-                        multiple works at the same location, a representative list of such works at that site;
-                        (b) identification of the material that is claimed to be infringing or to be the subject
-                        of infringing activity; (c) information for us to be able to contact the complaining
-                        party (e.g., email address, phone number); (d) a statement that the complaining party
-                        believes that the use of the material has not been authorized by the copyright owner or
-                        an authorized agent; and (e) a statement that the information in the notification is
-                        accurate and that the complaining party is authorized to act on behalf of the copyright
-                        owner.
-                    </p>
-                </em>
-            </div>
-            <h3 class="m-4">Entire Agreement</h3>
-            <div class="m-4">
-                <em>
-                    <p>
-                        These terms and conditions constitute the entire agreement between you and MIT with
-                        respect to your use of the Platform, superseding any prior agreements between you and
-                        MIT regarding your use of the Platform. The failure of MIT to exercise or enforce any
-                        right or provision of the terms and conditions shall not constitute a waiver of such
-                        right or provision. If any provision of the terms and conditions is found by a court of
-                        competent jurisdiction to be invalid, the parties nevertheless agree that the court
-                        should endeavor to give effect to the parties' intentions as reflected in the provision,
-                        and the other provisions of the terms and conditions remain in full force and effect.
-                    </p>
-                </em>
-            </div>
-            <h3 class="m-4">Governing Law</h3>
-            <div class="m-4">
-                <em>
-                    <p>
-                        You agree that any dispute arising out of or relating to these terms and conditions or
-                        any content posted to the Platform will be governed by the laws of the Commonwealth of
-                        Massachusetts, excluding its conflicts of law provisions. You further consent to the
-                        personal jurisdiction of and exclusive venue in the federal and state courts located in
-                        and serving Boston, Massachusetts as the legal forum for any such dispute.
-                    </p>
-                </em>
-                <p class="last-update">
-                    Last updated October 13, 2021
-                    <a href="https://github.com/lookit/research-resources/commits/master/lookit%20static%20pages/termsofuse.html"
-                       target="_blank"
-                       rel="noopener">[Changelog]</a>
-                    <a href="https://mailman.mit.edu/mailman/listinfo/lookit-terms-notifications"
-                       target="_blank"
-                       rel="noopener">[Change notifications]</a>
+            </em>
+        </div>
+        <h3 class="m-4">Governing Law</h3>
+        <div class="m-4">
+            <em>
+                <p>
+                    You agree that any dispute arising out of or relating to these terms and conditions or
+                    any content posted to the Platform will be governed by the laws of the Commonwealth of
+                    Massachusetts, excluding its conflicts of law provisions. You further consent to the
+                    personal jurisdiction of and exclusive venue in the federal and state courts located in
+                    and serving Boston, Massachusetts as the legal forum for any such dispute.
                 </p>
-            </div>
+            </em>
+            <p class="last-update">
+                Last updated October 13, 2021
+                <a href="https://github.com/lookit/research-resources/commits/master/lookit%20static%20pages/termsofuse.html"
+                   target="_blank"
+                   rel="noopener">[Changelog]</a>
+                <a href="https://mailman.mit.edu/mailman/listinfo/lookit-terms-notifications"
+                   target="_blank"
+                   rel="noopener">[Change notifications]</a>
+            </p>
         </div>
     {% endblock content %}

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -229,11 +229,11 @@ def subheading_classes():
 
 
 @register.simple_tag
-def page_title(title, btn=None):
-    if btn:
+def page_title(title, right_side_elements=None):
+    if right_side_elements:
         html = f"""<div class="d-flex flex-row bd-highlight mb-4 align-items-center">
         <h1 class="me-auto">{title}</h1>
-        <div>{btn}</div>
+        <div>{right_side_elements}</div>
         </div>"""
     else:
         html = f'<h1 class="mt-4 mb-4 text-center">{title}</h1>'

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -219,3 +219,18 @@ def button_secondary_classes(extra_classes=None):
         classes.extend([extra_classes])
 
     return " ".join(classes)
+
+
+@register.simple_tag
+def main_content_container_classes():
+    return "container my-4"
+
+
+@register.simple_tag
+def main_heading_classes():
+    return "mt-5 mb-2 text-center"
+
+
+@register.simple_tag
+def subheading_classes():
+    return "border-bottom pb-2 pt-4 mb-4 mx-4"

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -236,7 +236,7 @@ def page_title(title, btn=None):
         <div>{btn}</div>
         </div>"""
     else:
-        html = f'<h1 class="mt-5 mb-2 text-center">{title}</h1>'
+        html = f'<h1 class="mt-4 mb-4 text-center">{title}</h1>'
     return mark_safe(html)
 
 

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -222,15 +222,17 @@ def button_secondary_classes(extra_classes=None):
 
 
 @register.simple_tag
-def main_content_container_classes():
-    return "container my-4"
-
-
-@register.simple_tag
-def main_heading_classes():
-    return "mt-5 mb-2 text-center"
-
-
-@register.simple_tag
 def subheading_classes():
     return "border-bottom pb-2 pt-4 mb-4 mx-4"
+
+
+@register.simple_tag
+def page_title(title, btn=None):
+    if btn:
+        html = f"""<div class="d-flex flex-row bd-highlight mb-4 align-items-center">
+        <h1 class="me-auto">{title}</h1>
+        <div>{btn}</div>
+        </div>"""
+    else:
+        html = f'<h1 class="mt-5 mb-2 text-center">{title}</h1>'
+    return mark_safe(html)


### PR DESCRIPTION
This PR is to standardize (1) the spacing between the navigation bar, page heading(s) and/or the rest of the page content, and (2) the indentation of content relative to the navigation bar. Example screenshots below.

I've created template tags for BS5 classes for the page's container div, main title/heading (h1) and subheadings. However so far I've only implemented these in a small subset of pages in the web app. I will add more pages to this PR ASAP as I get them done.

I also made a small change to the state drop-down selection on the Resources page: I added "Select a state" to the default/blank option.

<img width="1252" alt="Screenshot 2023-03-22 at 11 17 33 PM" src="https://user-images.githubusercontent.com/9041788/227119946-5f42702c-b7d5-4048-9727-ca7615bef4cc.png">
<img width="1252" alt="Screenshot 2023-03-22 at 11 17 49 PM" src="https://user-images.githubusercontent.com/9041788/227120024-d1a5efff-b9c6-4abd-ab4c-a1e2832bd604.png">
<img width="1252" alt="Screenshot 2023-03-22 at 11 18 01 PM" src="https://user-images.githubusercontent.com/9041788/227120062-f2930547-5b3b-4b8c-85a1-d937246e8276.png">
<img width="1252" alt="Screenshot 2023-03-22 at 11 18 11 PM" src="https://user-images.githubusercontent.com/9041788/227120148-defb6bc3-2d12-4665-963a-7ac7d8741133.png">
