### PR TITLE
Edit explainer text on Studies History for CHS merger

### DIFF
--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -27,7 +27,13 @@
         {% endfor %}
     </ul>
     {% if object_list %}
-        <div class="m-3">{% trans "Here you can view your studies and see comments left by researchers:" %}</div>
+        <div class="m-3">
+            {% if form.past_studies_tabs|studies_tab_selected == "0" %}
+                {% trans "Lookit studies run here on our platform, and usually include a video of your session! You can find information about your previous study sessions, watch these videos, and see comments left by researchers below." %}
+            {% elif form.past_studies_tabs|studies_tab_selected == "1" %}
+                {% trans "External studies happen at other websites, and are listed below after you click the &quot;Participate Now&quot; button to follow a link. You can find information on the studies you have accessed and contact information for the researchers on a specific study below." %}
+            {% endif %}
+        </div>
     {% endif %}
     {% for study in object_list %}
         <div class="card mb-5">

--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -26,15 +26,19 @@
             </li>
         {% endfor %}
     </ul>
-    {% if object_list %}
-        <div class="m-3">
-            {% if form.past_studies_tabs|studies_tab_selected == "0" %}
-                {% trans "Lookit studies run here on our platform, and usually include a video of your session! You can find information about your previous study sessions, watch these videos, and see comments left by researchers below." %}
-            {% elif form.past_studies_tabs|studies_tab_selected == "1" %}
-                {% trans "External studies happen at other websites, and are listed below after you click the &quot;Participate Now&quot; button to follow a link. You can find information on the studies you have accessed and contact information for the researchers on a specific study below." %}
+    <div class="m-3">
+        {% if form.past_studies_tabs|studies_tab_selected == "0" %}
+            {% trans "Lookit studies run here on our platform, and usually include a video of your session! " %}
+            {% if object_list %}
+                {% trans "You can find information about your previous study sessions, watch these videos, and see comments left by researchers below." %}
             {% endif %}
-        </div>
-    {% endif %}
+        {% elif form.past_studies_tabs|studies_tab_selected == "1" %}
+            {% trans "External studies happen at other websites, and are listed below after you click the &quot;Participate Now&quot; button to follow a link. " %}
+            {% if object_list %}
+                {% trans "You can find information on the studies you have accessed and contact information for the researchers on a specific study below." %}
+            {% endif %}
+        {% endif %}
+    </div>
     {% for study in object_list %}
         <div class="card mb-5">
             <div class="card-body">


### PR DESCRIPTION
This PR contains updates to the explainer text that appears below the "Lookit studies" and "External studies" tabs on the "My Past Studies" (studies history) page.

## Internal
**One or more study**
> "Lookit studies run here on our platform, and usually include a video of your session! You can find information about your previous study sessions, watch these videos, and see comments left by researchers below."

**No studies**
> "Lookit studies run here on our platform, and usually include a video of your session! You have not participated in any Lookit studies."

## External
**One or more study**
> "External studies happen at other websites, and are listed below after you click the "Participate Now" button to follow a link. You can find information on the studies you have accessed and contact information for the researchers on a specific study below."

**No studies**
> "External studies happen at other websites, and are listed below after you click the "Participate Now" button to follow a link. You have not participated in any external studies."

## Implementation note
I've edited the logic in the template since some of the Lookit/External explainer text is repeated when the study list is and is not empty. Now instead of showing different strings for empty lists vs not, the first repeated bit of text is _always_ shown below the Lookit/External navigation tabs. 
There is additional text that conditionally added to the explainer blurb if the study list is not empty. 
Finally, I kept the styling for the text that is conditional on empty lists the same as it was before (centered and italicized) to be consistent with how we do this elsewhere on the site (#1169).

## Screenshots
Internal 
![Screenshot 2023-05-09 at 2 48 50 PM](https://github.com/lookit/lookit-api/assets/9041788/0022eddd-c990-4da8-97d1-e8ce664cbee3)
Internal, no studies
![Screenshot 2023-05-09 at 2 47 55 PM](https://github.com/lookit/lookit-api/assets/9041788/81c0088c-1858-4470-bcdd-ad8f5820e242)
External
![Screenshot 2023-05-09 at 2 49 00 PM](https://github.com/lookit/lookit-api/assets/9041788/83d2252e-d53d-4248-b818-ff45c5d58ae4)
External, no studies
![Screenshot 2023-05-09 at 2 48 04 PM](https://github.com/lookit/lookit-api/assets/9041788/b20bce4a-2b8f-411e-905f-a89cd4a18c8f)

