### PR TITLE
Prior participation eligibility logic (#1302, #1306)

### DIFF
--- a/accounts/queries.py
+++ b/accounts/queries.py
@@ -127,9 +127,7 @@ def get_child_participation_eligibility(child, study) -> bool:
             i
             for i in study.must_have_participated.all()
             if child.responses.filter(study=i)
-            .exclude(
-                study__study_type_id=StudyType.get_ember_frame_player().id, sequence=[]
-            )
+            .exclude(study__study_type=StudyType.get_ember_frame_player(), sequence=[])
             .exists()
         ]
 
@@ -143,9 +141,7 @@ def get_child_participation_eligibility(child, study) -> bool:
             i
             for i in study.must_not_have_participated.all()
             if child.responses.filter(study=i)
-            .exclude(
-                study__study_type_id=StudyType.get_ember_frame_player().id, sequence=[]
-            )
+            .exclude(study__study_type=StudyType.get_ember_frame_player(), sequence=[])
             .exists()
         ]
         # only true if response does NOT exist for any one (or more) of the studies in the list

--- a/accounts/queries.py
+++ b/accounts/queries.py
@@ -118,14 +118,24 @@ def get_child_participation_eligibility(child, study) -> bool:
     must_not_have_participated = True
 
     if study.must_have_participated.exists():
-        must_have_participated = child.responses.filter(
-            study__in=study.must_have_participated.all()
-        ).exists()
+        must_have_participated_all = [
+            i
+            for i in study.must_have_participated.all()
+            if child.responses.filter(study__exact=i).exists()
+        ]
+        # only true if response exists for each of the studies in the list
+        must_have_participated = set(must_have_participated_all) == set(
+            study.must_have_participated.all()
+        )
 
     if study.must_not_have_participated.exists():
-        must_not_have_participated = not child.responses.filter(
-            study__in=study.must_not_have_participated.all()
-        ).exists()
+        must_not_have_participated_all = [
+            i
+            for i in study.must_not_have_participated.all()
+            if child.responses.filter(study__exact=i).exists()
+        ]
+        # only true if response does NOT exist for any of the studies in the list
+        must_not_have_participated = len(must_not_have_participated_all) == 0
 
     return must_have_participated and must_not_have_participated
 

--- a/accounts/tests/test_accounts.py
+++ b/accounts/tests/test_accounts.py
@@ -20,15 +20,7 @@ from accounts.queries import (
     get_child_participation_eligibility,
 )
 from studies.fields import GESTATIONAL_AGE_CHOICES
-from studies.models import (
-    ConsentRuling,
-    Lab,
-    Response,
-    Study,
-    StudyType,
-    StudyTypeEnum,
-    Video,
-)
+from studies.models import ConsentRuling, Lab, Response, Study, StudyType, Video
 
 
 class AuthenticationTestCase(TestCase):
@@ -971,8 +963,12 @@ class EligibilityTestCase(TestCase):
         self.assertTrue(get_child_eligibility_for_study(child, study))
 
     def test_get_child_eligibilty_prior_studies_must_have_participated(self):
-        G(StudyType, name=StudyTypeEnum.ember_frame_player.value)
-        other_study = G(Study, max_age_years=2, criteria_expression="")
+        other_study = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_ember_frame_player(),
+        )
         study = G(
             Study,
             max_age_years=2,
@@ -985,16 +981,60 @@ class EligibilityTestCase(TestCase):
         self.assertFalse(get_child_participation_eligibility(child, study))
         self.assertFalse(get_child_eligibility_for_study(child, study))
 
-        # Add response
-        G(Response, child=child, study=other_study)
+        # Add invalid (empty) response
+        G(Response, child=child, study=other_study, sequence=[])
+
+        # Check with invalid response
+        self.assertFalse(get_child_participation_eligibility(child, study))
+        self.assertFalse(get_child_eligibility_for_study(child, study))
+
+        # Add valid response
+        G(Response, child=child, study=other_study, sequence=["0-video-config"])
 
         # Check with response
         self.assertTrue(get_child_participation_eligibility(child, study))
         self.assertTrue(get_child_eligibility_for_study(child, study))
 
+    def test_get_child_eligibilty_must_have_participated_external(self):
+        external_study = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_external(),
+        )
+        study = G(
+            Study,
+            name="study",
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_ember_frame_player(),
+            must_have_participated=[external_study],
+        )
+        child_1 = G(Child, birthday=datetime.date.today())
+        child_2 = G(Child, birthday=datetime.date.today())
+
+        # Check without response
+        self.assertFalse(get_child_participation_eligibility(child_1, study))
+        self.assertFalse(get_child_eligibility_for_study(child_1, study))
+        self.assertFalse(get_child_participation_eligibility(child_2, study))
+        self.assertFalse(get_child_eligibility_for_study(child_2, study))
+
+        # For external studies, an empty response still counts as 'participated'
+        G(Response, child=child_1, study=external_study)
+        G(Response, child=child_2, study=external_study, sequence=[])
+
+        self.assertTrue(get_child_participation_eligibility(child_1, study))
+        self.assertTrue(get_child_eligibility_for_study(child_1, study))
+        self.assertTrue(get_child_participation_eligibility(child_2, study))
+        self.assertTrue(get_child_eligibility_for_study(child_2, study))
+
     def test_get_child_eligibilty_prior_studies_must_not_have_participated(self):
-        G(StudyType, name=StudyTypeEnum.ember_frame_player.value)
-        other_study = G(Study, max_age_years=2, criteria_expression="")
+        other_study = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_ember_frame_player(),
+        )
         study = G(
             Study,
             max_age_years=2,
@@ -1008,45 +1048,83 @@ class EligibilityTestCase(TestCase):
         self.assertTrue(get_child_eligibility_for_study(child, study))
 
         # Add response
-        G(Response, child=child, study=other_study)
+        G(Response, child=child, study=other_study, sequence=["0-video-config"])
+
+        # Check again with response
+        self.assertFalse(get_child_participation_eligibility(child, study))
+        self.assertFalse(get_child_eligibility_for_study(child, study))
+
+    def test_get_child_eligibilty_must_not_have_participated_external(self):
+        other_study = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_external(),
+        )
+        study = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            must_not_have_participated=[other_study],
+        )
+        child = G(Child, birthday=datetime.date.today())
+
+        # Check without response
+        self.assertTrue(get_child_participation_eligibility(child, study))
+        self.assertTrue(get_child_eligibility_for_study(child, study))
+
+        # Add response (empty sequence still counts for external study participation)
+        G(Response, child=child, study=other_study, sequence=[])
 
         # Check again with response
         self.assertFalse(get_child_participation_eligibility(child, study))
         self.assertFalse(get_child_eligibility_for_study(child, study))
 
     def test_get_child_eligibilty_multiple_studies_must_have_participated(self):
-        G(StudyType, name=StudyTypeEnum.ember_frame_player.value)
-        other_study_1 = G(Study, max_age_years=2, criteria_expression="")
-        other_study_2 = G(Study, max_age_years=2, criteria_expression="")
+        required_study_1 = G(
+            Study, max_age_years=2, study_type=StudyType.get_ember_frame_player()
+        )
+        required_study_2 = G(
+            Study, max_age_years=2, study_type=StudyType.get_ember_frame_player()
+        )
         study = G(
             Study,
             max_age_years=2,
             criteria_expression="",
-            must_have_participated=[other_study_1, other_study_2],
+            must_have_participated=[required_study_1, required_study_2],
         )
         child = G(Child, birthday=datetime.date.today())
 
         # Add response to one of the required studies
-        G(Response, child=child, study=other_study_1)
+        G(Response, child=child, study=required_study_1, sequence=["0-video-config"])
 
-        # Should not be eligible with a response to only one of the two required studies
+        # Should not be eligible with a valid response to only one of the two required studies
         self.assertFalse(get_child_participation_eligibility(child, study))
         self.assertFalse(get_child_eligibility_for_study(child, study))
 
-        # Should be eligible with responses to all of the required studies
-        G(Response, child=child, study=other_study_2)
+        # Should be eligible with valid responses to all of the required studies
+        G(Response, child=child, study=required_study_2, sequence=["0-video-config"])
         self.assertTrue(get_child_participation_eligibility(child, study))
         self.assertTrue(get_child_eligibility_for_study(child, study))
 
     def test_get_child_eligibilty_multiple_studies_must_not_have_participated(self):
-        G(StudyType, name=StudyTypeEnum.ember_frame_player.value)
-        other_study_1 = G(Study, max_age_years=2, criteria_expression="")
-        other_study_2 = G(Study, max_age_years=2, criteria_expression="")
+        disallowed_study_1 = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_ember_frame_player(),
+        )
+        disallowed_study_2 = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_ember_frame_player(),
+        )
         study = G(
             Study,
             max_age_years=2,
             criteria_expression="",
-            must_not_have_participated=[other_study_1, other_study_2],
+            must_not_have_participated=[disallowed_study_1, disallowed_study_2],
         )
         child = G(Child, birthday=datetime.date.today())
 
@@ -1055,31 +1133,40 @@ class EligibilityTestCase(TestCase):
         self.assertTrue(get_child_eligibility_for_study(child, study))
 
         # Add response to one of the disallowed studies
-        G(Response, child=child, study=other_study_1)
+        G(Response, child=child, study=disallowed_study_1, sequence=["0-video-config"])
 
         # Should not be eligible with a response to one or both of the two disallowed studies
         self.assertFalse(get_child_participation_eligibility(child, study))
         self.assertFalse(get_child_eligibility_for_study(child, study))
-        G(Response, child=child, study=other_study_2)
+        G(Response, child=child, study=disallowed_study_2, sequence=["0-video-config"])
         self.assertFalse(get_child_participation_eligibility(child, study))
         self.assertFalse(get_child_eligibility_for_study(child, study))
 
     def test_get_child_eligibilty_multiple_participation_criteria(self):
-        G(StudyType, name=StudyTypeEnum.ember_frame_player.value)
-        other_study_1 = G(Study, max_age_years=2, criteria_expression="")
-        other_study_2 = G(Study, max_age_years=2, criteria_expression="")
+        required_study = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_ember_frame_player(),
+        )
+        disallowed_study = G(
+            Study,
+            max_age_years=2,
+            criteria_expression="",
+            study_type=StudyType.get_ember_frame_player(),
+        )
         study = G(
             Study,
             max_age_years=2,
             criteria_expression="",
-            must_have_participated=[other_study_1],
-            must_not_have_participated=[other_study_2],
+            must_have_participated=[required_study],
+            must_not_have_participated=[disallowed_study],
         )
 
         # Child is not eligible if they meet the required study criteria but not the disallowed study criteria
         child_1 = G(Child, birthday=datetime.date.today())
-        G(Response, child=child_1, study=other_study_1)
-        G(Response, child=child_1, study=other_study_2)
+        G(Response, child=child_1, study=required_study, sequence=["0-video-config"])
+        G(Response, child=child_1, study=disallowed_study, sequence=["0-video-config"])
         self.assertFalse(get_child_participation_eligibility(child_1, study))
         self.assertFalse(get_child_eligibility_for_study(child_1, study))
 
@@ -1089,7 +1176,7 @@ class EligibilityTestCase(TestCase):
         self.assertFalse(get_child_eligibility_for_study(child_2, study))
 
         # Child is eligible if they meet both the required and disallowed study criteria
-        G(Response, child=child_2, study=other_study_1)
+        G(Response, child=child_2, study=required_study, sequence=["0-video-config"])
         self.assertTrue(get_child_participation_eligibility(child_2, study))
         self.assertTrue(get_child_eligibility_for_study(child_2, study))
 


### PR DESCRIPTION
This PR makes a few changes to the 'must have/not have participated' Study eligibility criteria:

- When the study has more than one required (must have participated) study, the child must have participated in ALL of these in order to be eligible (#1306)
- When checking the child's eligibility, we now ignore empty (sequence=[]) responses to internal studies (#1302)
- Adds tests for more complex eligibility cases (e.g. study has multiple required or disallowed prior participation criteria, study has both required and disallowed participation criteria, required/disallowed studies are external/internal and responses are empty/non-empty)