### PR TITLE
Remove JSHint warning

### DIFF
--- a/web/static/js/js-validation.js
+++ b/web/static/js/js-validation.js
@@ -1,5 +1,5 @@
 function jsValidation(event, generator) {
-    const jshint_config = { "esversion": 6 };
+    const jshint_config = { "esversion": 6, "sub": true };
     const jsValidation = document.querySelector('.js-validation');
 
     // if jshint comes back with errors (false)


### PR DESCRIPTION
JSHint's warning for using [dot notation over bracket notation is deprecated](https://jshint.com/docs/options/#sub).  They provide an option to remove this warning.  

This PR adds that option to remove the warning to the jshint config.
