### PR TITLE
Update github api to pull from EFP's master branch

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -1038,7 +1038,6 @@ class ExperimentRunnerEditView(
     SingleObjectFetchProtocol[Study],
     generic.UpdateView,
 ):
-
     model = Study
 
     def user_can_edit_study(self):
@@ -1125,6 +1124,11 @@ class EFPEditView(ExperimentRunnerEditView):
             study.metadata = metadata
 
         return super().form_valid(form)
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["branch"] = settings.EMBER_EXP_PLAYER_BRANCH
+        return context
 
 
 class ExternalEditView(ExperimentRunnerEditView):

--- a/studies/templates/studies/experiment_runner/efp_edit.html
+++ b/studies/templates/studies/experiment_runner/efp_edit.html
@@ -7,7 +7,7 @@
     {% comment %} ace editor fix cannot be defered {% endcomment %}
     <script src="{% static 'js/ace-editor.js' %}"></script>
     {% comment %} <script src="{% static 'js/study-type.js' %}" defer></script> {% endcomment %}
-    <script src="{% static 'js/efp-runner.js' %}" defer></script>
+    <script src="{% static 'js/efp-runner.js' %}" defer data-branch={{branch}}></script>
     {{ form.media }}
 {% endblock head %}
 {% block header %}

--- a/web/static/js/efp-runner.js
+++ b/web/static/js/efp-runner.js
@@ -1,3 +1,6 @@
+// Get global variables from html
+const DATA = document.currentScript.dataset
+
 // Show the generator function field only if use_generator is checked.
 function updateGeneratorDisplay() {
     const generator = document.querySelector('[for=id_generator]').parentNode;
@@ -98,7 +101,7 @@ function updateCommitUpdateInfo() {
     const currentCommitDate = document.querySelector('#commit-description .date').innerHTML;
     const playerRepoUrl = document.querySelector('#id_player_repo_url').value;
     if (playerRepoUrl && currentCommitDate) {
-        const githubApiUrl = `${playerRepoUrl}/commits?since=${currentCommitDate}&sha=master`.replace('github.com', 'api.github.com/repos')
+        const githubApiUrl = `${playerRepoUrl}/commits?since=${currentCommitDate}&sha=${DATA.branch}`.replace('github.com', 'api.github.com/repos')
         httpRequest.open("GET", githubApiUrl, true);
         httpRequest.send();
     }
@@ -109,7 +112,7 @@ function updateLastPlayerSha() {
 
     if (!form.last_known_player_sha.value) {
         const playerRepoUrl = document.querySelector('#id_player_repo_url').value;
-        const githubApiUrl = `${playerRepoUrl}/commits?sha=master`.replace('github.com', 'api.github.com/repos')
+        const githubApiUrl = `${playerRepoUrl}/commits?sha=${DATA.branch}`.replace('github.com', 'api.github.com/repos')
         const httpRequest = new XMLHttpRequest();
         httpRequest.onreadystatechange = () => {
             if (httpRequest.readyState === XMLHttpRequest.DONE) {

--- a/web/static/js/efp-runner.js
+++ b/web/static/js/efp-runner.js
@@ -98,7 +98,7 @@ function updateCommitUpdateInfo() {
     const currentCommitDate = document.querySelector('#commit-description .date').innerHTML;
     const playerRepoUrl = document.querySelector('#id_player_repo_url').value;
     if (playerRepoUrl && currentCommitDate) {
-        const githubApiUrl = `${playerRepoUrl}/commits?since=${currentCommitDate}`.replace('github.com', 'api.github.com/repos')
+        const githubApiUrl = `${playerRepoUrl}/commits?since=${currentCommitDate}&sha=master`.replace('github.com', 'api.github.com/repos')
         httpRequest.open("GET", githubApiUrl, true);
         httpRequest.send();
     }
@@ -109,7 +109,7 @@ function updateLastPlayerSha() {
 
     if (!form.last_known_player_sha.value) {
         const playerRepoUrl = document.querySelector('#id_player_repo_url').value;
-        const githubApiUrl = `${playerRepoUrl}/commits`.replace('github.com', 'api.github.com/repos')
+        const githubApiUrl = `${playerRepoUrl}/commits?sha=master`.replace('github.com', 'api.github.com/repos')
         const httpRequest = new XMLHttpRequest();
         httpRequest.onreadystatechange = () => {
             if (httpRequest.readyState === XMLHttpRequest.DONE) {


### PR DESCRIPTION
Closes #1275

Github's API uses by default the default branch of a repo.  For EFP this was develop.  Updated API calls to specifically use the master branch.  

