### PR TITLE
Custom query for populating participation fields

### DIFF
--- a/studies/forms.py
+++ b/studies/forms.py
@@ -206,6 +206,19 @@ class StudyForm(ModelForm):
         initial=DEFAULT_GENERATOR,
     )
 
+    def participated_choices():
+        return [
+            (s[0], f"{s[1]} ({s[2]})")
+            for s in Study.objects.values_list("id", "name", "uuid")
+        ]
+
+    must_have_participated = forms.MultipleChoiceField(
+        choices=participated_choices, required=False
+    )
+    must_not_have_participated = forms.MultipleChoiceField(
+        choices=participated_choices, required=False
+    )
+
     def clean(self):
         cleaned_data = super().clean()
         min_age_days = self.cleaned_data.get("min_age_days")


### PR DESCRIPTION
Change query to populate participation fields.  Because the form fields are custom, the save and initial values for the form had to also be custom.  

Before:
<img width="1552" alt="Screenshot 2023-08-17 at 1 26 25 PM" src="https://github.com/lookit/lookit-api/assets/44074998/eb4cfd8d-8020-4f3e-bb7a-7e9e5e0efac8">

After:
<img width="1552" alt="Screenshot 2023-08-17 at 1 23 08 PM" src="https://github.com/lookit/lookit-api/assets/44074998/c41ce29a-f29e-4608-bb59-6d4230800702">
