### PR TITLE
Add questions/feedback link to participant emails

### DIFF
--- a/studies/templates/emails/base.html
+++ b/studies/templates/emails/base.html
@@ -2,5 +2,5 @@
 {% endblock content %}
 <br />
 <a href="{{ base_url }}{% url 'web:email-preferences' %}">Update your email preferences</a>
-<a href="{{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all emails</a>
+<a href="{{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all CHS emails</a>
 <a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>

--- a/studies/templates/emails/base.html
+++ b/studies/templates/emails/base.html
@@ -3,3 +3,4 @@
 <br />
 <a href="{{ base_url }}{% url 'web:email-preferences' %}">Update your email preferences</a>
 <a href="{{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all emails</a>
+<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>

--- a/studies/templates/emails/base.html
+++ b/studies/templates/emails/base.html
@@ -1,6 +1,6 @@
 {% block content %}
 {% endblock content %}
 <br />
-<a href="{{ base_url }}{% url 'web:email-preferences' %}">Update your email preferences</a>
+<a href="{{ base_url }}{% url 'web:email-preferences' %}">Update your CHS email preferences</a>
 <a href="{{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all CHS emails</a>
 <a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>

--- a/studies/templates/emails/base.txt
+++ b/studies/templates/emails/base.txt
@@ -2,3 +2,4 @@
 
 Update your email preferences here: {{ base_url }}{% url 'web:email-preferences' %}
 Unsubscribe from all emails: {{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}
+Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com 

--- a/studies/templates/emails/base.txt
+++ b/studies/templates/emails/base.txt
@@ -1,5 +1,5 @@
 {% block content %}{% endblock content %}
 
-Update your email preferences here: {{ base_url }}{% url 'web:email-preferences' %}
+Update your CHS email preferences here: {{ base_url }}{% url 'web:email-preferences' %}
 Unsubscribe from all CHS emails: {{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}
 Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com

--- a/studies/templates/emails/base.txt
+++ b/studies/templates/emails/base.txt
@@ -1,5 +1,5 @@
 {% block content %}{% endblock content %}
 
 Update your email preferences here: {{ base_url }}{% url 'web:email-preferences' %}
-Unsubscribe from all emails: {{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}
+Unsubscribe from all CHS emails: {{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}
 Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com

--- a/studies/templates/emails/base.txt
+++ b/studies/templates/emails/base.txt
@@ -2,4 +2,4 @@
 
 Update your email preferences here: {{ base_url }}{% url 'web:email-preferences' %}
 Unsubscribe from all emails: {{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}
-Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com 
+Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -45,6 +45,7 @@ Note: If you have taken part in Lookit studies before, you might notice that the
 
 Update your email preferences here: {base_url}/account/email/
 Unsubscribe from all emails: {base_url}{unsubscribe}
+Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com
 """
 
 
@@ -627,7 +628,7 @@ class TestSendMail(TestCase):
         self.assertEqual(
             email.alternatives[0],
             (
-                f'\n    \n        <p>line 1<br></p><p><img style="width: 24px;" src="cid:image-00001" data-filename="small.jpg"></p><p>line 2<br></p>\n    \n\n<br />\n<a href="https://localhost:8000/account/email/">Update your email preferences</a>\n<a href="https://localhost:8000/account/{self.context["username"]}/{self.context["token"]}/">Unsubscribe from all emails</a>\n',
+                f'\n    \n        <p>line 1<br></p><p><img style="width: 24px;" src="cid:image-00001" data-filename="small.jpg"></p><p>line 2<br></p>\n    \n\n<br />\n<a href="https://localhost:8000/account/email/">Update your email preferences</a>\n<a href="https://localhost:8000/account/{self.context["username"]}/{self.context["token"]}/">Unsubscribe from all emails</a>\n<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>\n',
                 "text/html",
             ),
         )

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -43,7 +43,7 @@ Note: If you have taken part in Lookit studies before, you might notice that the
 -- the Lookit/Children Helping Science team
 
 
-Update your email preferences here: {base_url}/account/email/
+Update your CHS email preferences here: {base_url}/account/email/
 Unsubscribe from all CHS emails: {base_url}{unsubscribe}
 Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com
 """
@@ -615,7 +615,7 @@ class TestSendMail(TestCase):
         self.assertEqual(email.to, ["lookit-test-email@mit.edu"])
         self.assertTrue(
             email.body.startswith(
-                "\nline 1[IMAGE]line 2\n\n\nUpdate your email preferences here"
+                "\nline 1[IMAGE]line 2\n\n\nUpdate your CHS email preferences here"
             ),
             "Email plain text does not have expected substitution of [IMAGE] for image tag",
         )
@@ -628,7 +628,7 @@ class TestSendMail(TestCase):
         self.assertEqual(
             email.alternatives[0],
             (
-                f'\n    \n        <p>line 1<br></p><p><img style="width: 24px;" src="cid:image-00001" data-filename="small.jpg"></p><p>line 2<br></p>\n    \n\n<br />\n<a href="https://localhost:8000/account/email/">Update your email preferences</a>\n<a href="https://localhost:8000/account/{self.context["username"]}/{self.context["token"]}/">Unsubscribe from all CHS emails</a>\n<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>\n',
+                f'\n    \n        <p>line 1<br></p><p><img style="width: 24px;" src="cid:image-00001" data-filename="small.jpg"></p><p>line 2<br></p>\n    \n\n<br />\n<a href="https://localhost:8000/account/email/">Update your CHS email preferences</a>\n<a href="https://localhost:8000/account/{self.context["username"]}/{self.context["token"]}/">Unsubscribe from all CHS emails</a>\n<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>\n',
                 "text/html",
             ),
         )

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -44,7 +44,7 @@ Note: If you have taken part in Lookit studies before, you might notice that the
 
 
 Update your email preferences here: {base_url}/account/email/
-Unsubscribe from all emails: {base_url}{unsubscribe}
+Unsubscribe from all CHS emails: {base_url}{unsubscribe}
 Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com
 """
 
@@ -628,7 +628,7 @@ class TestSendMail(TestCase):
         self.assertEqual(
             email.alternatives[0],
             (
-                f'\n    \n        <p>line 1<br></p><p><img style="width: 24px;" src="cid:image-00001" data-filename="small.jpg"></p><p>line 2<br></p>\n    \n\n<br />\n<a href="https://localhost:8000/account/email/">Update your email preferences</a>\n<a href="https://localhost:8000/account/{self.context["username"]}/{self.context["token"]}/">Unsubscribe from all emails</a>\n<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>\n',
+                f'\n    \n        <p>line 1<br></p><p><img style="width: 24px;" src="cid:image-00001" data-filename="small.jpg"></p><p>line 2<br></p>\n    \n\n<br />\n<a href="https://localhost:8000/account/email/">Update your email preferences</a>\n<a href="https://localhost:8000/account/{self.context["username"]}/{self.context["token"]}/">Unsubscribe from all CHS emails</a>\n<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>\n',
                 "text/html",
             ),
         )


### PR DESCRIPTION
### Summary 

Closes #1364

This PR simply adds an email to link to the bottom of the footer for participant emails.  

### Image

<img width="1312" alt="Screenshot 2024-03-14 at 11 56 40 AM" src="https://github.com/lookit/lookit-api/assets/44074998/f63c7e83-74a3-482b-ac86-531e535bb156">

### Testing

- [ ] Confirm email link in both HTML and Text versions of emails
- [ ] Passes CI/CD