### PR TITLE
Set cookies to have HttpOnly set

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -383,3 +383,7 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
+
+# https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-SESSION_COOKIE_HTTPONLY
+# Per the above documentation setting SESSION_COOKIE_HTTPONLY might break JavaScript.
+SESSION_COOKIE_HTTPONLY = True


### PR DESCRIPTION
Add value to Django settings to have "HttpOnly" flag set on cookies.  This all cookies (There's only two right now) except the CSRF cookie.  This value is readily available in the html and there's little reason to set it.  See [this post](https://security.stackexchange.com/questions/175536/does-a-csrf-cookie-need-to-be-httponly) for more information on the security theater that is the "HttpOnly" flag.  

Closes #1080
<img width="1281" alt="Screenshot 2023-09-28 at 10 25 06 AM" src="https://github.com/lookit/lookit-api/assets/44074998/60b4769c-3626-4b37-bf29-1975888a6de4">

