### PR TITLE
Change page title ending to Children Helping Science for merger

### DIFF
--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -13,7 +13,7 @@
         <title>
             {% block title %}
             {% endblock title %}
-            - {% trans "Lookit" %}
+            - {% trans "Children Helping Science" %}
         </title>
         {# google font #}
         <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
This PR changes the ending of all page titles from ' - Lookit' to ' - Children Helping Science'.

![Screenshot 2023-05-09 at 3 29 16 PM](https://github.com/lookit/lookit-api/assets/9041788/1dc6e7a2-d550-4848-99aa-b90e46a11e4c)
