### PR TITLE
Changing birth year format

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 
 from accounts.backends import two_factor_auth_backend
 from accounts.models import Child, DemographicData, User
+from accounts.widgets import BirthdayWidget
 
 
 class ForceLowercaseEmailField(EmailField):
@@ -372,7 +373,7 @@ class DemographicDataForm(forms.ModelForm):
 
 class ChildForm(forms.ModelForm):
     birthday = forms.DateField(
-        widget=forms.DateInput(attrs={"class": "datepicker"}),
+        widget=BirthdayWidget,
         help_text=_(
             "This lets us figure out exactly how old your child is when they participate in a study. We never publish children's birthdates or information that would allow a reader to calculate the birthdate."
         ),
@@ -437,57 +438,11 @@ class ChildForm(forms.ModelForm):
         }
 
 
-class ChildUpdateForm(forms.ModelForm):
-    birthday = forms.DateField(disabled=True, help_text="YYYY-MM-DD")
-
-    class Meta:
-        model = Child
-        fields = (
-            "given_name",
-            "birthday",
-            "gender",
-            "gender_self_describe",
-            "gestational_age_at_birth",
-            "languages_spoken",
-            "existing_conditions",
-            "additional_information",
-        )
-
-        labels = {
-            "given_name": _("First Name"),
-            "birthday": _("Birthday"),
-            "gender": _("Gender"),
-            "gestational_age_at_birth": _("Gestational Age at Birth"),
-            "additional_information": _(
-                "Any additional information you'd like us to know"
-            ),
-            "existing_conditions": _("Characteristics and conditions"),
-            "languages_spoken": _(
-                "Languages this child is exposed to at home, school, or with another caregiver."
-            ),
-        }
-
-        help_texts = {
-            "given_name": _(
-                "This lets you select the correct child to participate in a particular study. A nickname or initials are fine! We may include your child's name in email to you (for instance, \"There's a new study available for Molly!\") but will never publish names or use them in our research."
-            ),
-            "additional_information": _(
-                "For instance, diagnosed developmental disorders or vision or hearing problems"
-            ),
-            "existing_conditions": _(
-                "Most research studies are designed for a general age range, but some focus on a particular group of children. The choices you make below are used to show you studies that are designed for children with these characteristics."
-            ),
-        }
-
-        widgets = {
-            "existing_conditions": BitFieldCheckboxSelectMultiple(
-                attrs={"class": "column-checkbox"}
-            ),
-            "languages_spoken": BitFieldCheckboxSelectMultiple(
-                attrs={"class": "column-checkbox"}
-            ),
-            "gender_self_describe": forms.Textarea(attrs={"rows": 2}),
-        }
+class ChildUpdateForm(ChildForm):
+    birthday = forms.DateField(
+        disabled=True,
+        widget=BirthdayWidget,
+    )
 
 
 class FormChoiceEnum(Enum):

--- a/accounts/templates/widgets/birthday.html
+++ b/accounts/templates/widgets/birthday.html
@@ -1,0 +1,5 @@
+<div class="birthday-widget row align-items-center">
+    {% for widget in widget.subwidgets %}
+        <div class="col-auto">{% include "django/forms/widgets/select.html" %}</div>
+    {% endfor %}
+</div>

--- a/accounts/widgets.py
+++ b/accounts/widgets.py
@@ -1,0 +1,21 @@
+import datetime
+
+from django import forms
+
+this_year = datetime.date.today().year
+
+
+class BirthdayWidget(forms.SelectDateWidget):
+    template_name = "widgets/birthday.html"
+
+    def __init__(self, attrs=None, years=None, months=None, empty_label=None):
+        if not years:
+            years = range(this_year, this_year - 25, -1)
+
+        if attrs is None:
+            attrs = {}
+
+        if "class" not in attrs:
+            attrs["class"] = "form-select"
+
+        super().__init__(attrs, years, months, empty_label)

--- a/web/static/js/child-add.js
+++ b/web/static/js/child-add.js
@@ -1,34 +1,14 @@
+function getAge() {
+    const day = document.getElementById('id_birthday_day').value
+    const month = document.getElementById('id_birthday_month').value
+    const year = document.getElementById('id_birthday_year').value
+    const birthday = new Date(`${month}/${day}/${year}`);
 
-$('.datepicker').datepicker({
-    changeMonth: true,
-    changeYear: true,
-    showButtonPanel: true,
-    maxDate: 0,
-    yearRange: "1900:+nn"
-}).on('change', function () {
-    const age = getAge(this);
-    if (document.getElementById('age_calc')) {
-        document.getElementById('age_calc').innerHTML = `Age: ${age}`;
-    } else {
-        const x = document.createElement("p");
-        x.setAttribute("id", "age_calc");
-        x.setAttribute("class", "age_format")
-        const t = document.createTextNode(`Age: ${age}`);
-        x.appendChild(t);
-        document.getElementById("id_birthday").parentNode.insertBefore(x, document.getElementById("id_birthday"));
-    }
-});
-
-
-function getAge(dateValue) {
-    if (dateValue.value === '') {
-        return '{% trans "Empty birthday" %} '
-    }
-    const years = moment().diff(new Date(dateValue.value), 'years');
+    const years = moment().diff(birthday, 'years');
     if (years === 0) {
-        const months = moment().diff(new Date(dateValue.value), 'months');
+        const months = moment().diff(birthday, 'months');
         if (months === 0) {
-            const days = moment().diff(new Date(dateValue.value), 'days');
+            const days = moment().diff(birthday, 'days');
             return days === 1 ? days + " day" : days + " days";
         }
         return months === 1 ? months + " month" : months + " months";
@@ -36,3 +16,30 @@ function getAge(dateValue) {
         return years === 1 ? years + " year" : years + " years";
     }
 }
+
+function createAgeText() {
+    const birthdayWidget = document.querySelector('.birthday-widget');
+    const p = document.createElement("p");
+    p.setAttribute("id", "age_calc");
+    p.setAttribute("class", "age_format");
+    birthdayWidget.parentNode.insertBefore(p, birthdayWidget);
+}
+
+
+function updateAgeText() {
+    const age = getAge();
+    const p = document.getElementById("age_calc");
+    p.textContent = `Age: ${age}`;
+}
+
+/***
+ * Page Load
+ */
+createAgeText();
+
+/**
+ * Event Listeners
+ */
+document.querySelectorAll('#id_birthday_day, #id_birthday_month, #id_birthday_year').forEach(function (el) {
+    el.addEventListener('change', updateAgeText)
+});


### PR DESCRIPTION
Closes  #1096

For a child's birthday, it was encoded as `month/day/year`.  This can be confusing to those who don't order their dates this way.  To resolve this issue we changed the widget on the child's form for the birthday field to the [SelectDateWidget](https://docs.djangoproject.com/en/4.2/ref/forms/widgets/#django.forms.SelectDateWidget).  This provided to the localization needed for date fields.  

Additionally, some code clean up and an update to the age display JavaScript. 


Add Child English:
<img width="1335" alt="Screenshot 2023-10-26 at 11 47 43 AM" src="https://github.com/lookit/lookit-api/assets/44074998/30bf0d2d-0336-4210-91b3-7dbdc80a685c">
Add Child French:
<img width="1335" alt="Screenshot 2023-10-26 at 11 47 55 AM" src="https://github.com/lookit/lookit-api/assets/44074998/81b283cf-561a-4868-9d45-9b95a830aad5">
Update Child English:
<img width="1335" alt="Screenshot 2023-10-26 at 11 48 08 AM" src="https://github.com/lookit/lookit-api/assets/44074998/1ab350a8-b52e-4d5b-82c1-41dc503eaac3">
Update Child French:
<img width="1335" alt="Screenshot 2023-10-26 at 11 48 01 AM" src="https://github.com/lookit/lookit-api/assets/44074998/7ebefa34-f400-4019-9c32-6e7eb1c46a69">

