### PR TITLE
Send all emails from same MIT domain and move lab email to reply-to

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -677,7 +677,7 @@ class Message(models.Model):
             self.subject,
             to_email_list,
             bcc=bcc_email_list,
-            from_email=lab_email,
+            reply_to=[lab_email],
             **context,
         )
 

--- a/exp/tests/test_contact_views.py
+++ b/exp/tests/test_contact_views.py
@@ -263,8 +263,9 @@ class ContactViewTestCase(TestCase):
             [p.username for p in self.participants[0:3]],
         )
         self.assertEqual(
-            mock_send_mail.call_args.kwargs["from_email"], self.study.lab.contact_email
+            mock_send_mail.call_args.kwargs["reply_to"], [self.study.lab.contact_email]
         )
+        self.assertFalse("from_address" in mock_send_mail.call_args)
 
         # And that appropriate message object created
         self.assertTrue(Message.objects.filter(subject="test email").exists())
@@ -296,8 +297,9 @@ class ContactViewTestCase(TestCase):
         )
         self.assertEqual(mock_send_mail.call_args.kwargs["bcc"], [])
         self.assertEqual(
-            mock_send_mail.call_args.kwargs["from_email"], self.study.lab.contact_email
+            mock_send_mail.call_args.kwargs["reply_to"], [self.study.lab.contact_email]
         )
+        self.assertFalse("from_address" in mock_send_mail.call_args)
 
         # And that appropriate message object created
         self.assertTrue(Message.objects.filter(subject="test email").exists())

--- a/exp/tests/test_contact_views.py
+++ b/exp/tests/test_contact_views.py
@@ -265,7 +265,7 @@ class ContactViewTestCase(TestCase):
         self.assertEqual(
             mock_send_mail.call_args.kwargs["reply_to"], [self.study.lab.contact_email]
         )
-        self.assertFalse("from_address" in mock_send_mail.call_args)
+        self.assertFalse("from_email" in mock_send_mail.call_args)
 
         # And that appropriate message object created
         self.assertTrue(Message.objects.filter(subject="test email").exists())
@@ -299,7 +299,7 @@ class ContactViewTestCase(TestCase):
         self.assertEqual(
             mock_send_mail.call_args.kwargs["reply_to"], [self.study.lab.contact_email]
         )
-        self.assertFalse("from_address" in mock_send_mail.call_args)
+        self.assertFalse("from_email" in mock_send_mail.call_args)
 
         # And that appropriate message object created
         self.assertTrue(Message.objects.filter(subject="test email").exists())

--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -764,7 +764,7 @@ class ManageResearcherPermissionsViewTestCase(TestCase):
             "notify_researcher_of_study_permissions",
             f"New access granted for study {mock_get_object().name}",
             mock_user.username,
-            from_email=mock_get_object().lab.contact_email,
+            reply_to=[mock_get_object().lab.contact_email],
             permission=mock_permission,
             study_name=mock_get_object().name,
             study_id=mock_get_object().id,

--- a/exp/views/lab.py
+++ b/exp/views/lab.py
@@ -232,7 +232,7 @@ class LabMembersView(
                 "notify_researcher_of_lab_permissions",
                 f"You are now part of the Lookit lab {lab.name}",
                 researcher.username,
-                from_email=lab.contact_email,
+                reply_to=[lab.contact_email],
                 **context,
             )
         if action == "make_member":
@@ -256,7 +256,7 @@ class LabMembersView(
                 "notify_researcher_of_lab_permissions",
                 f"You now have lab member permissions for the Lookit lab {lab.name}",
                 researcher.username,
-                from_email=lab.contact_email,
+                reply_to=[lab.contact_email],
                 **context,
             )
         if action == "make_admin":
@@ -280,7 +280,7 @@ class LabMembersView(
                 "notify_researcher_of_lab_permissions",
                 f"You are now an admin of the Lookit lab {lab.name}",
                 researcher.username,
-                from_email=lab.contact_email,
+                reply_to=[lab.contact_email],
                 **context,
             )
         if action == "remove_researcher":
@@ -312,7 +312,7 @@ class LabMembersView(
                 "notify_researcher_of_lab_permissions",
                 f"You have been removed from the Lookit lab {lab.name}",
                 researcher.username,
-                from_email=lab.contact_email,
+                reply_to=[lab.contact_email],
                 **context,
             )
         if action == "reset_password":

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -545,7 +545,7 @@ class ManageResearcherPermissionsView(
             "notify_researcher_of_study_permissions",
             f"New access granted for study {self.get_object().name}",
             user.username,
-            from_email=study.lab.contact_email,
+            reply_to=[study.lab.contact_email],
             **context,
         )
 

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -26,16 +26,17 @@ def send_mail(
     to_addresses,
     cc=None,
     bcc=None,
-    from_email=None,
     reply_to=None,
     **context,
 ):
     """
     Helper for sending templated email
 
+    Note: we no longer allow an argument for the 'from' address because new email deliverability requirements say
+    that the 'from' address must match the domain that the email was actually sent from (in our case, mit.edu).
+
     :param str template_name: Name of the template to send. There should exist a txt and html version
     :param str subject: Subject line of the email
-    :param str from_email: From address for email
     :param list to_addresses: List of addresses to email. If str is provided, wrapped in list
     :param list cc: List of addresses to carbon copy
     :param list bcc: List of addresses to blind carbon copy
@@ -63,7 +64,8 @@ def send_mail(
     if not isinstance(to_addresses, list):
         to_addresses = [to_addresses]
 
-    from_address = from_email or EMAIL_FROM_ADDRESS
+    from_address = EMAIL_FROM_ADDRESS
+
     email = EmailMultiAlternatives(
         subject,
         text_content,

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -399,7 +399,6 @@ def build_zipfile_of_videos(
         "download_zip",
         "Your video archive has been created",
         [requesting_user.username],
-        from_email=settings.EMAIL_FROM_ADDRESS,
         **email_context,
     )
 
@@ -474,7 +473,6 @@ def build_framedata_dict(filename, study_uuid, requesting_user_uuid):
         "download_framedata_dict",
         "Your frame data dictionary has been created",
         [requesting_user.username],
-        from_email=settings.EMAIL_FROM_ADDRESS,
         **email_context,
     )
 

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -591,7 +591,6 @@ class TestSendMail(TestCase):
             "Test email",
             ["lookit-test-email@mit.edu"],
             bcc=[],
-            from_email="lookit-bot@mit.edu",
             base_url="https://lookit-staging.mit.edu/",
             custom_message=mark_safe(
                 '<p>line 1<br></p><p><img style="width: 24px;" src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QCURXhpZgAATU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgExAAIAAAAHAAAAWodpAAQAAAABAAAAYgAAAAAAAABIAAAAAQAAAEgAAAABUGljYXNhAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAGKADAAQAAAABAAAAEAAAAAD/7QA4UGhvdG9zaG9wIDMuMAA4QklNBAQAAAAAAAA4QklNBCUAAAAAABDUHYzZjwCyBOmACZjs+EJ+/8AAEQgAEAAYAwERAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/bAEMACAYGCAoKCAgICAkICAkICQgICQkIDQgIBwkdGh8eHRocHCAkLicgIiwjHBwoNyksMDE0NDQfJzk9ODI8LjM0Mv/bAEMBCQkJDQoNFQ0NFTIhECEyMjIyMjIyMjInJzIyJiYnJycmMiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJv/dAAQAA//aAAwDAQACEQMRAD8AyvBEcEer2e6B5QNzK6hmUcHj09+avELTQ5sHZ6vf/gHsN/qejR3tjo7eU93qFs7QKjM2GwSpyOMHa35VnpojsVOTi59EeKeK7e5jv7+WFGeJpFR2iy56DOQPp+laU6kF7r3PPxeGqz96Pws//9Cj4RlJaWG0jjf/AEVRJdzv8iuc8HHIODWE60VNOb0+83hhn7K1Na+el2/8jQX+0ZLe3jh1Ww/tC0tLm2nkE7TeUN3yZOBtYAHjHrVzrUpJuK1/LyN6OFxFHldZe7p/296HC3muXf2nZ9nignKyM08nmzSGXJyQCcEcn25p+zjZSvc5p1pzm4yja2i9Ef/Z" data-filename="small.jpg"></p><p>line 2<br></p>'
@@ -662,6 +661,18 @@ class TestSendMail(TestCase):
             reply_to=reply_to,
         )
         self.assertEquals(email.reply_to, reply_to)
+
+    def test_no_custom_from_address(self):
+        # We used to send certain emails with lab emails as the 'from' address - this is no longer allowed by email clients.
+        # Need to check that send_mail with ignore attempts to send emails with a different 'from' address.
+        different_from_address = "other_from_email@domain.com"
+        email = send_mail(
+            template_name="custom_email",
+            subject="subject",
+            to_addresses="to_addresses",
+            from_email=different_from_address,
+        )
+        self.assertEquals(email.from_email, settings.EMAIL_FROM_ADDRESS)
 
 
 class StudyTypeModelTestCase(TestCase):


### PR DESCRIPTION
Fixes #1356

This PR does two key things:
1. Removes the optional 'from_email' argument from the `send_email` helper function, because we are now always sending email from the default MIT email address (specifically the `EMAIL_FROM_ADDRESS` in project settings).
2. In cases where we were sending email "from" a lab email address, this PR adds the lab email to the "reply-to" email header.

A few implementation notes:
- The reply-to must be a list or tuple, hence the square brackets around the lab email address in the reply-to argument.
- I didn't need to modify every `send_mail` call in the codebase because the 'from_email' argument was optional, and when omitted, it defaulted to sending from the project's default 'from' address. 
- The `send_mail` function is mocked in `exp/tests/test_contact_views.py`, so there we're just checking that the mocked function wasn't called with the "from_email" argument. 
- There's a new test in `studies/tests.py` called `test_no_custom_from_address` that I think does a better job of testing that any 'from_email' arguments that are passed to `send_mail` will be ignored, and mail will only be sent from the project's 'from' address.