### PR TITLE
Update links to lookit's unpkg packages

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -17,11 +17,11 @@
         <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.2"
                 integrity="sha384-ieDTpJ57nlVDQBu9ti3FiIIqRDAYQWLVyNSvkkA241eFPk+63fwBqc0Rn+ePnSZt"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/lookit-initjspsych@1.0.4"
-                integrity="sha384-ChFT/KSP0S4cJ0N9WAg7v86UvHTOK2ItNJMTGAjz/88HciyA8hGoUJkoDce0rXc9"
+        <script src="https://unpkg.com/@lookit/lookit-initjspsych@0.0.1"
+                integrity="sha384-RepAqqTAnziAru8pDzd7Zp6izZdkSvLZ0EKGQv1JAnGpfjKLm10+GjIE7OEpFp16"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/lookit-helpers@1.0.1"
-                integrity="sha384-YM4GoyuMF+EE8e0Kx2XcNVn2BwNAbr6ewTT6Sk/ufprVsQVOeSjoRz4lHGLToxUU"
+        <script src="https://unpkg.com/@lookit/lookit-helpers@0.0.1"
+                integrity="sha384-Ty+Qfh8Ms6Bjv4eKgq/Unoa3C0xQiXE6UyRb2lPl3WpCiUFEGCBzgZhTO/UKdG59"
                 crossorigin="anonymous"></script>
         <link rel="stylesheet"
               href="https://unpkg.com/jspsych@7.3.3/css/jspsych.css"


### PR DESCRIPTION
### Summary

In a [recent PR](https://github.com/lookit/lookit-jspsych/pull/21) on the lookit-jspysch repo, we reset the version of our packages to `0.0.1`. This PR updates the lookit-jspysch packages in use in this repo. 