### PR TITLE
Updated jspsych urls

### DIFF
--- a/exp/urls.py
+++ b/exp/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     2. Import the include() function: from django.conf.urls import url, include
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
+
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
@@ -256,7 +257,7 @@ urlpatterns = [
         name="preview-proxy",
     ),
     path(
-        "studies/jspsych/<uuid:uuid>/<uuid:child_id>/preview/",
+        "studies/j/<uuid:uuid>/<uuid:child_id>/preview/",
         JsPsychPreviewView.as_view(),
         name="preview-jspsych",
     ),

--- a/web/urls.py
+++ b/web/urls.py
@@ -61,7 +61,7 @@ urlpatterns = [
         name="experiment-proxy",
     ),
     path(
-        "studies/jspsych/<uuid:uuid>/<uuid:child_id>/",
+        "studies/j/<uuid:uuid>/<uuid:child_id>/",
         views.JsPsychExperimentView.as_view(),
         name="jspsych-experiment",
     ),


### PR DESCRIPTION
Closes  #1325

This issue was hoping to have the same URL for all experiment runners.  After some research, redirecting to the reverse proxy prevents us from having a single URL for all runners.  The solution we leaned into was to provide a unique URL for each experiment runner.

Here are the URLs for the two experiment runners we currently support. 
- EFP: studies/`study_uuid`/`child_uuid`/
- jsPsych: studies/j/`study_uuid`/`child_uuid`/

The single "j" in the URL provides us with the uniqueness to tell them apart without necessarily exposing additional data to the experiment participant. Additionally, this leaves the EFP URL as it was, so no legacy URLs need to be updated. 

