### PR TITLE
Jspsych helpers

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -13,7 +13,7 @@ router.register(r"labs", api_views.LabViewSet)
 router.register(r"feedback", api_views.FeedbackViewSet)
 router.register(r"video", api_views.VideoViewSet)
 router.register(
-    r"past-sessions", api_views.PassSessionsViewSet, basename="past-sessions"
+    r"past-sessions", api_views.PastSessionsViewSet, basename="past-sessions"
 )
 
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -12,6 +12,9 @@ router.register(r"responses", api_views.ResponseViewSet)
 router.register(r"labs", api_views.LabViewSet)
 router.register(r"feedback", api_views.FeedbackViewSet)
 router.register(r"video", api_views.VideoViewSet)
+router.register(
+    r"past-sessions", api_views.PassSessionsViewSet, basename="past-sessions"
+)
 
 
 # Users can have demographics and children nested.

--- a/api/views.py
+++ b/api/views.py
@@ -1,8 +1,11 @@
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
+from rest_framework import mixins
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response as DRFResponse
+from rest_framework.viewsets import GenericViewSet
 from rest_framework_json_api import views
 
 from accounts.models import Child, DemographicData, User
@@ -466,3 +469,26 @@ class VideoViewSet(ConvertUuidToIdMixin, views.ModelViewSet):
     lookup_field = "uuid"
     http_method_names = ["post"]
     permission_classes = [VideoFromS3Permissions]
+
+
+class PassSessionsViewSet(mixins.RetrieveModelMixin, GenericViewSet):
+    resource_name = "past_sessions"
+    serializer_class = ResponseSerializer
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = ResponsesFilter
+    lookup_field = "uuid"
+    http_method_names = ("get",)
+    permission_classes = [IsAuthenticated, ResponsePermissions]
+
+    def get_queryset(self):
+        child_id, study_id = (
+            Response.objects.values_list("child_id", "study_id")
+            .filter(uuid=self.kwargs["uuid"])
+            .first()
+        )
+        return Response.objects.filter(child_id=child_id, study_id=study_id)
+
+    def retrieve(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return DRFResponse(serializer.data)

--- a/api/views.py
+++ b/api/views.py
@@ -471,7 +471,7 @@ class VideoViewSet(ConvertUuidToIdMixin, views.ModelViewSet):
     permission_classes = [VideoFromS3Permissions]
 
 
-class PassSessionsViewSet(mixins.RetrieveModelMixin, GenericViewSet):
+class PastSessionsViewSet(mixins.RetrieveModelMixin, GenericViewSet):
     resource_name = "past_sessions"
     serializer_class = ResponseSerializer
     filter_backends = (filters.DjangoFilterBackend,)

--- a/studies/templates/studies/experiment_runner/efp_edit.html
+++ b/studies/templates/studies/experiment_runner/efp_edit.html
@@ -17,11 +17,11 @@
     </p>
 {% endblock header %}
 {% block js_error %}
-    <ul class="text-danger js-validation d-none">
+    <div class="text-danger js-validation d-none">
         <div class="my-3">
             Generator JavaScript seems to be invalid.  Please edit and save again. If you reload this page, all changes will be lost.
         </div>
-    </ul>
+    </div>
 {% endblock js_error %}
 {% block form %}
     {% bootstrap_form form label_class="fw-bold" %}

--- a/studies/templates/studies/experiment_runner/jspsych_edit.html
+++ b/studies/templates/studies/experiment_runner/jspsych_edit.html
@@ -11,11 +11,11 @@
     {{ form.media }}
 {% endblock head %}
 {% block js_error %}
-    <ul class="text-danger js-validation d-none">
+    <div class="text-danger js-validation d-none">
         <div class="my-3">
             JsPsych JavaScript seems to be invalid.  Please edit and save again. If you reload this page, all changes will be lost.
         </div>
-    </ul>
+    </div>
 {% endblock js_error %}
 {% block form %}
     {% bootstrap_form form label_class="fw-bold" %}

--- a/web/static/js/js-validation.js
+++ b/web/static/js/js-validation.js
@@ -1,5 +1,5 @@
 function jsValidation(event, generator) {
-    const jshint_config = { "esversion": 6, "sub": true, "undef": true };
+    const jshint_config = { "esversion": 6, "sub": true };
     const jsValidation = document.querySelector('.js-validation');
 
     // if jshint comes back with errors (false)

--- a/web/static/js/js-validation.js
+++ b/web/static/js/js-validation.js
@@ -1,26 +1,22 @@
 function jsValidation(event, generator) {
-    const jshint_config = { "esversion": 6, "sub": true };
     const jsValidation = document.querySelector('.js-validation');
+    try {
+        Babel.transform(generator.value, { presets: ["env"] });
+        jsValidation.classList.add('d-none');
+    } catch ({ message }) {
+        // Remove existing errors
+        document.querySelectorAll('.js-validation pre').forEach(el => el.remove());
 
-    // if jshint comes back with errors (false)
-    if (!JSHINT(generator.value, jshint_config)) {
         // Show errors element
         jsValidation.classList.remove('d-none');
-
-        // Remove existing errors
-        document.querySelectorAll('.js-validation ol').forEach(el => el.remove());
 
         // Don't submit the form and scroll to top of page.
         event.preventDefault();
         window.scrollTo(0, 0);
 
-        // Add errors to the list
-        JSHINT.errors.map(({ line, reason }) => {
-            const errorEl = document.createElement('ol');
-            errorEl.innerHTML = `${line}: ${reason}`;
-            jsValidation.appendChild(errorEl);
-        });
-    } else {
-        jsValidation.classList.add('d-none');
+        // Add error message
+        const errorEl = document.createElement('pre');
+        errorEl.innerHTML = message;
+        jsValidation.appendChild(errorEl);
     }
 }

--- a/web/templates/web/base.html
+++ b/web/templates/web/base.html
@@ -99,11 +99,10 @@
                 integrity="sha512-iJh0F10blr9SC3d0Ow1ZKHi9kt12NYa+ISlmCdlCdNZzFwjH1JppRTeAnypvUez01HroZhAmP4ro4AvZ/rG0UQ=="
                 crossorigin="anonymous"
                 referrerpolicy="no-referrer"></script>
-        {# JSHint #}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jshint/2.13.6/jshint.min.js"
-                integrity="sha512-MCUpdWtSMK1rm+4sWFpfFuz4UTpXEud5p236Otyw1Ea4kdVyNxy+eMHR76u7xfY5DlpDmOzgEhgDq1ZGLHqkCA=="
-                crossorigin="anonymous"
-                referrerpolicy="no-referrer"></script>
+        {# Babel (used for linting) #}
+        <script src="https://unpkg.com/@babel/standalone@7.23.10/babel.min.js"
+                integrity="sha384-KCD0A3BqTNZfWlXJcL7fKzDri97vicyNr4NUIr0vX6K9PZ0X5hOTeEbFh99jPEST"
+                crossorigin="anonymous"></script>
         {# bootstrap 5 #}
         {% bootstrap_javascript %}
         {% bootstrap_css %}

--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -26,11 +26,11 @@
               crossorigin="anonymous">
         <script src="http://localhost:8080/packages/lookit-helpers/dist/index.browser.js"></script>
         <script type="module">
-                const child = await lookitHelpers.child("{{response.child.uuid}}");
-                const pastSessions = await lookitHelpers.pastSessions("{{response.uuid}}");
                 const responseApiUrl="{% url 'api:response-detail' version='v2' uuid=response.uuid %}";
                 const responseUuid="{{ response.uuid }}";
                 const exitUrl="{{ response.study.exit_url }}"
+                const childUuid ="{{response.child.uuid}}"
+                const Helpers = new lookitHelpers(childUuid, responseUuid);
                 initJsPsych = lookitInitJsPsych(responseApiUrl, responseUuid, exitUrl);
                 {% autoescape off %}{{ study.metadata.experiment }}{% endautoescape %}
         </script>

--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -24,7 +24,10 @@
               href="https://unpkg.com/jspsych@7.3.3/css/jspsych.css"
               integrity="sha384-V/UDJ5gQqHFzUZFNp/XZxaqNCEGfcX0ExsYH3gH8dFRe6piMutG6hSKyCYJsql96"
               crossorigin="anonymous">
-        <script>
+        <script src="http://localhost:8080/packages/lookit-helpers/dist/index.browser.js"></script>
+        <script type="module">
+                const child = await lookitHelpers.child("{{response.child.uuid}}");
+                const pastSessions = await lookitHelpers.pastSessions("{{response.uuid}}");
                 const responseApiUrl="{% url 'api:response-detail' version='v2' uuid=response.uuid %}";
                 const responseUuid="{{ response.uuid }}";
                 const exitUrl="{{ response.study.exit_url }}"

--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -24,7 +24,6 @@
               href="https://unpkg.com/jspsych@7.3.3/css/jspsych.css"
               integrity="sha384-V/UDJ5gQqHFzUZFNp/XZxaqNCEGfcX0ExsYH3gH8dFRe6piMutG6hSKyCYJsql96"
               crossorigin="anonymous">
-        <script src="http://localhost:8080/packages/lookit-helpers/dist/index.browser.js"></script>
         <script type="module">
                 const responseApiUrl="{% url 'api:response-detail' version='v2' uuid=response.uuid %}";
                 const responseUuid="{{ response.uuid }}";

--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -20,6 +20,9 @@
         <script src="https://unpkg.com/@lookit/lookit-initjspsych@1.0.4"
                 integrity="sha384-ChFT/KSP0S4cJ0N9WAg7v86UvHTOK2ItNJMTGAjz/88HciyA8hGoUJkoDce0rXc9"
                 crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/@lookit/lookit-helpers@1.0.1"
+                integrity="sha384-YM4GoyuMF+EE8e0Kx2XcNVn2BwNAbr6ewTT6Sk/ufprVsQVOeSjoRz4lHGLToxUU"
+                crossorigin="anonymous"></script>
         <link rel="stylesheet"
               href="https://unpkg.com/jspsych@7.3.3/css/jspsych.css"
               integrity="sha384-V/UDJ5gQqHFzUZFNp/XZxaqNCEGfcX0ExsYH3gH8dFRe6piMutG6hSKyCYJsql96"


### PR DESCRIPTION
Closes #1294

### Summary

Now that the lookit-helpers package is fairly close to being released to NPM, we can implement it in the JSPsych template.  

#### Additional Work

1. The existing linter for researcher code was proving to be difficult as we moved away from ES6.  A modular version of Babel is used instead.  
2. Added endpoint "past-sessions" to fulfill the need for researchers to know the past sessions (or responses) a user has done on their experiment.  