### PR TITLE
Remove panel class from response consent view

### DIFF
--- a/studies/templates/studies/study_responses_consent_ruling.html
+++ b/studies/templates/studies/study_responses_consent_ruling.html
@@ -111,11 +111,9 @@
                         </li>
                     {% endfor %}
                 </ul>
-                <form id="consent-ruling-form"
-                      class="panel-footer clearfix m-2"
-                      method="post">
+                <form id="consent-ruling-form" class="m-3" method="post">
                     {% csrf_token %}
-                    <div class="d-grid gap-2 col-11 mx-auto">
+                    <div class="d-grid gap-3">
                         <ul class="list-group text-center small">
                             <li class="list-group-item list-group-item-warning d-flex justify-content-between align-items-center">
                                 <div>Revert to Pending</div>
@@ -145,7 +143,7 @@
             <div class="card">
                 <div class="card-body">
                     {# Basic video information/warnings go in below div #}
-                    <div id="current-video-information" class="panel-body"></div>
+                    <div id="current-video-information"></div>
                 </div>
             </div>
             <video controls id="video-under-consideration" height="270" width="360">


### PR DESCRIPTION
To complete a task on the BS5 style concerns issue, I've removed the last "panel-*" class from our project.  There are two html files that still have this class, but they're not being used.  At some point we'll have to remove unused html files. 

Below is the images from the one view altered for this PR:
<img width="1552" alt="Screenshot 2023-04-12 at 11 00 36 AM" src="https://user-images.githubusercontent.com/44074998/231499060-d6026cc4-2506-4233-98f3-6b7b52882837.png">
<img width="1552" alt="Screenshot 2023-04-12 at 11 00 39 AM" src="https://user-images.githubusercontent.com/44074998/231499067-16d67611-8d5e-44ce-86e1-acf42acdf837.png">
