### PR TITLE
Edit study detail text for CHS merger

### DIFF
--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -151,6 +151,11 @@
                                 <p>
                                     {% trans "It will also make it possible for the researchers of this study to contact you, and will share your child's profile information with the researchers." %}
                                 </p>
+                            {% else %}
+                                <p>{% trans "This study runs here on the Lookit platform." %}</p>
+                                <p>
+                                    {% trans "Clicking to participate will make it possible for the researchers of this study to contact you, and will share your child's profile information with the researchers." %}
+                                </p>
                             {% endif %}
                         {% endif %}
                     </form>

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -147,9 +147,9 @@
                                 </p>
                             {% endif %}
                             {% if object.study_type.is_external %}
-                                <p>{% trans "This study is being run outside of Lookit." %}</p>
+                                <p>{% trans "This study runs on another website, and clicking to participate will take you to that link." %}</p>
                                 <p>
-                                    {% trans "Clicking to participate via Lookit will make it possible for researchers to contact you & will share profile information with researchers." %}
+                                    {% trans "It will also make it possible for the researchers of this study to contact you, and will share your child's profile information with the researchers." %}
                                 </p>
                             {% endif %}
                         {% endif %}


### PR DESCRIPTION
This PR edits/adds the text below the "Participate" button on the family-facing study detail pages:

Internal: This study runs here on the Lookit platform. Clicking to participate will make it possible for the researchers of this study to contact you, and will share your child's profile information with the researchers.

External: This study runs on another website, and clicking to participate will take you to that link. It will also make it possible for the researchers of this study to contact you, and will share your child's profile information with the researchers.

Internal:

![Screenshot 2023-05-09 at 12 45 37 PM](https://github.com/lookit/lookit-api/assets/9041788/4ddda44c-5781-465d-91b1-0b055411996e)

External:

![Screenshot 2023-05-09 at 12 43 42 PM](https://github.com/lookit/lookit-api/assets/9041788/6f643f0a-a799-45f8-a659-adf6b1728124)

With child eligibility warning:

![Screenshot 2023-05-09 at 12 52 45 PM](https://github.com/lookit/lookit-api/assets/9041788/84a5e6bf-a67c-4e6f-aac4-60e359ac91d1)
