### PR TITLE
pass S3 environment variables into run_docker_container in EFP builder class

### DIFF
--- a/studies/experiment_builder.py
+++ b/studies/experiment_builder.py
@@ -232,6 +232,14 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
                 "SENTRY_DSN": os.environ.get("SENTRY_DSN_JS", None),
                 "PIPE_ACCOUNT_HASH": os.environ.get("PIPE_ACCOUNT_HASH"),
                 "PIPE_ENVIRONMENT": os.environ.get("PIPE_ENVIRONMENT"),
+                "AWS_RECORDING_REGION": os.environ.get("AWS_RECORDING_REGION"),
+                "AWS_RECORDING_ACCESS_KEY_ID": os.environ.get(
+                    "AWS_RECORDING_ACCESS_KEY_ID"
+                ),
+                "AWS_RECORDING_SECRET_ACCESS_KEY": os.environ.get(
+                    "AWS_RECORDING_SECRET_ACCESS_KEY"
+                ),
+                "AWS_RECORDING_BUCKET": os.environ.get("AWS_RECORDING_BUCKET"),
             },
             volumes={
                 local_paths.checkouts: {"bind": "/checkouts", "mode": "ro"},


### PR DESCRIPTION
This adds the S3 environment variables to the `run_docker_container` method in the `EmberFrameplayerBuilder` class. This is a test to see if these variables will be successfully passed into the EFP study.

This is just intended for testing on staging, and changes will be reverted after testing.