### PR TITLE
Add class to center search bars

### DIFF
--- a/accounts/templates/accounts/participant_list.html
+++ b/accounts/templates/accounts/participant_list.html
@@ -9,7 +9,7 @@
 {% block content %}
     {% button_primary_classes "btn-sm" as btn_primary_classes %}
     {% page_title "Participants" %}
-    <form method="get">
+    <form method="get" class="search-bar mb-5">
         <input id="search-participants"
                class="form-control"
                name="match"

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -18,3 +18,7 @@
 .empty-text {
     @extend .my-4, .mx-auto, .text-center, .fst-italic
 }
+
+.search-bar {
+    @extend .mx-5, .row
+}

--- a/studies/templates/studies/lab_list.html
+++ b/studies/templates/studies/lab_list.html
@@ -12,19 +12,17 @@
     {% button_primary_classes as btn_primary_classes %}
     {% bootstrap_button bs_icon_plus|add:"Create Lab" href=url_exp_lab_create button_class=btn_primary_classes as btn_create_lab %}
     {% page_title "View Labs" right_side_elements=btn_create_lab %}
-    <div class="my-4">
-        <form method="get">
-            <input id="search-labs"
-                   class="form-control"
-                   name="match"
-                   placeholder="Filter by name, PI, or institution"
-                   size="50"
-                   type="text"
-                   value="{{ match }}"/>
-            <input type="hidden" name="set" value="{{ set }}"/>
-            <input type="hidden" name="page" value="1"/>
-        </form>
-    </div>
+    <form method="get" class="search-bar mb-4">
+        <input id="search-labs"
+               class="form-control"
+               name="match"
+               placeholder="Filter by name, PI, or institution"
+               size="50"
+               type="text"
+               value="{{ match }}"/>
+        <input type="hidden" name="set" value="{{ set }}"/>
+        <input type="hidden" name="page" value="1"/>
+    </form>
     <ul class="nav nav-tabs">
         <li class="nav-item">
             <a class="nav-link{% if set == 'myLabs' %} active{% endif %}"

--- a/studies/templates/studies/lab_member_list.html
+++ b/studies/templates/studies/lab_member_list.html
@@ -13,7 +13,7 @@
 {% endbreadcrumb %}
 {% endblock breadcrumb %}
 {% block content %}
-    <form method="get">
+    <form method="get" class="search-bar my-5">
         <input id="search-researchers"
                class="form-control"
                name="match"

--- a/studies/templates/studies/study_attachments.html
+++ b/studies/templates/studies/study_attachments.html
@@ -39,20 +39,15 @@
             </span>
         </div>
     </div>
-    <div class="row text-center justify-content-center mt-3">
-        <div class="col-12 col-sm-offset-1 col-sm-10 col-md-offset-2 col-md-8">
-            <form method="get">
-                <input id="search-attachments"
-                       class="form-control form-control-sm"
-                       name="match"
-                       placeholder="Filter video name"
-                       size="50"
-                       type="text"
-                       value="{{ match }}"/>
-                <input type="hidden" name="sort" value="{{ sort }}"/>
-            </form>
-        </div>
-    </div>
+    <form method="get" class="search-bar my-4">
+        <input id="search-attachments"
+               class="form-control"
+               name="match"
+               placeholder="Filter video name"
+               type="text"
+               value="{{ match }}"/>
+        <input type="hidden" name="sort" value="{{ sort }}"/>
+    </form>
     <div class="row mt-3">
         <div class="col-12">
             <div class="table-responsive">

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -16,20 +16,18 @@
     {% else %}
         {% page_title "Manage Studies" %}
     {% endif %}
-    <div class="row mx-5">
-        <form method="get">
-            <input id="search-studies"
-                   class="form-control"
-                   name="match"
-                   placeholder="Filter name or description"
-                   size="50"
-                   type="text"
-                   value="{{ match }}"/>
-            <input type="hidden" name="sort" value="{{ sort }}"/>
-            <input type="hidden" name="state" value="{{ state }}"/>
-            <input type="hidden" name="page" value="1"/>
-        </form>
-    </div>
+    <form method="get" class="search-bar">
+        <input id="search-studies"
+               class="form-control"
+               name="match"
+               placeholder="Filter name or description"
+               size="50"
+               type="text"
+               value="{{ match }}"/>
+        <input type="hidden" name="sort" value="{{ sort }}"/>
+        <input type="hidden" name="state" value="{{ state }}"/>
+        <input type="hidden" name="page" value="1"/>
+    </form>
     <div class="row text-center mb-5 mt-2">
         <ul class="nav nav-pills justify-content-center">
             {% nav_link request 'exp:study-list-active' 'Active' %}

--- a/web/static/custom_bootstrap5.css
+++ b/web/static/custom_bootstrap5.css
@@ -562,7 +562,7 @@ progress {
   .container-xxl, .container-xl, .container-lg, .container-md, .container-sm, .container {
     max-width: 1320px; } }
 
-.row {
+.row, .search-bar {
   --bs-gutter-x: 1.5rem;
   --bs-gutter-y: 0;
   display: flex;
@@ -570,7 +570,7 @@ progress {
   margin-top: calc(-1 * var(--bs-gutter-y));
   margin-right: calc(-.5 * var(--bs-gutter-x));
   margin-left: calc(-.5 * var(--bs-gutter-x)); }
-  .row > * {
+  .row > *, .search-bar > * {
     flex-shrink: 0;
     width: 100%;
     max-width: 100%;
@@ -6133,7 +6133,7 @@ textarea.form-control-lg {
   margin-right: 1.5rem !important;
   margin-left: 1.5rem !important; }
 
-.mx-5 {
+.mx-5, .search-bar {
   margin-right: 3rem !important;
   margin-left: 3rem !important; }
 

--- a/web/templates/web/studies-list.html
+++ b/web/templates/web/studies-list.html
@@ -10,17 +10,21 @@
     <script src="{% static 'js/studies-list.js' %}" defer></script>
 {% endblock head %}
 {% block content %}
-    <form action method="post" class="study-list row g-2">
+    <form action method="post">
         {% csrf_token %}
         {{ form.study_list_tabs }}
-        <div class="col-auto">{% bootstrap_field form.child show_label=False %}</div>
-        <div class="col-auto">{% bootstrap_field form.study_location show_label=False %}</div>
-        <div class="col-auto p-2">{% bootstrap_field form.hide_studies_we_have_done %}</div>
-        {% if user.is_anonymous %}<div class="col-auto pt-2">Log in to find studies just right for your child!</div>{% endif %}
-        <div class="col-auto">{% bootstrap_field form.search show_label=False %}</div>
-        <div class="col-auto">
-            {% trans "Clear" as clear_button_text %}
-            {% bootstrap_button clear_button_text button_class="btn btn-light link-secondary border-secondary" button_type="reset" %}
+        <div class="d-flex align-content-center justify-content-evenly">
+            <div class="pe-2">{% bootstrap_field form.child show_label=False %}</div>
+            <div>{% bootstrap_field form.study_location show_label=False %}</div>
+            <div class="p-2 flex-grow-1">{% bootstrap_field form.hide_studies_we_have_done %}</div>
+            {% if user.is_anonymous %}
+                <div class="p-2 flex-grow-1">Log in to find studies just right for your child!</div>
+            {% endif %}
+            <div class="pe-2">{% bootstrap_field form.search show_label=False %}</div>
+            <div>
+                {% trans "Clear" as clear_button_text %}
+                {% bootstrap_button clear_button_text button_class="btn btn-light link-secondary border-secondary" button_type="reset" %}
+            </div>
         </div>
     </form>
     <ul class="nav nav-tabs">


### PR DESCRIPTION
Add a CSS class to center search bars.  For studies list, added appropriate BS5 classes to style filter/search bar. 

<img width="1552" alt="Screenshot 2023-04-17 at 11 46 41 AM" src="https://user-images.githubusercontent.com/44074998/232540168-05429095-c65e-41dd-a34e-16552018023d.png">
<img width="1552" alt="Screenshot 2023-04-17 at 11 46 26 AM" src="https://user-images.githubusercontent.com/44074998/232540148-bb4df379-dd77-434c-a99d-6a6993f3294b.png">
<img width="1552" alt="Screenshot 2023-04-17 at 11 46 37 AM" src="https://user-images.githubusercontent.com/44074998/232540162-c02bdd55-a85b-4150-834b-1d0a6a8a2c3d.png">
<img width="1552" alt="Screenshot 2023-04-24 at 12 48 32 PM" src="https://user-images.githubusercontent.com/44074998/234063195-2dc3b507-f677-4f00-be22-ae6d60520d81.png">
<img width="1552" alt="Screenshot 2023-04-24 at 12 48 36 PM" src="https://user-images.githubusercontent.com/44074998/234063213-4d00db32-12c3-439c-8c67-6839fc3cf4f5.png">
<img width="1552" alt="Screenshot 2023-04-24 at 12 48 44 PM" src="https://user-images.githubusercontent.com/44074998/234063216-6fe31bdb-f184-43bf-903d-18e138669482.png">
