### PR TITLE
Add error "undef" to jshint

### DIFF
--- a/web/static/js/js-validation.js
+++ b/web/static/js/js-validation.js
@@ -1,5 +1,5 @@
 function jsValidation(event, generator) {
-    const jshint_config = { "esversion": 6, "sub": true };
+    const jshint_config = { "esversion": 6, "sub": true, "undef": true };
     const jsValidation = document.querySelector('.js-validation');
 
     // if jshint comes back with errors (false)


### PR DESCRIPTION
For the study cloned [here](https://childrenhelpingscience.com/exp/studies/3294/), JSHint wasn't returning two errors.  We can find these errors by putting the JS code into JSHint's [sandbox](https://jshint.com/).  I added an [option](https://jshint.com/docs/options/) that will report errors for undefined variables.  The other semi-obvious error we could add would be "unused", but this gives us error for the function that wraps the user's code.  

The warning message "Too many errors" comes from the ace editor.  This doesn't prevent the user from saving their code, but it's not great.  The bug is reported in many different places, still searching for a solution.