### PR TITLE
This is the implementation of "Add email template text to Contact Participants page"

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -673,12 +673,15 @@ class Message(models.Model):
         return announcement_message
 
     def send_as_email(self):
+        lab_email = self.related_study.lab.contact_email
+
         context = {
             "base_url": settings.BASE_URL,
             "custom_message": mark_safe(self.body),
+            "lab_name": self.related_study.lab.name,
+            "lab_email": lab_email,
+            "study_name": self.related_study.name,
         }
-
-        lab_email = self.related_study.lab.contact_email
 
         recipient_email_list = list(self.recipients.values_list("username", flat=True))
 

--- a/studies/templates/emails/custom_email.html
+++ b/studies/templates/emails/custom_email.html
@@ -1,5 +1,6 @@
 {% extends "emails/base.html" %}
 {% block content %}
+    {% include "emails/custom_email_header.html" %}
     {% autoescape off %}
         {{ custom_message }}
     {% endautoescape %}

--- a/studies/templates/emails/custom_email.txt
+++ b/studies/templates/emails/custom_email.txt
@@ -1,4 +1,6 @@
 {% extends "emails/base.txt" %}
+
 {% block content %}
+{% include "emails/custom_email_header.txt"  %}
 {{ custom_message|striptags }}
 {% endblock content %}

--- a/studies/templates/emails/custom_email_header.html
+++ b/studies/templates/emails/custom_email_header.html
@@ -1,0 +1,1 @@
+<p>{% include "emails/custom_email_header.txt" %}</p>

--- a/studies/templates/emails/custom_email_header.txt
+++ b/studies/templates/emails/custom_email_header.txt
@@ -1,0 +1,3 @@
+This is an email from {{ lab_name }} for "{{ study_name }}". You 
+may reply to this email to message directly with the researchers at {{ lab_name }} or 
+email them at {{ lab_email }} if you have other questions.

--- a/studies/templates/studies/study_participant_contact.html
+++ b/studies/templates/studies/study_participant_contact.html
@@ -143,6 +143,15 @@
                     </div>
                 </div>
             </div>
+            <div class="card bg-light mb-3">
+                <div class="card-header">Email Header</div>
+                <div class="card-body">
+                    <p>All particiapant emails will see the following header when they're contacted from this form:</p>
+                    <i>
+                        {% include "emails/custom_email_header.html" with lab_name=study.lab.name study_name=study.name lab_email=study.lab.contact_email %}
+                    </i>
+                </div>
+            </div>
             <form method="post">
                 {% csrf_token %}
                 {% bootstrap_form form %}


### PR DESCRIPTION
Closes #1361

### Summary
Add text to emails to give the receiver context on which study they're being contacted about. 

### Implementation

Created a single template that is used in both types of email (text or HTML) and the participant contact view.  Since all three places share the same source, then they'll all have the same text.  

### Images
Text as seen from the participant view:
<img width="1515" alt="Screenshot 2024-03-12 at 11 34 14 AM" src="https://github.com/lookit/lookit-api/assets/44074998/ca1b0720-a3ae-43ce-badb-92c6e1e35b2c">
Emails as seen in the participant email inbox:
<img width="1552" alt="Screenshot 2024-03-12 at 11 35 03 AM" src="https://github.com/lookit/lookit-api/assets/44074998/4dbe155b-1833-476d-8e53-e2b541f2b99d">
