### PR TITLE
Diable json validation when using generator

### DIFF
--- a/exp/tests/test_runner_forms.py
+++ b/exp/tests/test_runner_forms.py
@@ -7,12 +7,24 @@ from studies.models import default_study_structure
 
 
 class EFPFormTestCase(TestCase):
-    def test_successful(self):
+    def test_successful_structure(self):
         form = EFPForm(
             data={
                 "last_known_player_sha": "862604874f7eeff8c9d72adcb8914b21bfb5427e",
                 "player_repo_url": "https://github.com/lookit/ember-lookit-frameplayer",
+                "use_generator": False,
                 "structure": json.dumps(default_study_structure()),
+            }
+        )
+        self.assertDictEqual(form.errors, {})
+        self.assertTrue(form.is_valid())
+
+    def test_successful_generator(self):
+        form = EFPForm(
+            data={
+                "last_known_player_sha": "862604874f7eeff8c9d72adcb8914b21bfb5427e",
+                "player_repo_url": "https://github.com/lookit/ember-lookit-frameplayer",
+                "use_generator": True,
             }
         )
         self.assertDictEqual(form.errors, {})
@@ -43,6 +55,7 @@ class EFPFormTestCase(TestCase):
                 "player_repo_url": "https://github.com/lookit/ember-lookit-frameplayer",
                 "structure": json.dumps(default_study_structure()),
                 "generator": "This is not valid Javascript.",
+                "use_generator": True,
             }
         )
 

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -424,8 +424,8 @@ class EFPForm(ModelForm):
     class Meta:
         model = Study
         fields = (
-            "structure",
             "use_generator",
+            "structure",
             "generator",
             "player_repo_url",
             "last_known_player_sha",
@@ -441,7 +441,12 @@ class EFPForm(ModelForm):
 
     def clean_structure(self):
         try:
-            structure = json.loads(self.cleaned_data["structure"])
+            # Validate structure if not using generator
+            if not self.cleaned_data["use_generator"]:
+                structure = json.loads(self.cleaned_data["structure"])
+            else:
+                structure = {}
+
             structure["exact_text"] = self.cleaned_data["structure"]
             return structure
         except json.JSONDecodeError:
@@ -456,7 +461,10 @@ class EFPForm(ModelForm):
             if not generator.strip():
                 generator = DEFAULT_GENERATOR
 
-            js2py.eval_js(generator)
+            # Validate generator only if using generator
+            if self.cleaned_data["use_generator"]:
+                js2py.eval_js(generator)
+
             return generator
         except js2py.internals.simplex.JsException as err:
             raise forms.ValidationError(

--- a/web/static/js/efp-runner.js
+++ b/web/static/js/efp-runner.js
@@ -2,9 +2,17 @@
 const DATA = document.currentScript.dataset
 
 // Show the generator function field only if use_generator is checked.
-function updateGeneratorDisplay() {
+function updateProtocolDisplay() {
     const generator = document.querySelector('[for=id_generator]').parentNode;
-    document.querySelector('#id_use_generator:checked') ? generator.classList.remove('d-none') : generator.classList.add('d-none');
+    const structure = document.querySelector('[for=id_structure]').parentNode;
+
+    if (document.querySelector('#id_use_generator:checked')) {
+        generator.classList.remove('d-none');
+        structure.classList.add('d-none');
+    } else {
+        generator.classList.add('d-none');
+        structure.classList.remove('d-none');
+    }
 }
 
 function updateCommitDescription() {
@@ -131,14 +139,14 @@ function updateLastPlayerSha() {
 /**
  * Page load
  */
-updateGeneratorDisplay();
+updateProtocolDisplay();
 updateCommitDescription();
 updateLastPlayerSha();
 
 /**
  * Event Listeners
  */
-document.querySelector('#id_use_generator').addEventListener("click", updateGeneratorDisplay);
+document.querySelector('#id_use_generator').addEventListener("click", updateProtocolDisplay);
 document.querySelector('#update-button').addEventListener("click", (event) => {
     event.preventDefault();
     updateCommitUpdateInfo();


### PR DESCRIPTION
Closes #1043 

In the EFP config, it was confusing to have to validate JSON when the generator is used.  

To resolve this, we moved the "use_generator" checkbox to the top of the form.  When it's not checked, the JSON protocol field is visible and the generator field will NOT be validated.  The reverse is true when the "use_generator" checkbox is checked.  

![out](https://github.com/lookit/lookit-api/assets/44074998/4743b14e-a00f-498a-b88e-c52e9e2df293)
