### PR TITLE
fix test: sometimes fails due to list order mismatch

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -436,7 +436,11 @@ class FeedbackViewSet(FilterByUrlKwargsMixin, ConvertUuidToIdMixin, views.ModelV
             | (Q(study__id__in=studies_for_preview) & Q(is_preview=True))
         )
         response_ids = consented_responses.values_list("id", flat=True)
-        return qs.filter(
-            Q(response__id__in=response_ids)
-            | Q(response__child__user=self.request.user)
-        ).distinct()
+        return (
+            qs.filter(
+                Q(response__id__in=response_ids)
+                | Q(response__child__user=self.request.user)
+            )
+            .distinct()
+            .order_by("-id")
+        )

--- a/exp/tests/test_video_views.py
+++ b/exp/tests/test_video_views.py
@@ -1,3 +1,4 @@
+import logging
 import urllib.parse
 from unittest import skip
 
@@ -55,6 +56,7 @@ class RenameVideoTestCase(APITestCase):
 
 class CheckPipeProcessingTestCase(TestCase):
     def setUp(self):
+        logging.disable(logging.CRITICAL)
         self.lab = G(Lab, name="MIT", approved_to_test=True)
         self.study_creator = G(User, is_active=True, is_researcher=True)
         self.study = G(
@@ -136,3 +138,6 @@ class CheckPipeProcessingTestCase(TestCase):
         self.assertRaises(
             ValueError, Video.check_and_parse_pipe_payload, initial_payload
         )
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)

--- a/exp/views/analytics.py
+++ b/exp/views/analytics.py
@@ -88,7 +88,7 @@ class StudyParticipantAnalyticsView(
 
         # now, map studies for each child, and gather demographic data as well.
         studies_for_child = defaultdict(set)
-        paginator = Paginator(annotated_responses, RESPONSE_PAGE_SIZE)
+        paginator = Paginator(annotated_responses.order_by("id"), RESPONSE_PAGE_SIZE)
         for page_num in paginator.page_range:
             page_of_responses = paginator.page(page_num)
             for resp in page_of_responses:
@@ -138,7 +138,7 @@ def get_flattened_responses(response_qs, studies_for_child):
     TODO: consider whether or not this work should be extracted out into a dataframe.
     """
     response_data = []
-    paginator = Paginator(response_qs, RESPONSE_PAGE_SIZE)
+    paginator = Paginator(response_qs.order_by("id"), RESPONSE_PAGE_SIZE)
     for page_num in paginator.page_range:
         page_of_responses = paginator.page(page_num)
         for resp in page_of_responses:

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -922,7 +922,7 @@ class StudyDeletePreviewResponses(
         preview_responses = study.responses.filter(is_preview=True).prefetch_related(
             "videos", "consent_rulings", "feedback"
         )
-        paginator = Paginator(preview_responses, RESPONSE_PAGE_SIZE)
+        paginator = Paginator(preview_responses.order_by("id"), RESPONSE_PAGE_SIZE)
         for page_num in paginator.page_range:
             page_of_responses = paginator.page(page_num)
             for resp in page_of_responses:

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -431,10 +431,10 @@ class TestAnnouncementEmailFunctionality(TestCase):
             message_object.subject,
             'Moe and Curly are invited to take part in "The Most Fake Study Ever" on Lookit (Children Helping Science)!',
         )
-        self.assertEqual(list(message_object.recipients.all()), [self.participant_two])
+        self.assertEqual(set(message_object.recipients.all()), {self.participant_two})
         self.assertEqual(
-            list(message_object.children_of_interest.all()),
-            [self.child_two, self.child_three],
+            set(message_object.children_of_interest.all()),
+            {self.child_two, self.child_three},
         )
         self.assertEqual(message_object.related_study, self.study_two)
         self.assertIsNone(message_object.sender)


### PR DESCRIPTION
This PR fixes the `test_correct_message_structure` test in `studies/tests.py` that can fail due to a mismatch in the order of elements between two lists. The order mismatch occurs because the `all` method on querysets does not necessarily return objects in the same order. This PR fixes the problem by comparing sets of objects rather than lists.

Also, the test result output contains logs and warnings that make it difficult to see clearly whether the tests are running as expected, or if there's anything that needs to be fixed. This PR does two other things to clean up the test result output. 
1. Disables logging for non-critical issues during the `CheckPipeProcessingTestCase` tests, since these tests always produce error logs (due to `Video` model [`check_and_parse_pipe_payload`](https://github.com/lookit/lookit-api/blob/f05dc63d2d1c3544e798f29f97d296e5151ce883/studies/models.py#L1301-L1316)). Note that disabling the logs here only prevents the messages from showing up in the test output - it does not prevent exceptions from being raised.
2. Add ordering to any querysets that are passed into `Paginator` to fix this warning: `UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list`.

Test results on `develop`:

![Screenshot 2023-07-19 at 10 34 03 AM](https://github.com/lookit/lookit-api/assets/9041788/c957dcf3-3a52-4c19-8b42-aa55004f0c15)

Test results on `fix-test-issues`:

![Screenshot 2023-07-19 at 10 29 28 AM](https://github.com/lookit/lookit-api/assets/9041788/f6b873d6-e4b2-402c-8934-83dfb0d88329)

These last two changes are optional - I can remove them from this PR if there are any concerns.