### PR TITLE
Remove text from home page when page is slender

### DIFF
--- a/web/templates/web/home.html
+++ b/web/templates/web/home.html
@@ -13,9 +13,9 @@
              alt="CHS home page collage"
              src="{% static 'images/chs_collage.png' %}"/>
         <div class="d-flex flex-column align-items-center position-absolute bottom-0">
-            <h3 class="m-xl-4 m-md-1">{% trans "Powered by Lookit" %}</h3>
-            <h5>{% trans "Fun for Families, Serious for Science" %}</h5>
-            <a class="{% button_primary_classes %} btn-lg m-xl-5 m-md-1"
+            <h3 class="d-none d-md-block m-xl-4 m-md-1">{% trans "Powered by Lookit" %}</h3>
+            <h5 class="d-none d-md-block">{% trans "Fun for Families, Serious for Science" %}</h5>
+            <a class="{% button_primary_classes %} btn-lg btn-md-sm m-xl-5 m-md-1"
                href="{% url 'web:studies-list' %}">{% trans "Participate in a Study" %}</a>
         </div>
     </div>


### PR DESCRIPTION
When page is slender, hide the text over the home page image.  Note,  the button under the text is still large, there isn't a great easy way to have the button change size depending on webpage size.  

![out](https://user-images.githubusercontent.com/44074998/228877769-de80c55e-a839-4011-bc6a-ff472ee0ce8c.gif)

Closes #1159