### PR TITLE
move email footer links to new lines

### DIFF
--- a/studies/templates/emails/base.html
+++ b/studies/templates/emails/base.html
@@ -2,5 +2,7 @@
 {% endblock content %}
 <br />
 <a href="{{ base_url }}{% url 'web:email-preferences' %}">Update your CHS email preferences</a>
+<br />
 <a href="{{ base_url }}{% url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all CHS emails</a>
+<br />
 <a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -628,7 +628,7 @@ class TestSendMail(TestCase):
         self.assertEqual(
             email.alternatives[0],
             (
-                f'\n    \n        <p>line 1<br></p><p><img style="width: 24px;" src="cid:image-00001" data-filename="small.jpg"></p><p>line 2<br></p>\n    \n\n<br />\n<a href="https://localhost:8000/account/email/">Update your CHS email preferences</a>\n<a href="https://localhost:8000/account/{self.context["username"]}/{self.context["token"]}/">Unsubscribe from all CHS emails</a>\n<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>\n',
+                f'\n    \n        <p>line 1<br></p><p><img style="width: 24px;" src="cid:image-00001" data-filename="small.jpg"></p><p>line 2<br></p>\n    \n\n<br />\n<a href="https://localhost:8000/account/email/">Update your CHS email preferences</a>\n<br />\n<a href="https://localhost:8000/account/{self.context["username"]}/{self.context["token"]}/">Unsubscribe from all CHS emails</a>\n<br />\n<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>\n',
                 "text/html",
             ),
         )


### PR DESCRIPTION
This PR puts line breaks between the three links at the bottom of participant emails, so they don't appear all on the same line (see screenshot). This issue only affects the HTML version of the base template.

![Screenshot 2024-03-19 at 2 52 56 PM](https://github.com/lookit/lookit-api/assets/9041788/abea23ee-972d-4086-976d-f2dc080b0e50)
