### PR TITLE
Edit help text/prompt for entering OTP

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -74,7 +74,9 @@ class TOTPCheckForm(forms.Form):
     is set in view kwargs.
     """
 
-    otp_code = TOTPField(label="Enter your one-time password (OTP code).")
+    otp_code = TOTPField(
+        label="Enter your one-time password (OTP code) via the Google Authenticator app on your mobile device."
+    )
 
     def __init__(self, *args, **kwargs):
         request = kwargs.pop("request")


### PR DESCRIPTION
Fixes #1193 

Researchers might come back to the CHS site after not logging in for a long time. This change to the 2FA prompt is to remind researchers that they can find their one-time password in the Google Authenticator app on their mobile device. 

![Screenshot 2023-05-17 at 3 55 20 PM](https://github.com/lookit/lookit-api/assets/9041788/4185cb27-587e-461b-b883-c1843b54fd30)

