### PR TITLE
Add warning when ineligible due to study participation criteria

### DIFF
--- a/web/static/js/study-detail-web.js
+++ b/web/static/js/study-detail-web.js
@@ -28,7 +28,6 @@ function childSelected(selectElement) {
     } else if (ineligibleBasedOnAge < 0 && !(ineligibleBasedOnCriteriaExpression) && !(ineligibleBasedOnParticipation)) { // Too young, but otherwise eligible
         document.getElementById('too-young').classList.remove('d-none');
     } else if (ineligibleBasedOnCriteriaExpression || ineligibleBasedOnParticipation) {
-        console.log('show ineligible warning');
         // Doesn't meet criteria from the criteria expression and/or the prior study participation requirements
         document.getElementById('criteria-not-met').classList.remove('d-none');
     }

--- a/web/static/js/study-detail-web.js
+++ b/web/static/js/study-detail-web.js
@@ -20,13 +20,16 @@ function childSelected(selectElement) {
     let birthday = selectElement.selectedOptions[0].dataset["birthdate"];
     let age = calculateAgeInDays(birthday);
     let ineligibleBasedOnAge = ageCheck(age);
-    let ineligibleBasedOnCriteria = selectElement.selectedOptions[0].dataset["eligible"] === "False";
+    let ineligibleBasedOnCriteriaExpression = selectElement.selectedOptions[0].dataset["eligibleCriteria"] === "False";
+    let ineligibleBasedOnParticipation = selectElement.selectedOptions[0].dataset["eligibleParticipation"] === "False";
 
     if (ineligibleBasedOnAge > 0) { // Too old
         document.getElementById('too-old').classList.remove('d-none');
-    } else if (ineligibleBasedOnAge < 0 && !ineligibleBasedOnCriteria) { // Too young, but otherwise eligible
+    } else if (ineligibleBasedOnAge < 0 && !(ineligibleBasedOnCriteriaExpression) && !(ineligibleBasedOnParticipation)) { // Too young, but otherwise eligible
         document.getElementById('too-young').classList.remove('d-none');
-    } else if (ineligibleBasedOnCriteria) {
+    } else if (ineligibleBasedOnCriteriaExpression || ineligibleBasedOnParticipation) {
+        console.log('show ineligible warning');
+        // Doesn't meet criteria from the criteria expression and/or the prior study participation requirements
         document.getElementById('criteria-not-met').classList.remove('d-none');
     }
 }

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -113,11 +113,14 @@
                                 onchange="childSelected(this)">
                             <option value=none>{% trans "None Selected" %}</option>
                             {% for child in children %}
-                                {% child_is_valid_for_study_criteria_expression child object as child_is_eligible %}
+                                {% child_is_valid_for_study_criteria child object as child_is_eligible %}
                                 <option onemptied=""
                                         value="{{ child.uuid }}"
                                         data-birthdate="{{ child.birthday|date:'c' }}"
-                                        data-eligible="{{ child_is_eligible }}">{{ child.given_name }}</option>
+                                        data-eligible-participation="{{ child_is_eligible.participation_eligibility }}"
+                                        data-eligible-criteria="{{ child_is_eligible.criteria_expression_eligibility }}">
+                                    {{ child.given_name }}
+                                </option>
                             {% endfor %}
                         </select>
                         <p class="text-danger mb-0 mt-3 d-none" id="too-young">

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -121,13 +121,13 @@
                             {% endfor %}
                         </select>
                         <p class="text-danger mb-0 mt-3 d-none" id="too-young">
-                            {% trans "Your child is still younger than the recommended age range for this study. If you can wait until he or she is old enough, we'll be able to use the collected data in our research!" %}
+                            {% trans "Your child is still younger than the recommended age range for this study. If you can wait until he or she is old enough, the researchers will be able to compensate you and use the collected data in their research!" %}
                         </p>
                         <p class="text-danger mb-0 mt-3 d-none" id="too-old">
-                            {% trans "Your child is older than the recommended age range for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research." %}
+                            {% trans "Your child is older than the recommended age range for this study. You're welcome to try the study anyway, but researchers may not be able to compensate you or use the collected data in their research." %}
                         </p>
                         <p class="text-danger mb-0 mt-3 d-none" id="criteria-not-met">
-                            {% blocktranslate with contact=study.contact_info %} Your child does not meet the eligibility criteria listed for this study. You're welcome to try the study anyway, but we won't be able to use the collected data in our research. Please contact the study researchers {{ contact }} if you feel this is in error. {% endblocktranslate %}
+                            {% blocktranslate with contact=study.contact_info %} Your child does not meet the eligibility criteria listed for this study. You're welcome to try the study anyway, but researchers may not be able to compensate you or use your data. Please review the “Who can participate” information for this study and contact the study researchers ({{ contact }}) if you feel this is in error. {% endblocktranslate %}
                         </p>
                         {% if preview_mode and object.needs_to_be_built %}
                             {% bootstrap_button build_runner href=build_runner_url button_class=btn_secondary_classes id="participate-button" %}

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -7,7 +7,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from accounts.forms import StudyListSearchForm
-from accounts.queries import get_child_eligibility_for_study
+from accounts.queries import get_child_eligibility, get_child_participation_eligibility
 from project.settings import GOOGLE_TAG_MANAGER_ID
 
 register = template.Library()
@@ -66,8 +66,14 @@ def nav_next(request, url, text, button):
 
 
 @register.simple_tag
-def child_is_valid_for_study_criteria_expression(child, study):
-    return get_child_eligibility_for_study(child, study)
+def child_is_valid_for_study_criteria(child, study):
+    eligibility = {
+        "participation_eligibility": get_child_participation_eligibility(child, study),
+        "criteria_expression_eligibility": get_child_eligibility(
+            child, study.criteria_expression
+        ),
+    }
+    return eligibility
 
 
 @register.simple_tag

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -7,7 +7,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from accounts.forms import StudyListSearchForm
-from accounts.queries import get_child_eligibility
+from accounts.queries import get_child_eligibility_for_study
 from project.settings import GOOGLE_TAG_MANAGER_ID
 
 register = template.Library()
@@ -67,7 +67,7 @@ def nav_next(request, url, text, button):
 
 @register.simple_tag
 def child_is_valid_for_study_criteria_expression(child, study):
-    return get_child_eligibility(child, study.criteria_expression)
+    return get_child_eligibility_for_study(child, study)
 
 
 @register.simple_tag


### PR DESCRIPTION
Fixes #1288

On the study detail page, this PR adds in a check for the child's prior study participation criteria (in addition to the existing checks against age range and criteria expression). Therefore a warning is shown when the child is ineligible due to prior study participation.

See example screenshots from #1288. 

In the screenshot below, the selected child is not eligible for the study only due to not having participated in another study. The change in this PR produces in a warning message for this case.

![Screenshot 2023-10-27 at 3 47 23 PM](https://github.com/lookit/lookit-api/assets/9041788/46110c03-ac33-4793-9493-a2d7bc993a69)