### PR TITLE
Replace pipe video access

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -442,10 +442,15 @@ class FeedbackViewSet(FilterByUrlKwargsMixin, ConvertUuidToIdMixin, views.ModelV
             | (Q(study__id__in=studies_for_preview) & Q(is_preview=True))
         )
         response_ids = consented_responses.values_list("id", flat=True)
-        return qs.filter(
-            Q(response__id__in=response_ids)
-            | Q(response__child__user=self.request.user)
-        ).distinct()
+
+        return (
+            qs.filter(
+                Q(response__id__in=response_ids)
+                | Q(response__child__user=self.request.user)
+            )
+            .distinct()
+            .order_by("-id")
+        )
 
 
 class VideoViewSet(ConvertUuidToIdMixin, views.ModelViewSet):

--- a/attachment_helpers.py
+++ b/attachment_helpers.py
@@ -25,27 +25,21 @@ def get_download_url(video_key, recording_method_is_pipe):
     """
     url = None
     if recording_method_is_pipe:
-        # get video from Pipe bucket
-        try:
-            url = S3_CLIENT.generate_presigned_url(
-                "get_object",
-                Params={"Bucket": settings.BUCKET_NAME, "Key": video_key},
-                ExpiresIn=600,
-            )
-        except ClientError as e:
-            logging.error(e)
-            return None
+        # Pipe bucket
+        bucket = settings.BUCKET_NAME
     else:
-        # get video from RecordRTC bucket
-        try:
-            url = S3_CLIENT.generate_presigned_url(
-                "get_object",
-                Params={"Bucket": settings.S3_BUCKET_NAME, "Key": video_key},
-                ExpiresIn=600,
-            )
-        except ClientError as e:
-            logger.warning(f"Video not found in bucket. {e}")
-            return None
+        # RecordRTC bucket
+        bucket = settings.S3_BUCKET_NAME
+
+    try:
+        url = S3_CLIENT.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": video_key},
+            ExpiresIn=600,
+        )
+    except ClientError as e:
+        logger.warning(f"Video {video_key} not found in bucket. {e}")
+        return None
 
     return url
 

--- a/exp/tests/test_video_views.py
+++ b/exp/tests/test_video_views.py
@@ -1,3 +1,4 @@
+import logging
 import urllib.parse
 from unittest import skip
 
@@ -55,6 +56,7 @@ class RenameVideoTestCase(APITestCase):
 
 class CheckPipeProcessingTestCase(TestCase):
     def setUp(self):
+        logging.disable(logging.CRITICAL)
         self.lab = G(Lab, name="MIT", approved_to_test=True)
         self.study_creator = G(User, is_active=True, is_researcher=True)
         self.study = G(
@@ -136,3 +138,6 @@ class CheckPipeProcessingTestCase(TestCase):
         self.assertRaises(
             ValueError, Video.check_and_parse_pipe_payload, initial_payload
         )
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)

--- a/exp/views/analytics.py
+++ b/exp/views/analytics.py
@@ -88,7 +88,7 @@ class StudyParticipantAnalyticsView(
 
         # now, map studies for each child, and gather demographic data as well.
         studies_for_child = defaultdict(set)
-        paginator = Paginator(annotated_responses, RESPONSE_PAGE_SIZE)
+        paginator = Paginator(annotated_responses.order_by("id"), RESPONSE_PAGE_SIZE)
         for page_num in paginator.page_range:
             page_of_responses = paginator.page(page_num)
             for resp in page_of_responses:
@@ -138,7 +138,7 @@ def get_flattened_responses(response_qs, studies_for_child):
     TODO: consider whether or not this work should be extracted out into a dataframe.
     """
     response_data = []
-    paginator = Paginator(response_qs, RESPONSE_PAGE_SIZE)
+    paginator = Paginator(response_qs.order_by("id"), RESPONSE_PAGE_SIZE)
     for page_num in paginator.page_range:
         page_of_responses = paginator.page(page_num)
         for resp in page_of_responses:

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -922,7 +922,7 @@ class StudyDeletePreviewResponses(
         preview_responses = study.responses.filter(is_preview=True).prefetch_related(
             "videos", "consent_rulings", "feedback"
         )
-        paginator = Paginator(preview_responses, RESPONSE_PAGE_SIZE)
+        paginator = Paginator(preview_responses.order_by("id"), RESPONSE_PAGE_SIZE)
         for page_num in paginator.page_range:
             page_of_responses = paginator.page(page_num)
             for resp in page_of_responses:

--- a/studies/models.py
+++ b/studies/models.py
@@ -1400,7 +1400,7 @@ class Video(models.Model):
 
     @property
     def download_url(self):
-        return get_download_url(self.full_name)
+        return get_download_url(self.full_name, self.recording_method_is_pipe)
 
     @property
     def recording_method_is_pipe(self):

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -134,9 +134,12 @@ def get_responses_with_current_rulings_and_videos(study_id, preview_only):
     ).values("full_name", "response_id")
     videos_per_response = defaultdict(list)
     for video in consent_videos:
+        recording_is_pipe = Video.objects.get(
+            full_name=video["full_name"]
+        ).recording_method_is_pipe
         videos_per_response[video["response_id"]].append(
             {
-                "aws_url": get_download_url(video["full_name"]),
+                "aws_url": get_download_url(video["full_name"], recording_is_pipe),
                 "filename": video["full_name"],
             }
         )


### PR DESCRIPTION
Related issue: #1074 (but merging this PR shouldn't automatically close the issue)

This PR contains some of the changes required to support our pipe-replacement webcam recordings. To go along with the other changes made to support non-Pipe webcam recordings in #1237, we need to fetch the recordings from the correct S3 bucket, depending on whether the video was recorded using Pipe or RecordRTC. 

The changes in this PR depend on those made in the `replace-pipe` branch (#1237) - I've just put them in a separate branch off of `replace-pipe` to make the PRs a little smaller and easier to review.

This PR does the following:            
- Adds an argument to the `get_download_url` attachment helper function indicating whether or not the video was recorded with Pipe, and generates the correct download URL accordingly.
- Adds this argument to the `get_download_url` calls in `studies/queries.py` and `studies/models.py`.
- Adds logic to the `delete_video_from_cloud` Celery task to determine the recording method and corresponding bucket before attempting to delete the video from S3. 
