### PR TITLE
Allow removal of english specific content for home

### DIFF
--- a/web/templates/web/home.html
+++ b/web/templates/web/home.html
@@ -73,7 +73,7 @@
              alt="University logos"
              src="{% static 'images/university_logo_grid.png' %}" />
     </div>
-    <div class="clearfix px-md-5 pt-5 mb-5">
+    <div class="clearfix px-md-5 pt-5 mb-5" style="{{ style_for_english_specific }}">
         <a href="{% url 'web:garden-home' %}">
             <img class="img-fluid mb-3 col-md-5 float-md-start me-md-3 img-hover p-2"
                  alt="Garden project logo"

--- a/web/urls.py
+++ b/web/urls.py
@@ -72,7 +72,7 @@ urlpatterns = [
         views.ExperimentAssetsProxyView.as_view(),
         name="experiment-assets-proxy",
     ),
-    path("", TemplateView.as_view(template_name="web/home.html"), name="home"),
+    path("", views.HomeView.as_view(), name="home"),
     path("faq/", TemplateView.as_view(template_name="web/faq.html"), name="faq"),
     path(
         "privacy/",

--- a/web/views.py
+++ b/web/views.py
@@ -13,7 +13,7 @@ from django.db.models.query_utils import Q
 from django.dispatch import receiver
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, reverse
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import get_language, gettext_lazy as _
 from django.views import generic
 from django.views.generic.edit import FormView
 from django_countries import countries
@@ -799,4 +799,13 @@ class ScientistsView(generic.TemplateView):
             for s in InstitutionSection.objects.order_by("order")
         ]
 
+        return context
+
+class HomeView(generic.TemplateView):
+    template_name = "web/home.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Trigger removal of English-specific content, when not in English language
+        context["style_for_english_specific"] = 'display: block;' if get_language()[:2]=='en' else 'display: none;'
         return context


### PR DESCRIPTION
On the home page, there are some graphics and content that is not relevant to a non-English speaking audience - for example, graphics and text corresponding to "Project Garden"

This commit allows for this to be removed:

- adding to the Project Garden div in web/templates/web/home.html a CSS style parameter with a variable style="{{ style_for_english_specific }}
- add custom method web.views.HomeView
- in this, set style_for_english_specific to 'display: block' if URL language code starts with en, otherwise makes it invisible