### PR TITLE
Remove reference to CHS on Resources for merger

### DIFF
--- a/web/templates/web/resources.html
+++ b/web/templates/web/resources.html
@@ -38,13 +38,6 @@
     <h3 class="{% subheading_classes %}">Other ways to participate from home</h3>
     <div class="m-4">
         <p>
-            Visit
-            <a href="https://childrenhelpingscience.com/"
-               target="_blank"
-               rel="noopener">Children Helping Science</a>
-            for an extensive list of other opportunities to participate in research about child development!
-        </p>
-        <p>
             To contribute to other scientific research as a family, check out <a href="https://scistarter.org/">SciStarter</a>, which has many citizen
             science projects
             suitable for elementary school children and up!


### PR DESCRIPTION
As part of our upcoming merger with CHS, this PR removes the reference to the separate CHS site in the "Other ways to participate from home" section on the Resources page. This just leaves SciStarter as the only link in that section.

![Screenshot 2023-05-09 at 3 37 15 PM](https://github.com/lookit/lookit-api/assets/9041788/28a8259f-a9bd-49af-8b08-09395ba80823)
