### PR TITLE
Add country + state from demographic data to session data on consent ruling page (Closes #1291)

### DIFF
--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -794,6 +794,9 @@ class StudyResponsesConsentManager(
                         "hashed_id": hash_participant_id(response),
                         "uuid": str(response.pop("child__user__uuid")),
                         "nickname": response.pop("child__user__nickname"),
+                        "country": response.pop("demographic_snapshot__country"),
+                        "state": response.pop("demographic_snapshot__state")
+
                     },
                     "child": {
                         "hashed_id": hash_child_id(response),

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -795,8 +795,7 @@ class StudyResponsesConsentManager(
                         "uuid": str(response.pop("child__user__uuid")),
                         "nickname": response.pop("child__user__nickname"),
                         "country": response.pop("demographic_snapshot__country"),
-                        "state": response.pop("demographic_snapshot__state")
-
+                        "state": response.pop("demographic_snapshot__state"),
                     },
                     "child": {
                         "hashed_id": hash_child_id(response),

--- a/project/settings.py
+++ b/project/settings.py
@@ -33,7 +33,7 @@ SECRET_KEY = os.environ.get(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(os.environ.get("DEBUG", False))
+DEBUG = True  # bool(os.environ.get("DEBUG", False))
 ALLOWED_HOSTS = [h for h in os.environ.get("ALLOWED_HOSTS", "").split(" ") if h]
 
 SESSION_COOKIE_SECURE = True

--- a/project/settings.py
+++ b/project/settings.py
@@ -33,7 +33,7 @@ SECRET_KEY = os.environ.get(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True  # bool(os.environ.get("DEBUG", False))
+DEBUG = bool(os.environ.get("DEBUG", False))
 ALLOWED_HOSTS = [h for h in os.environ.get("ALLOWED_HOSTS", "").split(" ") if h]
 
 SESSION_COOKIE_SECURE = True

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -95,7 +95,9 @@ def get_responses_with_current_rulings_and_videos(study_id, preview_only):
         responses_for_study = responses_for_study.filter(is_preview=True)
 
     responses_for_study = (
-        responses_for_study.select_related("child", "child__user","demographic_snapshot")
+        responses_for_study.select_related(
+            "child", "child__user", "demographic_snapshot"
+        )
         .order_by("-date_created")
         .values(
             "id",
@@ -124,7 +126,7 @@ def get_responses_with_current_rulings_and_videos(study_id, preview_only):
             "child__user__nickname",
             "demographic_snapshot_id",
             "demographic_snapshot__country",
-            "demographic_snapshot__state"
+            "demographic_snapshot__state",
         )
     )
 
@@ -148,7 +150,7 @@ def get_responses_with_current_rulings_and_videos(study_id, preview_only):
         )
 
     for response in responses_for_study:
-        
+
         response["videos"] = videos_per_response.get(response["id"], [])
 
     return responses_for_study

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -95,7 +95,7 @@ def get_responses_with_current_rulings_and_videos(study_id, preview_only):
         responses_for_study = responses_for_study.filter(is_preview=True)
 
     responses_for_study = (
-        responses_for_study.select_related("child", "child__user")
+        responses_for_study.select_related("child", "child__user","demographic_snapshot")
         .order_by("-date_created")
         .values(
             "id",
@@ -122,6 +122,9 @@ def get_responses_with_current_rulings_and_videos(study_id, preview_only):
             "child__user_id",
             "child__user__uuid",
             "child__user__nickname",
+            "demographic_snapshot_id",
+            "demographic_snapshot__country",
+            "demographic_snapshot__state"
         )
     )
 
@@ -145,6 +148,7 @@ def get_responses_with_current_rulings_and_videos(study_id, preview_only):
         )
 
     for response in responses_for_study:
+        
         response["videos"] = videos_per_response.get(response["id"], [])
 
     return responses_for_study

--- a/studies/templates/studies/study_responses_consent_ruling.html
+++ b/studies/templates/studies/study_responses_consent_ruling.html
@@ -212,6 +212,8 @@
                         <th>ID</th>
                         <th>Global ID</th>
                         <th>Parent name</th>
+                        <th>Country</th>
+                        <th>State</th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
This PR is in response to issue #1291 

Now, on the consent ruling page for a study, when a user clicks on a given consent to rule on, the user's location will be collated with the rest of the info under "Session Data"

The changes required for this were fairly minimal. The consent_ruling data query already grabs "demographic_snapshot_id" from the response row, so I just had to add "demographic_snapshot" when calling "select_related" for "child" and "child__user".

<img width="1272" alt="Screenshot 2023-11-09 at 3 43 45 PM" src="https://github.com/lookit/lookit-api/assets/8931559/0aec2f3b-6490-4eb3-88f1-f562d237aaaa">
