### PR TITLE
Parameterize and update translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,9 @@ css: poetry
 
 makemigrations:
 	poetry run ./manage.py makemigrations
+
+makemessages:
+	poetry run ./manage.py makemessages --all
+
+compilemessages:
+	poetry run ./manage.py compilemessages

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -2,35 +2,50 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "E-Mail-Addresse"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Spitzname"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr ""
 "Es ist Zeit für eine weitere Sitzung einer Studie, an der wir derzeit "
 "teilnehmen"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Für eines meiner Kinder liegt eine neue Studie vor"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -38,7 +53,7 @@ msgstr ""
 "Es gibt ein Update zu einer Studie, an der wir teilgenommen haben (z. B. "
 "werden Ergebnisse veröffentlicht)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -46,107 +61,96 @@ msgstr ""
 "Ein Forscher hat Fragen zu meinen individuellen Antworten (z. B. ob ich "
 "während der Studie ein technisches Problem melde)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "Mit welcher/n Kategorie(n) identifiziert sich Ihre Familie?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Land"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr ""
 "Geben Sie als durch Kommas getrennte Liste folgendes ein: JJJJ-MM-TT, JJJJ-"
 "MM-TT, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Nur numerische Antworten - eine grobe Einschätzung ist in Ordnung!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "In welchem Land leben Sie?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "In welchem Bundesland leben Sie?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Wie würden Sie die Gegend beschreiben, in der Sie leben?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Welche Sprache(n) spricht Ihre Familie zu Hause?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Wie viele Kinder haben Sie?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Bitte geben Sie für jedes Kind sein oder ihr Geburtsdatum ein:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr ""
 "Mit wie vielen Elternteilen/Erziehungsberechtigten leben Ihre Kinder "
 "zusammen?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Wie alt sind Sie?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Was ist Ihr Geschlecht?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Was ist Ihr Geschlecht?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Was ist das höchste Bildungsniveau, das Sie abgeschlossen haben?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr ""
-"Was ist das höchste Bildungsniveau, das Ihr(e) Ehepartner(in) abgeschlossen "
-"hat?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Was ist Ihr ungefähres jährliches Familieneinkommen (in Euro)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Wie viele Kinderbücher haben Sie zu Hause?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Möchten Sie uns noch etwas mitteilen?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Wie haben Sie von Lookit erfahren?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Wenn die Antwort aufgrund von Sorgerechtsvereinbarungen oder Reisen "
-"unterschiedlich ist, geben Sie bitte die Anzahl der Elternteile/"
-"Erziehungsberechtigten ein, mit denen Ihre Kinder normalerweise "
-"zusammenleben, oder erklären Sie dies."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Geburtstag"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Eine andere ethnische Zugehörigkeit oder Herkunft"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -157,33 +161,36 @@ msgstr ""
 "Informationen von Kindern, die es einem Leser ermöglichen würden, das "
 "Geburtsdatum zu berechnen."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Geburtstage können nicht in der Zukunft liegen."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Vorname"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Geburtstag"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Geschlecht"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Gestationsalter bei der Geburt"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Zusätzliche Informationen, die Sie uns gerne mitteilen würden"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Eigenschaften und Bedingungen"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -191,7 +198,7 @@ msgstr ""
 "Sprachen, denen dieses Kind zu Hause, in der Schule oder bei einer anderen "
 "Betreuungsperson ausgesetzt ist."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -204,502 +211,610 @@ msgstr ""
 "\"Es gibt eine neue Studie für Marie!\"), werden jedoch niemals Namen "
 "veröffentlichen oder in unserer Forschung verwenden."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Zum Beispiel diagnostizierte Entwicklungsstörungen oder Seh- oder Hörprobleme"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Bitte runden Sie auf die letzte volle Schwangerschaftswoche ab"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Studien"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Derzeitige Studien"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Ihre früheren Studien"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Derzeitige Studien"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Nicht sicher oder lieber nicht antworten"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Unter 24 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 Wochen"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 oder mehr Wochen"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Kann die Organisation sehen"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Kann die Organisation bearbeiten"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Kann die Organisation erstellen"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Kann die Organisation entfernen"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Kann den Experimentator sehen"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Kann die Analyse sehen"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Kann einen Benutzer erstellen"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Kann einen Benutzer sehen"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Kann einen Benutzer bearbeiten"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Kann einen Benutzer entfernen"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Kann Benutzerberechtigungen sehen"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Kann Benutzerberechtigungen bearbeiten"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Kann alle Benutzerdaten lesen"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Kann Benutzernamen lesen"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "männlich"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "weiblich"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "andere"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "lieber nicht antworten"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Kann die Organisation sehen"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Kann die Organisation bearbeiten"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Kann die Organisation erstellen"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Kann die Organisation entfernen"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Kann den Experimentator sehen"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Kann die Analyse sehen"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Kann einen Benutzer erstellen"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Kann einen Benutzer sehen"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Kann einen Benutzer bearbeiten"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Kann einen Benutzer entfernen"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Kann Benutzerberechtigungen sehen"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Kann Benutzerberechtigungen bearbeiten"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Kann alle Benutzerdaten lesen"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Kann Benutzernamen lesen"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "weiß"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Hispanischer, lateinamerikanischer oder spanischer Herkunft"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Schwarzer oder Afroamerikaner"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asiate"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Indianer oder Alaska-Ureinwohner"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Nahost- oder Nordafrikaner"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Einheimische Hawaiianer oder andere pazifische Insulaner"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Eine andere ethnische Zugehörigkeit oder Herkunft"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "Haupt- oder Realschulabschluss"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "(Fach-)Abitur"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "(Fach-)Hoschule besucht (bisher) ohne Abschluss"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "Bachelor; abgeschlossene Lehre (3-jähriger Abschluss)"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "Master; Gesellenprüfung (4- oder 5-jähriger Abschluss)"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "Promotion; Meisterprüfung"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "anderer Abschluss"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "nicht zutreffend - kein Ehepartner oder Partner"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Mehr als 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "unter 18"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 oder älter"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 oder mehr"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "variiert"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "über 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "städtisch"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "Vorort"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "ländlich"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Wähle ein Bundesland"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Kontoinformationen"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Demografischer Fragebogen"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Erzähl Sie uns mehr über sich."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informationen für Kinder"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Teilnehmerinformationen hinzufügen oder bearbeiten."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "E-Mail Präferenzen"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Bearbeiten, wenn Sie kontaktiert werden können."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Mein Konto"
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr "Kontoinformation aktualisieren"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Sichern"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Ändern Sie Ihr Passwort"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Alle Teilnehmer(innen)"
 
@@ -707,76 +822,83 @@ msgstr "Alle Teilnehmer(innen)"
 msgid "Participant ID"
 msgstr "Teilnehmer(in)-ID"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Letzte Aktivität:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "Allgemeine ID des Teilnehmers:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Kinder"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Alter"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Zusätzliche Information"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Keine Kinderprofile registriert!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Neueste demografische Daten"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Land"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Bundesland"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Beschreibung der Gegend"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Zu Hause gesprochene Sprachen"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Anzahl der Kinder"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "aktuelles Alter der Kinder"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Studienantworten"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Anzahl der Erziehungberechtigten"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Erklärung für die Erziehungsberechtigten:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Ethnische Zugehörigkeit"
 
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Dashboard"
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
 
-#: project/settings.py:243 studies/fields.py:97
-#, fuzzy
-#| msgid "Asian"
-msgid "Russian"
-msgstr "Asiate"
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
 
 #: studies/fields.py:45
 msgid "Twin"
@@ -806,35 +928,269 @@ msgstr "Siebenling"
 msgid "Octuplet"
 msgstr "Achtling"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
 #: studies/fields.py:69
 #, fuzzy
 #| msgid "Duration"
 msgid "Gujarati"
 msgstr "Dauer"
 
-#: studies/fields.py:115
-#, fuzzy
-#| msgid "Yes"
-msgid "Yue"
-msgstr "Ja"
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+#, fuzzy
+#| msgid "Duration"
+msgid "Marathi"
+msgstr "Dauer"
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+#, fuzzy
+#| msgid "Asian"
+msgid "Russian"
+msgstr "Asiate"
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Nicht beantwortet"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Andere"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Männlich"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Weiblich"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -843,155 +1199,68 @@ msgstr ""
 "Studien erstellen, die mit diesem Labor verknüpft sind, und kann zu den "
 "Studien dieses Labors hinzugefügt werden."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Die Benutzer, die die Teilnahme an diesem Labor beantragt haben."
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-#, fuzzy
-#| msgid "researcher login"
-msgid "For researchers"
-msgstr "Forscherlogin"
-
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Schau mal"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-#, fuzzy
-#| msgid "Contact:"
-msgid "Contact us"
-msgstr "Kontakt:"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Teilnehmen"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Melden Sie sich an, um teilzunehmen"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Melden Sie sich an, um teilzunehmen"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Was ist Ihr Geschlecht?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Dauer"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "Wir führen derzeit keine Studien durch!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Teilnehmen"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Datenschutzerklärung"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Alle Teilnehmer(innen)"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Zusätzliche Information"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Sie haben sich erfolgreich abgemeldet."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-#, fuzzy
-#| msgid "Your username and password didn't match. Please try again."
-msgid "Your login credentials didn't work. Please try again."
-msgstr ""
-"Ihr Benutzername und Ihr Passwort stimmen nicht überein. Bitte versuchen Sie "
-"es erneut."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Anmeldung"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Neu bei Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Passwort geändert"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Dein Passwort wurde geändert."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Dokumentation"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Ändere das Passwort"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Ausloggen"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Zuhause"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Passwortänderung"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Bitte korrigieren Sie den Fehler unten."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Bitte korrigieren Sie die Fehler unten."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -1000,28 +1269,28 @@ msgstr ""
 "dann Ihr neues Passwort zweimal ein, damit wir überprüfen können, ob Sie es "
 "richtig eingegeben haben."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Mein Passwort ändern"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Zurücksetzung des Passworts abgeschlossen"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Ihr Passwort wurde festgelegt. Sie können sich jetzt anmelden."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 msgid "Log in"
 msgstr "Anmeldung"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Zurücksetzung des Passworts abgeschlossen"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Ihr Passwort wurde festgelegt. Sie können sich jetzt anmelden."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Bestätigung zum Zurücksetzen des Passworts"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1029,15 +1298,7 @@ msgstr ""
 "Bitte geben Sie Ihr neues Passwort zweimal ein, damit wir überprüfen können, "
 "ob Sie es richtig eingegeben haben."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Neues Kennwort:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Bestätigen Sie das Passwort:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1045,13 +1306,13 @@ msgstr ""
 "Der Link zum Zurücksetzen des Passworts war ungültig, möglicherweise weil er "
 "bereits verwendet wurde. Bitte fordern Sie ein neues Passwort an."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset link sent"
 msgstr "Zurücksetzung des Passworts abgeschlossen"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 #, fuzzy
 #| msgid ""
 #| "We've emailed you instructions for setting your password, if an account "
@@ -1064,7 +1325,7 @@ msgstr ""
 "gesendet, falls ein Konto mit der von Ihnen eingegebenen E-Mail-Adresse "
 "vorhanden ist. Sie sollten diese in Kürze erhalten."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 #, fuzzy
 #| msgid ""
 #| "If you don't receive an email, please make sure you've entered the "
@@ -1078,11 +1339,14 @@ msgstr ""
 "eingegeben haben, unter der Sie sich registriert haben, und überprüfen Sie "
 "Ihren Spam-Ordner."
 
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Sie erhalten diese E-Mail, weil Sie ein Zurücksetzen des Passwoerts für Ihr "
 "Benutzerkonto unter %(site_name)s angefordert haben."
@@ -1095,22 +1359,25 @@ msgstr "Bitte gehen Sie zur folgenden Seite und wählen Sie ein neues Passwort:"
 msgid "Your username, in case you've forgotten:"
 msgstr "Ihr Benutzername - falls Sie vergessen haben:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Vielen Dank für die Nutzung unserer Website!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, python-format
-msgid "The %(site_name)s team"
-msgstr "Das Team von %(site_name)s"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Mein Passwort zurücksetzen"
+
+#: web/templates/registration/password_reset_form.html:8
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset"
 msgstr "Zurücksetzung des Passworts abgeschlossen"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1118,129 +1385,257 @@ msgstr ""
 "Passwort vergessen? Geben Sie unten Ihre E-Mail-Adresse ein und wir senden "
 "Ihnen Anweisungen zur Erstellung eines neuen Passworts."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "E-Mail-Addresse:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset complete"
+msgid "Password reset on Children Helping Science"
+msgstr "Zurücksetzung des Passworts abgeschlossen"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Mein Passwort zurücksetzen"
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Experimentator"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Studien"
+#: web/templates/web/_footer.html:17
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact us"
+msgstr "Kontakt:"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "FAQ"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Die Wissenschaftler"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Ressourcen"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Hallo"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Ausloggen"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "Anmelden"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Experimentator"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Kinder"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Beenden"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Kind hinzufügen"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Kind"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 #| msgid "Back to list"
 msgid "Back to Children List"
 msgstr "Zurück zur Liste"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Aktualisieren"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Löschen"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Beenden"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Sichern"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Leerer Geburtstag"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Aktualisieren"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " Tag"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " Tage"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " Monat"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " Monate"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " Jahr"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " Jahre"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Kind hinzufügen"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Form ausblenden"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Name"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Kind aktualisieren"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Name"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Keine Kinderprofile registriert!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+#, fuzzy
+#| msgid "researcher login"
+msgid "For researchers"
+msgstr "Forscherlogin"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Dokumentation"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Demografische Angaben aktualisieren"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1254,7 +1649,7 @@ msgstr ""
 "wir erreichen und wie sich Faktoren wie das Sprechen mehrerer Sprachen oder "
 "ältere Geschwister auf das Lernen von Kindern auswirken."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1264,126 +1659,1552 @@ msgstr ""
 "Werbezwecken veröffentlicht werden, werden Ihre demografischen Informationen "
 "niemals in Verbindung mit Ihrem Video veröffentlicht."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Teilnehmen"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Ihre früheren Studien"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "Wir führen derzeit keine Studien durch!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Melden Sie sich an, um teilzunehmen"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Was ist Ihr Geschlecht?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Dauer"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "In welchem Bundesland leben Sie?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "researcher login"
+msgid "For Researchers"
+msgstr "Forscherlogin"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Wie alt sind Sie?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Melden Sie sich an, um teilzunehmen"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Die Wissenschaftler"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Teilnehmen"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Zuhause"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Ich möchte kontaktiert werden, wenn:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Melden Sie sich an, um teilzunehmen"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Konto erstellen"
+
+#: web/templates/web/participant-signup.html:13
 #, fuzzy
 #| msgid "Participant account"
 msgid "Create Participant Account"
 msgstr "Teilnehmerkonto"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead?"
+msgid "instead."
+msgstr "stattdessen?"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr ""
 "Durch Klicken auf \"Konto erstellen\" stimme ich zu, dass ich ... gelesen "
 "habe und akzeptiere."
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Datenschutzerklärung"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Konto erstellen"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Datenschutzerklärung"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Alle Teilnehmer(innen)"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Zusätzliche Information"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Frühere Studien"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
 msgstr ""
-"Ihr Konto hat keinen Zugriff auf diese Seite. Um fortzufahren, melden Sie "
-"sich bitte mit einem Konto an, das Zugriff hat."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Bitte melden Sie sich an, um diese Seite zu sehen."
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Derzeitige Studien"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Ihre früheren Studien"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr "Hier können Sie Ihre Studien und Kommentare von Forschern sehen:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Studiere Thumbnail"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Teilnahmeberechtigung:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Kontakt:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Sammeln Sie noch Daten?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Ja"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Nein"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Vergütung: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Vergütung"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Studienantworten"
 
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Datum"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Zustimmungsstatus"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Genehmigt"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Ihr Einwilligungsvideo wurde von einem Forscher überprüft und ist gültig."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "steht aus"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "Ihr Einwilligungsvideo wurde noch nicht von einem Forscher überprüft."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Ungültig"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1394,160 +3215,183 @@ msgstr ""
 "Daten aus dieser Sitzung werden von den Studienforschern nicht angezeigt "
 "oder verwendet."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr "Keine Informationen zum Status der Einwilligungsvideoüberprüfung."
 
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Sie haben bisher an keiner Studie teilgenommen."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Derzeitige Studien"
-
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
-msgstr ""
-"Bitte beachten Sie, dass Sie einen Laptop oder Desktop-Computer (kein "
-"mobiles Gerät) benötigen, auf dem Chrome oder Firefox ausgeführt werden "
-"kann, um teilnehmen zu können."
-
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Siehe Einzelheiten"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "Wir führen derzeit keine Studien durch!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
-msgstr ""
-"Suchen Sie nach weiteren Möglichkeiten, um von zu Hause aus zur Forschung "
-"beizutragen? Weitere Studien finden Sie auf <a href=\"https://"
-"childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer noopener\"> "
-"Children Helping Science </a>!"
-
-#: web/templates/web/study-detail.html:53
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-#| msgid " days"
-msgid "days"
-msgstr " Tage"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Sie haben bisher an keiner Studie teilgenommen."
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Studienübersicht"
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studien"
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Zurück zur Liste"
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Zulassungskriterien"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
 
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Dauer"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Vergütung"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Was geschieht"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressourcen"
 
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Was wir studieren"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Diese Studie wird durchgeführt von"
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
 
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Möchten Sie an dieser Studie teilnehmen?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Melden Sie sich an, um teilzunehmen"
-
-#: web/templates/web/study-detail.html:142
-#, fuzzy
-#| msgid "No child profiles registered!"
-msgid "Add child profile to "
-msgstr "Keine Kinderprofile registriert!"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 #, fuzzy
 #| msgid "Participate"
 msgid "participate"
 msgstr "Teilnehmen"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Das Experiment wird geladen, um eine Vorschau anzuzeigen"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Melden Sie sich an, um teilzunehmen"
+
+#: web/templates/web/study-detail.html:22
+#, fuzzy
+#| msgid "No child profiles registered!"
+msgid "Add child profile to "
+msgstr "Keine Kinderprofile registriert!"
+
+#: web/templates/web/study-detail.html:23
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Complete demographic survey to "
 msgstr "Demografischer Fragebogen"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Teilnehmen"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Was geschieht"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Was wir studieren"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Dauer"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Diese Studie wird durchgeführt von"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Möchten Sie an dieser Studie teilnehmen?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Wählen Sie ein Kind aus:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Nichts ausgewählt"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Ihr Kind ist noch jünger als die für diese Studie empfohlene Altersspanne. "
 "Wenn Sie warten können <span id = 'warten können bis'>bis</ span> er oder "
 "sie alt genug ist, können wir die gesammelten Daten für unsere Forschung "
 "verwenden!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Ihr Kind ist älter als die für diese Studie empfohlene Altersspanne. Sie "
 "können die Studie trotzdem gerne ausprobieren, aber wir können die "
 "gesammelten Daten nicht für unsere Forschung verwenden."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Ihr Kind erfüllt die für diese Studie aufgeführten Zulassungskriterien "
 "nicht. Sie können die Studie trotzdem gerne ausprobieren, aber wir können "
 "die gesammelten Daten nicht für unsere Forschung verwenden. Bitte wenden Sie "
 "sich an die Studienforscher"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Das Experiment wird geladen, um eine Vorschau anzuzeigen"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Teilnehmen"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1556,34 +3400,269 @@ msgstr ""
 "Studienprotokolls passiert, setzen Sie ein Lesezeichen auf die URL, an die "
 "Sie über die Schaltfläche oben gesendet werden."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Anmelden"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Bitte beachten Sie, dass Sie einen Laptop oder Desktop-Computer (kein "
+"mobiles Gerät) benötigen, auf dem Chrome oder Firefox ausgeführt werden "
+"kann, um teilnehmen zu können."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 #, fuzzy
 #| msgid "Participant account"
 msgid "Participant created."
 msgstr "Teilnehmerkonto"
 
-#: web/views.py:88
+#: web/views.py:157
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Demographic data saved."
 msgstr "Demografischer Fragebogen"
 
-#: web/views.py:156
+#: web/views.py:223
 #, fuzzy
 #| msgid "Children"
 msgid "Child added."
 msgstr "Kinder"
 
-#: web/views.py:217
+#: web/views.py:264
+#, fuzzy
+#| msgid "Children"
+msgid "Child deleted."
+msgstr "Kinder"
+
+#: web/views.py:266
+#, fuzzy
+#| msgid "Children"
+msgid "Child updated."
+msgstr "Kinder"
+
+#: web/views.py:294
 #, fuzzy
 #| msgid "Email Preferences"
 msgid "Email preferences saved."
 msgstr "E-Mail Präferenzen"
 
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "Mit welcher/n Kategorie(n) identifiziert sich Ihre Familie?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Nur numerische Antworten - eine grobe Einschätzung ist in Ordnung!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Welche Sprache(n) spricht Ihre Familie zu Hause?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr ""
+#~ "Was ist das höchste Bildungsniveau, das Ihr(e) Ehepartner(in) "
+#~ "abgeschlossen hat?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Wie viele Kinderbücher haben Sie zu Hause?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Wenn die Antwort aufgrund von Sorgerechtsvereinbarungen oder Reisen "
+#~ "unterschiedlich ist, geben Sie bitte die Anzahl der Elternteile/"
+#~ "Erziehungsberechtigten ein, mit denen Ihre Kinder normalerweise "
+#~ "zusammenleben, oder erklären Sie dies."
+
+#~ msgid "other"
+#~ msgstr "andere"
+
+#~ msgid "3 or more"
+#~ msgstr "3 oder mehr"
+
+#~ msgid "varies"
+#~ msgstr "variiert"
+
+#~ msgid "My Account"
+#~ msgstr "Mein Konto"
+
+#~ msgid "Last Active:"
+#~ msgstr "Letzte Aktivität:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "Allgemeine ID des Teilnehmers:"
+
+#~ msgid "Dashboard"
+#~ msgstr "Dashboard"
+
 #, fuzzy
-#~| msgid "instead?"
-#~ msgid "instead"
-#~ msgstr "stattdessen?"
+#~| msgid "Yes"
+#~ msgid "Yue"
+#~ msgstr "Ja"
+
+#~ msgid "Lookit"
+#~ msgstr "Schau mal"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Melden Sie sich an, um teilzunehmen"
+
+#, fuzzy
+#~| msgid "Your username and password didn't match. Please try again."
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr ""
+#~ "Ihr Benutzername und Ihr Passwort stimmen nicht überein. Bitte versuchen "
+#~ "Sie es erneut."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Neu bei Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Neues Kennwort:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Bestätigen Sie das Passwort:"
+
+#, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "Das Team von %(site_name)s"
+
+#~ msgid "Email address:"
+#~ msgstr "E-Mail-Addresse:"
+
+#~ msgid "FAQ"
+#~ msgstr "FAQ"
+
+#~ msgid "Hi"
+#~ msgstr "Hallo"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Leerer Geburtstag"
+
+#~ msgid " day"
+#~ msgstr " Tag"
+
+#~ msgid " days"
+#~ msgstr " Tage"
+
+#~ msgid " month"
+#~ msgstr " Monat"
+
+#~ msgid " months"
+#~ msgstr " Monate"
+
+#~ msgid " year"
+#~ msgstr " Jahr"
+
+#~ msgid " years"
+#~ msgstr " Jahre"
+
+#~ msgid "Hide Form"
+#~ msgstr "Form ausblenden"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Ihr Konto hat keinen Zugriff auf diese Seite. Um fortzufahren, melden Sie "
+#~ "sich bitte mit einem Konto an, das Zugriff hat."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Bitte melden Sie sich an, um diese Seite zu sehen."
+
+#~ msgid "Compensation: "
+#~ msgstr "Vergütung: "
+
+#~ msgid "Current Studies"
+#~ msgstr "Derzeitige Studien"
+
+#~ msgid "See details"
+#~ msgstr "Siehe Einzelheiten"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Wir führen derzeit keine Studien durch!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Suchen Sie nach weiteren Möglichkeiten, um von zu Hause aus zur Forschung "
+#~ "beizutragen? Weitere Studien finden Sie auf <a href=\"https://"
+#~ "childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
+#~ "noopener\"> Children Helping Science </a>!"
+
+#, fuzzy
+#~| msgid " days"
+#~ msgid "days"
+#~ msgstr " Tage"
+
+#~ msgid "Study overview"
+#~ msgstr "Studienübersicht"
+
+#~ msgid "Back to list"
+#~ msgstr "Zurück zur Liste"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Zulassungskriterien"
 
 #, fuzzy
 #~| msgid "Birthday"
@@ -1668,6 +3747,3 @@ msgstr "E-Mail Präferenzen"
 
 #~ msgid "Signup"
 #~ msgstr "Anmelden"
-
-#~ msgid "Update account information"
-#~ msgstr "Kontoinformation aktualisieren"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -3324,10 +3324,8 @@ msgstr "Dauer"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Diese Studie wird durchgeführt von"
+msgstr "Diese Studie wird durchgeführt von %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -4339,10 +4339,8 @@ msgstr "Duración"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Este estudio es realizado por"
+msgstr "Este estudio es realizado por %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-15 17:12+0200\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr ""
 "Ingrese una contraseña válida de un solo uso con 6 dígitos de Google "
@@ -33,42 +33,24 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "Esta cuenta está inactiva."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr "Tu contraseña no puede ser muy similar a la información personal."
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "Tu contraseña debe contener al menos 16 caracteres."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "Tu contraseña no puede ser una contraseña de uso común."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "Tu contraseña no puede ser completamente numérica."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Dirección e-mail"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Apodo"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "Es la hora de otra sesión de un estudio en el que estamos participando"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Un nuevo estudio está disponible para uno/a de mis hijos/as"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -76,7 +58,7 @@ msgstr ""
 "Hay notificaciones sobre un estudio en el que hemos participado (por "
 "ejemplo, se han publicado los resultados)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -84,100 +66,92 @@ msgstr ""
 "Un/a investigador/a tiene preguntas sobre mis respuestas individuales (por "
 "ejemplo, si notifico un problema técnico durante el estudio)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "¿Con qué categoría(s) se identifica tu familia?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "País"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Introduce una lista separada por comas: AAAA-MM-DD, AAAA-MM-DD"
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Sólo respuestas numéricas - ¡una aproximación es suficiente!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "¿Cuál es vuestro país de residencia?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "¿En qué provincia vivís?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "¿Cómo describirías la zona donde vivís?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "¿Qué idioma(s) habla vuestra familia en casa?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "¿Cuántos hijos/as tienes?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Para cada niño/a, introduce su fecha de nacimiento:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "¿Con cuántos/as madres/padres/tutores/as viven tus hijos?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "¿Qué edad tienes?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "¿Cuál es tu género?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "¿Cuál es tu género?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "¿Cuál es el máximo nivel educativo que has completado?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "¿Cuál es el máximo nivel educativo que ha completado tu pareja?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "¿Cuáles son vuestros ingresos anuales aproximados (en euros)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Aproximadamente ¿cuántos libros infantiles hay en vuestra casa?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "¿Te gustaría decirnos algo más?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "¿Cómo has conocido Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Si la respuesta varía debido a asuntos de custodia compartida o viajes, "
-"introduce el número de madres/padres/tutores con los que viven habitualmente "
-"tus hijos/as o explícanoslo."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Fecha de nacimiento"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Otra etnia u origen"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -187,33 +161,36 @@ msgstr ""
 "en un estudio. Nunca publicamos las fechas de nacimiento de los/as niños/as "
 "ni información que permita al lector calcular la fecha de nacimiento."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Las fechas de nacimiento no pueden ser en el futuro."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Nombre"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Fecha de nacimiento"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Género"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Semanas de gestación al nacer"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Cualquier información adicional que te gustaría que supiéramos"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Características y condiciones"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -221,7 +198,7 @@ msgstr ""
 "Idiomas a los que el/la niño/a está expuesto/a en casa, la escuela o con "
 "otro/a cuidador/a."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -234,511 +211,600 @@ msgstr ""
 "un nuevo estudio disponible para María!\") pero nunca publicaremos nombres "
 "ni los usaremos en nuestra investigación."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Por ejemplo, trastornos del desarrollo diagnosticados o problemas de visión "
 "o audición"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Redondea a la semana completa de embarazo completada más cercana"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Estudios"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Estudios actuales"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+#, fuzzy
+#| msgid "Meet the Lookit team"
+msgid "here on the Lookit platform"
+msgstr "Conoce al equipo de Lookit"
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Sus estudios anteriores"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Estudios actuales"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "No estoy seguro/a o prefiero no contestar"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Menos de 24 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 o más semanas"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Puede ver la organización"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Puede editar la organización"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Puede crear la organización"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Puede eliminar la organización"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Puede ver el experimentador"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Puede ver los análisis"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Puede crear un usuario"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Puede ver al usuario"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Puede editar al usuario"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Puede eliminar al usuario"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Puede ver los permisos de usuario"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Puede editar permisos de usuario"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Puede leer todos los datos de usuario"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Puede leer los nombres de usuario de los usuarios"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "masculino"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "femenino"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "otro"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "prefiero no responder"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Puede ver la organización"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Puede editar la organización"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Puede crear la organización"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Puede eliminar la organización"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Puede ver el experimentador"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Puede ver los análisis"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Puede crear un usuario"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Puede ver al usuario"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Puede editar al usuario"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Puede eliminar al usuario"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Puede ver los permisos de usuario"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Puede editar permisos de usuario"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Puede leer todos los datos de usuario"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Puede leer los nombres de usuario de los usuarios"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Blanco"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Origen hispano, latino"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Negro/a o afroamericano/a"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asiático/a"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Indio/a americano/a o nativo/a de Alaska"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Medio Oriente o África del Norte"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Nativo/a de Hawai u otra isla del Pacífico"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Otra etnia u origen"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "alguno o asistiendo a la Educación Secundaria Obligatoria (ESO)"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "título de graduado en Educación Secundaria Obligatoria (ESO)"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "alguno o asistiendo a la universidad"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "título universitario"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "título de Formación Profesional"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "algunos o asistiendo a una escuela de Formación Profesional"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "título de Máster o posgrado"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "no aplicable - sin cónyuge o pareja"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Mas de 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "menores de 18 años"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 o más"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 o más"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "varía"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "más de 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "urbano"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "afueras"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "rural"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Selecciona una provincia"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "Gan"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Información de la cuenta"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "Cambia tus credenciales de inicio de sesión y/o apodo."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Encuesta demográfica"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Cuéntenos más sobre usted."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Información sobre los/as niños/as"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Agregue o edite la información del/de la participante."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Preferencias de correo electrónico"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Edite cuándo puede ser contactado/a."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:38 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Mi cuenta"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Información de la cuenta"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Guardar"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Cambiar su contraseña"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "Gestionar la autenticación de dos factores"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -747,11 +813,18 @@ msgstr ""
 "¡Simplemente introduce aquí tu contraseña de un solo uso, presiona enviar y "
 "se eliminará!"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "Configurar la autenticación de dos factores"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Todos los/as participantes"
 
@@ -759,146 +832,63 @@ msgstr "Todos los/as participantes"
 msgid "Participant ID"
 msgstr "ID de participante"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Activo por última vez:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "ID global de participante:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Niños/as"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Edad"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Información adicional"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "¡No hay perfiles de niños/as registrados!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Últimos datos demográficos"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "País"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Provincia"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Descripción del área"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Idiomas que se hablan en casa"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Número de niños/as"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Edad actual de los/as niños/as"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Respuestas del estudio"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Número de tutores/as"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Explicación sobre tutores/as:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Etnia"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Panel de control"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "Alemán"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "Inglés"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "Español"
-
-#: project/settings.py:231
-msgid "Argentinian Spanish"
-msgstr "Español argentino"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "Francés"
-
-#: project/settings.py:233
-msgid "Canadian French"
-msgstr "Francés canadiense"
-
-#: project/settings.py:234
-msgid "Hebrew"
-msgstr "Hebreo"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "Italiano"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "Japonés"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "Coreano"
-
-#: project/settings.py:238
-msgid "Norwegian Bokmål"
-msgstr "Noruego bokmål"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "Polaco"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "Portugués"
-
-#: project/settings.py:241
-msgid "Brazilian Portuguese"
-msgstr "Portugués brasileño"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "Rumano"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "Ruso"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "Turco"
-
-#: project/settings.py:245
-msgid "Simplified Chinese"
-msgstr "Chino simplificado"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "Holandés"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -948,6 +938,10 @@ msgstr "Septillizo"
 msgid "Octuplet"
 msgstr "Octillizos"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "Inglés"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "Amárico"
@@ -972,13 +966,25 @@ msgstr "Cebuano"
 msgid "Chhattisgarhi"
 msgstr "Chhattisgarhi"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "Holandés"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "Árabe egipcio hablado"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "Francés"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "Gan"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "Alemán"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -993,162 +999,204 @@ msgid "Hausa"
 msgstr "Hausa"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr "Hebreo"
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "Hindi"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "Igbo"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "Indonesio"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "Persa iraní"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "Italiano"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "Japonés"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "Javanés"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "Jinyu"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "Canarés"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "Jemer"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "Coreano"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "Magahi"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "Maithili"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "Malayo"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "Mandarín"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "Marathi"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "Min Nan"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "Árabe marroquí hablado"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "Pastún del norte"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "Uzbeko del norte"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "Odia"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "Polaco"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "Portugués"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "Rumano"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "Ruso"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "Saraiki"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "Somalí"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "Español"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "Sunda"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "Tagalo"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "Tamil"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "Telugu"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "Tailandés"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "Turco"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "Ucranio"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "Urdu"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "Punjabi occidental"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "Wu"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "Xiang chino"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "Yue"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "No respondido"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Otro"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Masculino"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Femenino"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -1157,35 +1205,204 @@ msgstr ""
 "laboratorio podrá crear estudios asociados con este laboratorio y ser "
 "añadido/a a estudios de este laboratorio."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Ususarios/as que han solicitado unirse a este laboratorio."
 
-#: web/templates/frontpages/contact.html:15
-msgid "Technical difficulties"
-msgstr "Dificultades técnicas"
+#: web/templates/registration/logged_out.html:5
+msgid "You've successfully logged out."
+msgstr "Has cerrado la sesión correctamente."
 
-#: web/templates/frontpages/contact.html:17
-msgid "Questions about the studies"
-msgstr "Preguntas sobre los estudios"
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
+msgid "Login"
+msgstr "Iniciar sesión"
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-msgid "For researchers"
-msgstr "Para personal de investigación"
+#: web/templates/registration/login.html:25
+msgid "Forgot password?"
+msgstr "¿Has olvidado tu contraseña?"
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:16 web/templates/web/_navigation.html:21
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/frontpages/default.html:53
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr "¡Registra tu familia!"
+
+#: web/templates/registration/password_change_done.html:9
+msgid "Password changed"
+msgstr "Contraseña cambiada"
+
+#: web/templates/registration/password_change_done.html:12
+msgid "Your password was changed."
+msgstr "Tu contraseña se ha cambiado."
+
+#: web/templates/registration/password_change_form.html:12
+msgid "Documentation"
+msgstr "Documentación"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Change password"
+msgstr "Cambia la contraseña"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Log out"
+msgstr "Cerrar sesión"
+
+#: web/templates/registration/password_change_form.html:18
+msgid "Home"
+msgstr "Inicio"
+
+#: web/templates/registration/password_change_form.html:19
+msgid "Password change"
+msgstr "Cambio de contraseña"
+
+#: web/templates/registration/password_change_form.html:36
+msgid "Please correct the error below."
+msgstr "Por favor, corrige el error a continuación."
+
+#: web/templates/registration/password_change_form.html:38
+msgid "Please correct the errors below."
+msgstr "Por favor, corrige los errores a continuación."
+
+#: web/templates/registration/password_change_form.html:43
+msgid ""
+"Please enter your old password, for security's sake, and then enter your new "
+"password twice so we can verify you typed it in correctly."
+msgstr ""
+"Introduce su contraseña anterior, por motivos de seguridad, y luego "
+"introduzca su nueva contraseña dos veces para que podamos verificar que la "
+"ingresó correctamente."
+
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
+msgid "Change my password"
+msgstr "Cambiar mi contraseña"
+
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "Iniciar sesión"
+
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Restablecimiento de contraseña completado"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr ""
+"Tu contraseña ha sido establecida. Puedes continuar e iniciar sesión ahora."
+
+#: web/templates/registration/password_reset_confirm.html:8
+msgid "Password reset confirmation"
+msgstr "Confirmación de restablecimiento de contraseña"
+
+#: web/templates/registration/password_reset_confirm.html:11
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly."
+msgstr ""
+"Introduce tu nueva contraseña dos veces para que podamos verificar que la "
+"has introducido correctamente."
+
+#: web/templates/registration/password_reset_confirm.html:21
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+"El enlace de restablecimiento de contraseña no es válido, posiblemente "
+"porque ya se ha utilizado. Por favor, solicita un nuevo restablecimiento de "
+"contraseña."
+
+#: web/templates/registration/password_reset_done.html:6
+msgid "Password reset link sent"
+msgstr "Se envió el enlace para restablecer la contraseña"
+
+#: web/templates/registration/password_reset_done.html:9
+msgid ""
+"If an account exists with the email you entered, we've emailed instructions "
+"for resetting your password and you should receive them shortly."
+msgstr ""
+"Si existe una cuenta con el correo electrónico que has ingresado, te "
+"enviaremos instrucciones por correo electrónico para restablecer tu "
+"contraseña y deberías recibirlas en breve."
+
+#: web/templates/registration/password_reset_done.html:12
+msgid ""
+"If you don't receive an email, please check your spam folder and make sure "
+"you've entered the address you registered with. (You won't get an email "
+"unless there's already an account for that email address!)"
+msgstr ""
+"Si no recibes un correo electrónico, verifica tu carpeta de correo no "
+"deseado y asegúrate de haber ingresado la dirección con la que te has "
+"registrado. (¡No recibirás un correo electrónico a menos que ya haya una "
+"cuenta para esa dirección de correo electrónico!)"
+
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at Children Helping Science."
+msgstr ""
+"Recibiste este correo electrónico porque has solicitado un restablecimiento "
+"de contraseña para tu cuenta de usuario/a en %(site_name)s."
+
+#: web/templates/registration/password_reset_email.html:4
+msgid "Please go to the following page and choose a new password:"
+msgstr "Ve a la página siguiente y elige una nueva contraseña:"
+
+#: web/templates/registration/password_reset_email.html:8
+msgid "Your username, in case you've forgotten:"
+msgstr "Tu nombre de usuario/a, en caso de que lo hayas olvidado:"
+
+#: web/templates/registration/password_reset_email.html:9
+msgid "Thanks for using our site!"
+msgstr "¡Gracias por usar nuestra página web!"
+
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Restablecer mi contraseña"
+
+#: web/templates/registration/password_reset_form.html:8
+msgid "Password reset"
+msgstr "Restablecimiento de contraseña"
+
+#: web/templates/registration/password_reset_form.html:11
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll email "
+"instructions for setting a new one."
+msgstr ""
+"¿Olvidaste tu contraseña? Introduce tu dirección de correo electrónico a "
+"continuación y te enviaremos las instrucciones para configurar una nueva."
+
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "Se envió el enlace para restablecer la contraseña"
+
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
 msgid ""
 "This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
 "findings, and conclusions or recommendations expressed in this material are "
 "those of the authors(s) and do not necessarily reflect the views of the "
 "National Science Foundation."
@@ -1199,48 +1416,304 @@ msgstr ""
 "no reflejan necesariamente los puntos de vista de la National Science "
 "Foundation."
 
-#: web/templates/frontpages/default.html:58 web/templates/frontpages/home.html:48
+#: web/templates/web/_footer.html:14
 msgid "Privacy"
 msgstr "Privacidad"
 
-#: web/templates/frontpages/default.html:59 web/templates/frontpages/home.html:49
+#: web/templates/web/_footer.html:17
 msgid "Contact us"
 msgstr "Contáctenos"
 
-#: web/templates/frontpages/default.html:60
+#: web/templates/web/_footer.html:20
 msgid "Connect"
 msgstr "Conectar"
 
-#: web/templates/frontpages/faq.html:11
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr "Cerrar sesión"
+
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Experimentador"
+
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Niños/as"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Agregar niño/a"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr "Niño"
+
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr "Volver a la lista de niños/as"
+
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr "Eliminar"
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Guardar"
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Actualizar"
+
+#: web/templates/web/children-list.html:9
+msgid "Update child"
+msgstr "Actualizar niño/a"
+
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nombre"
+
+#: web/templates/web/children-list.html:64
+msgid "No child profiles registered!"
+msgstr "¡No hay perfiles de niños/as registrados/as!"
+
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr "Dificultades técnicas"
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr "Preguntas sobre los estudios"
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr "Para personal de investigación"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Documentación"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
+msgid "Update demographics"
+msgstr "Actualizar datos demográficos"
+
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
+msgid ""
+"One reason we are developing Internet-based experiments is to represent a "
+"more diverse group of families in our research. Your answers to these "
+"questions will help us understand what audience we reach, as well as how "
+"factors like speaking multiple languages or having older siblings affect "
+"children's learning."
+msgstr ""
+"Una de las razones por la que estamos desarrollando experimentos on-line es "
+"para representar a un grupo más plural de familias en nuestra investigación. "
+"Sus respuestas a estas preguntas nos ayudarán a comprender a qué población "
+"llegamos, y cómo factores como hablar varios idiomas o tener hermanos "
+"mayores afectan el aprendizaje de los/as niños/as."
+
+#: web/templates/web/demographic-data-update.html:47
+msgid ""
+"Even if you allow your study videos to be published for scientific or "
+"publicity purposes, your demographic information is never published in "
+"conjunction with your video."
+msgstr ""
+"Incluso si permite que sus vídeos del estudio se publiquen con fines "
+"científicos o publicitarios, su información demográfica nunca será publicada "
+"junto con su vídeo."
+
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
 msgid "Frequently Asked Questions"
 msgstr "Preguntas más frecuentes"
 
-#: web/templates/frontpages/faq.html:16
+#: web/templates/web/faq.html:12
 msgid "Participation"
 msgstr "Participación"
 
-#: web/templates/frontpages/faq.html:20
+#: web/templates/web/faq.html:22
 msgid "What is a 'study' about cognitive development?"
 msgstr "¿Qué es un \"estudio\" sobre desarrollo cognitivo?"
 
-#: web/templates/frontpages/faq.html:25
+#: web/templates/web/faq.html:30
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Cognitive development is the science "
+#| "of what kids understand and how they learn. Researchers in cognitive "
+#| "development are interested in questions like...</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li>what knowledge and abilities "
+#| "infants are born with, and what they have to learn from experience</li>\n"
+#| "                                    <li>how abilities like mathematical "
+#| "reasoning are organized and how they develop over time</li>\n"
+#| "                                    <li>what strategies children use to "
+#| "learn from the wide variety of data they observe</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>A study is meant to answer a very "
+#| "specific question about how children learn or what they know: for "
+#| "instance, 'Do three-month-olds recognize their parents' faces?'</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Cognitive development is the science of "
-"what kids understand and how they learn. Researchers in cognitive "
-"development are interested in questions like...</p>\n"
-"                                <ul>\n"
-"                                    <li>what knowledge and abilities infants "
-"are born with, and what they have to learn from experience</li>\n"
-"                                    <li>how abilities like mathematical "
-"reasoning are organized and how they develop over time</li>\n"
-"                                    <li>what strategies children use to "
-"learn from the wide variety of data they observe</li>\n"
-"                                </ul>\n"
-"                                <p>A study is meant to answer a very "
-"specific question about how children learn or what they know: for instance, "
-"'Do three-month-olds recognize their parents' faces?'</p>\n"
-"                                "
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
 msgstr ""
 "\n"
 "        \t\t\t\t\t\t\t\t<p>El Desarrollo Cognitivo es la ciencia que "
@@ -1261,92 +1734,266 @@ msgstr ""
 "\"</p>\n"
 "        \t\t\t\t\t\t\t"
 
-#: web/templates/frontpages/faq.html:40
-msgid "How can we participate online?"
-msgstr "¿Cómo podemos participar on-line?"
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
 
-#: web/templates/frontpages/faq.html:45
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
 msgid ""
 "\n"
 "                            <p>If you have a child and would like to "
-"participate, create an account and take a look at what we have available for "
-"your child's age range. You'll need a working webcam to participate.</p>\n"
-"                                <p>When you select a study, you'll be asked "
-"to read a consent form and record yourself stating that you and your child "
-"agree to participate. Then we'll guide you through what will happen during "
-"the study. Depending on your child's age, your child may answer questions "
-"directly or we may be looking for indirect signs of what she thinks is going "
-"on--like how long she looks at a surprising outcome.</p>\n"
-"                                <p>Some portions of the study will be "
-"automatically recorded using your webcam and sent securely to the Lookit "
-"platform. Trained researchers will watch the video and record your child's "
-"responses--for instance, which way he pointed, or how long she looked at "
-"each image. We'll put these together with responses from lots of other "
-"children to learn more about how kids think!</p>\n"
-"                            "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
 msgstr ""
-"\n"
-"        \t\t\t\t\t\t\t\t<p>Si tienes un/a hijo/a y te gustaría participar, "
-"crea una cuenta y echa un vistazo a los estudios que tenemos disponibles "
-"para el rango de edad de tu hijo/a. Necesitarás una webcam que funcione para "
-"participar.</p>\n"
-"        \t\t\t\t\t\t\t\t<p>Cuando selecciones un estudio te pediremos que "
-"leas un consentimiento informado y te grabes declarando que tú y tu hijo/a "
-"aceptáis participar. Después os explicaremos lo que haréis durante el "
-"estudio. Dependiendo de su edad, tu hijo/a responderá las preguntas "
-"directamente o buscará pistas indirectas de lo que piensa que ocurrirá--como "
-"por ejemplo cuánto tiempo mira hacia un evento sorprendente.</p>\n"
-"        \t\t\t\t\t\t\t\t<p>Algunas partes del estudio serán grabadas "
-"automáticamente utilizando vuestra webcam y se enviarán de forma segura a la "
-"plataforma de Lookit. Investigadores/as entrenados/as verán el video y "
-"registrarán las respuestas de tu hijo/a--por ejemplo, hacia qué lado señala "
-"o cuánto tiempo mira a cada imagen. ¡Juntaremos estas respuestas con "
-"respuestas de muchos otros niños/as para conocer más sobre cómo piensan los "
-"bebés!</p>\n"
-"        \t\t\t\t\t\t\t"
 
-#: web/templates/frontpages/faq.html:56
-msgid "Who can create studies on Lookit?"
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Who can create studies on Lookit?"
+msgid "Who creates the studies?"
 msgstr "¿Quién puede crear estudios en Lookit?"
 
-#: web/templates/frontpages/faq.html:61
+#: web/templates/web/faq.html:114
+#, python-format
 msgid ""
-"Any researcher with questions about how kids learn and grow can propose a "
-"Lookit study! Each institution using Lookit has to sign a contract with MIT "
-"where they agree to the <a href='/termsofuse'>Terms of Use</a> and certify "
-"that their studies will be reviewed and approved by an institutional review "
-"board. Studies are also subject to approval by Lookit. As of June 2020 we "
-"have agreements with 20 universities!"
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
 msgstr ""
-"¡Cualquier investigador/a con preguntas sobre cómo aprenden y crecen los/as "
-"niños/as puede proponer un estudio en Lookit! Cada institución que utilice "
-"Lookit debe firmar un contrato con el MIT donde aceptan los <a href='/"
-"termsofuse'>Términos de Uso</a> y certificar que sus estudios serán "
-"revisados y aprobados por un comité revisor institucional. Los estudios "
-"serán aprobados por Lookit. ¡Lookit tiene acuerdos con 20 universidades "
-"desde junio de 2020!"
 
-#: web/templates/frontpages/faq.html:69
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+msgid "Why are you running studies online instead of in person?"
+msgstr ""
+"¿Por qué realizáis estos estudios on-line, en lugar de hacerlo en persona?"
+
+#: web/templates/web/faq.html:159
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <ul>\n"
+#| "                                    <li>Make it easier for you to take "
+#| "part in research, especially for families without a stay-at-home parent</"
+#| "li>\n"
+#| "                                    <li>Work with more kids when needed--"
+#| "right now a limiting factor in designing studies is the time it takes to "
+#| "recruit participants</li>\n"
+#| "                                    <li>Draw conclusions from a more "
+#| "representative population of families--not just those who live near a "
+#| "university and are able to visit the lab during the day.\n"
+#| "                                    </li>\n"
+#| "                                    <li>Make it easier for families to "
+#| "continue participating in longitudinal studies, which may involve "
+#| "multiple testing sessions separated by months or years</li>\n"
+#| "                                    <li>Observe more natural behavior "
+#| "because children are at home rather than in an unfamiliar place</li>\n"
+#| "                                    <li>Create a system for learning "
+#| "about special populations--for instance, children with specific "
+#| "developmental disorders</li>\n"
+#| "                                    <li>Make the procedures we use in "
+#| "doing research more transparent, and make it easier to replicate our "
+#| "findings</li>\n"
+#| "                                    <li>Communicate with families about "
+#| "the research we're doing and what we can learn from it</li>\n"
+#| "                                </ul>\n"
+#| "                                "
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+"\n"
+"<ul>\n"
+"        \t\t\t\t\t\t\t\t\t<li>Facilitar vuestra participación en nuestros "
+"estudios, especialmente la de familias en las que ningún adulto se queda en "
+"casa durante los días entre semana.</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>Trabajar con más niños/as cuando se necesite--"
+"ahora mismo uno de los factores que más limitan el diseño de un estudios es "
+"el tiempo que se tarda en reclutar participantes.</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>Extraer conclusiones desde una población de "
+"familias más representativa-- no solo incluyendo aquellas familias que viven "
+"cerca de la universidad y pueden visitar el laboratorio durante el día.\n"
+"        \t\t\t\t\t\t\t\t\t</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>Facilitar que las familias continúen "
+"participando en nuestros estudios longitudinales, lo cual requiere que "
+"participen en más de una sesión, a veces separadas por meses o años.</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>Observar comportamientos más naturales gracias "
+"a que los/as niños/as se encuentren en casa en lugar de en un lugar "
+"desconocido, como un laboratorio.</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>Crear un sistema para aprender sobre "
+"poblaciones especiales--por ejemplo, niños/as con problemas específicos del "
+"desarrollo.</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>Hacer los procedimientos que utilizamos en "
+"nuestros estudios más transparentes y hacer nuestros resultados más fáciles "
+"de replicar.</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>Comunicar a las familias nuestra labor "
+"investigadora y sobre lo que aprendemos de ella.</li>\n"
+"        \t\t\t\t\t\t\t\t</ul>\n"
+"                                "
+
+#: web/templates/web/faq.html:184
 msgid "How do we provide consent to participate?"
 msgstr "¿Cómo podemos dar nuestro consentimiento para participar?"
 
-#: web/templates/frontpages/faq.html:74
+#: web/templates/web/faq.html:191
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Rather than having the parent or legal "
+#| "guardian sign a form, we ask that you read aloud (or sign in ASL) a "
+#| "statement of consent which is recorded using your webcam. This statement "
+#| "holds the same weight as a signed form, but should be less hassle for "
+#| "you. It also lets us verify that you understand written English and that "
+#| "you understand you're being videotaped.</p>\n"
+#| "                                <p>Researchers watch these consent videos "
+#| "on a special page of the researcher interface, and record for each one "
+#| "whether the video shows informed consent. They cannot view other video or "
+#| "download data from a session unless they have confirmed that you "
+#| "consented to participate! If they see a consent video that does NOT "
+#| "clearly demonstrate informed consent--for instance, there was a technical "
+#| "problem and there's no audio--they may contact you to check, depending on "
+#| "your email settings.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Rather than having the parent or legal "
-"guardian sign a form, we ask that you read aloud (or sign in ASL) a "
-"statement of consent which is recorded using your webcam. This statement "
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
 "holds the same weight as a signed form, but should be less hassle for you. "
 "It also lets us verify that you understand written English and that you "
 "understand you're being videotaped.</p>\n"
-"                                <p>Researchers watch these consent videos on "
-"a special page of the researcher interface, and record for each one whether "
-"the video shows informed consent. They cannot view other video or download "
-"data from a session unless they have confirmed that you consented to "
-"participate! If they see a consent video that does NOT clearly demonstrate "
-"informed consent--for instance, there was a technical problem and there's no "
-"audio--they may contact you to check, depending on your email settings.</p>\n"
-"                                "
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
 msgstr ""
 "\n"
 "        \t\t\t\t\t\t\t\t<p>En lugar de pedir a un padre/madre o tutor que "
@@ -1366,39 +2013,59 @@ msgstr ""
 "dependiendo de vuestros ajustes de email.</p>\n"
 "        \t\t\t\t\t\t\t\t"
 
-#: web/templates/frontpages/faq.html:80
-msgid "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-msgstr ""
-"https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-
-#: web/templates/frontpages/faq.html:89
+#: web/templates/web/faq.html:215
 msgid "How is our information kept secure and confidential?"
 msgstr "¿Cómo se mantiene nuestra información segura y confidencial?"
 
-#: web/templates/frontpages/faq.html:94
+#: web/templates/web/faq.html:223
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>\n"
+#| "                                Researchers using Lookit agree to uphold "
+#| "a common set of standards about how data is protected and shared. For "
+#| "instance, they never publish children's names or birthdates, or "
+#| "information that could be used to calculate a birthdate.</p>\n"
+#| "                                <p>The Lookit researcher interface is "
+#| "designed with participant data protection as the top priority. For "
+#| "instance, a special interface lets researchers confirm consent videos "
+#| "before they are able to download any other data from your session. "
+#| "Research groups can control who has access to what data in a very fine-"
+#| "grained way, for instance allowing an assistant to confirm consent and "
+#| "send gift cards, but not download study data.</p>\n"
+#| "                                <p>All of your data, including video, is "
+#| "transmitted over a secure HTTPS connection to Lookit storage, and is "
+#| "encrypted at rest. We take security very seriously; in addition to making "
+#| "sure any software we use is up-to-date, cloud servers are configured "
+#| "securely, and unit tests cover checking that accessing data requires "
+#| "correct permissions, we conducted a risk assessment and detailed manual "
+#| "penetration testing with a security contractor prior to our 2020 launch.</"
+#| "p>\n"
+#| "                                <p>See also 'Who will see our video?'</"
+#| "p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>\n"
-"                                Researchers using Lookit agree to uphold a "
-"common set of standards about how data is protected and shared. For "
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
 "instance, they never publish children's names or birthdates, or information "
 "that could be used to calculate a birthdate.</p>\n"
-"                                <p>The Lookit researcher interface is "
-"designed with participant data protection as the top priority. For instance, "
-"a special interface lets researchers confirm consent videos before they are "
-"able to download any other data from your session. Research groups can "
-"control who has access to what data in a very fine-grained way, for instance "
-"allowing an assistant to confirm consent and send gift cards, but not "
-"download study data.</p>\n"
-"                                <p>All of your data, including video, is "
-"transmitted over a secure HTTPS connection to Lookit storage, and is "
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
 "encrypted at rest. We take security very seriously; in addition to making "
 "sure any software we use is up-to-date, cloud servers are configured "
 "securely, and unit tests cover checking that accessing data requires correct "
-"permissions, we conducted a risk assessment and detailed manual penetration "
-"testing with a security contractor prior to our 2020 launch.</p>\n"
-"                                <p>See also 'Who will see our video?'</p>\n"
-"                                "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
 msgstr ""
 "\n"
 "        \t\t\t\t\t\t\t\t<p>\n"
@@ -1428,35 +2095,106 @@ msgstr ""
 "        \t\t\t\t\t\t\t\t<p>Ver también '¿Quién verá nuestro vídeo?'</p>\n"
 "        \t\t\t\t\t\t\t"
 
-#: web/templates/frontpages/faq.html:107
+#: web/templates/web/faq.html:239
 msgid "Who will see our video?"
 msgstr "¿Quién verá nuestro vídeo?"
 
-#: web/templates/frontpages/faq.html:112
+#: web/templates/web/faq.html:246
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Lookit staff at MIT will have access "
+#| "to your video and other data in order to improve and promote the platform "
+#| "and help with troubleshooting. The researchers running the study you "
+#| "participated in will also have access to your video and other data (like "
+#| "responses to questions during the study, and information you fill out "
+#| "when registering a child) for research purposes. They will watch the "
+#| "video segments you send to mark down information specific to the study--"
+#| "for instance, what your child said, or how long he/she looked to the left "
+#| "versus the right of the screen. This research group may be at MIT or at "
+#| "another institution. All studies run on Lookit must be approved by an "
+#| "Institutional Review Board (IRB) that ensures participants' rights and "
+#| "welfare are protected. All researchers using Lookit also agree to Terms "
+#| "of Use that govern what data they can share and what sorts of studies are "
+#| "okay to run on Lookit; these rules are sometimes stricter than their own "
+#| "institution might be.  </p>\n"
+#| "                                <p>Whether anyone else may view the video "
+#| "depends on the privacy settings you select at the end of the study. There "
+#| "are two decisions to make: whether to share your data with Databrary, and "
+#| "how to allow your video clips to be used by the researchers you have "
+#| "selected.</p>\n"
+#| "                                <p>First, we ask if you would like to "
+#| "share your data (including video) with authorized users fo the secure "
+#| "data library Databrary. Data sharing will lead to faster progress in "
+#| "research on human development and behavior. Researchers who are granted "
+#| "access to the Databrary library must agree to treat the data with the "
+#| "same high standard of care they would use in their own laboratories. "
+#| "Learn more about Databrary's <a href=\"https://databrary.org/about."
+#| "html\">mission</a> or the <a href=\"https://databrary.org/about/agreement."
+#| "html\">requirements for authorized users</a>.</p>\n"
+#| "                                <p>Next, we ask what types of uses of "
+#| "your video are okay with you.</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li><strong>Private</strong> This "
+#| "privacy level ensures that your video clips will be viewed only by "
+#| "authorized scientists (Lookit staff, the research group running the study "
+#| "and, if you have opted to share your data with Databrary, authorized "
+#| "Databrary users.) They will view the videos to record information about "
+#| "what your child did during the study--for instance, looking for 9 seconds "
+#| "at one image and 7 seconds at another image.</li>\n"
+#| "                                    <li><strong>Scientific and "
+#| "educational</strong> This privacy level gives permission to share your "
+#| "video clips with other researchers or students for scientific or "
+#| "educational purposes. For example, researchers might show a video clip in "
+#| "a talk at a scientific conference or an undergraduate class about "
+#| "cognitive development, or include an image or video in a scientific "
+#| "paper. In some circumstances, video or images may be available online, "
+#| "for instance as supplemental material in a scientific paper. Sharing "
+#| "videos with other researchers helps other groups trust and build on our "
+#| "work.</li>\n"
+#| "                                    <li><strong>Publicity</strong> This "
+#| "privacy level is for families who would be excited to see their child "
+#| "featured on the Lookit website or in the news! Selecting this privacy "
+#| "level gives permission to use your video clips to communicate about "
+#| "developmental studies and the Lookit platform with the public. For "
+#| "instance, we might post a short video clip on the Lookit website, on our "
+#| "Facebook page, or in a press release. Your video will never be used for "
+#| "commercial purposes.</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>If for some reason you do not select a "
+#| "privacy level, we treat the data as 'Private' and do not share with "
+#| "Databrary. Participants also have the option to withdraw all video "
+#| "besides consent at the end of the study if necessary (for instance, "
+#| "because someone was discussing state secrets in the background), and in "
+#| "this case it is automatically deleted. Privacy settings for completed "
+#| "sessions cannot automatically be changed retroactively. If you have any "
+#| "questions or concerns about privacy, please contact our team at <a "
+#| "href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Lookit staff at MIT will have access to "
-"your video and other data in order to improve and promote the platform and "
-"help with troubleshooting. The researchers running the study you "
-"participated in will also have access to your video and other data (like "
-"responses to questions during the study, and information you fill out when "
-"registering a child) for research purposes. They will watch the video "
-"segments you send to mark down information specific to the study--for "
-"instance, what your child said, or how long he/she looked to the left versus "
-"the right of the screen. This research group may be at MIT or at another "
-"institution. All studies run on Lookit must be approved by an Institutional "
-"Review Board (IRB) that ensures participants' rights and welfare are "
-"protected. All researchers using Lookit also agree to Terms of Use that "
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
 "govern what data they can share and what sorts of studies are okay to run on "
-"Lookit; these rules are sometimes stricter than their own institution might "
-"be.  </p>\n"
-"                                <p>Whether anyone else may view the video "
-"depends on the privacy settings you select at the end of the study. There "
-"are two decisions to make: whether to share your data with Databrary, and "
-"how to allow your video clips to be used by the researchers you have "
-"selected.</p>\n"
-"                                <p>First, we ask if you would like to share "
-"your data (including video) with authorized users fo the secure data library "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
 "Databrary. Data sharing will lead to faster progress in research on human "
 "development and behavior. Researchers who are granted access to the "
 "Databrary library must agree to treat the data with the same high standard "
@@ -1464,43 +2202,44 @@ msgid ""
 "Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
 "<a href=\"https://databrary.org/about/agreement.html\">requirements for "
 "authorized users</a>.</p>\n"
-"                                <p>Next, we ask what types of uses of your "
-"video are okay with you.</p>\n"
-"                                <ul>\n"
-"                                    <li><strong>Private</strong> This "
-"privacy level ensures that your video clips will be viewed only by "
-"authorized scientists (Lookit staff, the research group running the study "
-"and, if you have opted to share your data with Databrary, authorized "
-"Databrary users.) They will view the videos to record information about what "
-"your child did during the study--for instance, looking for 9 seconds at one "
-"image and 7 seconds at another image.</li>\n"
-"                                    <li><strong>Scientific and educational</"
-"strong> This privacy level gives permission to share your video clips with "
-"other researchers or students for scientific or educational purposes. For "
-"example, researchers might show a video clip in a talk at a scientific "
-"conference or an undergraduate class about cognitive development, or include "
-"an image or video in a scientific paper. In some circumstances, video or "
-"images may be available online, for instance as supplemental material in a "
-"scientific paper. Sharing videos with other researchers helps other groups "
-"trust and build on our work.</li>\n"
-"                                    <li><strong>Publicity</strong> This "
-"privacy level is for families who would be excited to see their child "
-"featured on the Lookit website or in the news! Selecting this privacy level "
-"gives permission to use your video clips to communicate about developmental "
-"studies and the Lookit platform with the public. For instance, we might post "
-"a short video clip on the Lookit website, on our Facebook page, or in a "
-"press release. Your video will never be used for commercial purposes.</li>\n"
-"                                </ul>\n"
-"                                <p>If for some reason you do not select a "
-"privacy level, we treat the data as 'Private' and do not share with "
-"Databrary. Participants also have the option to withdraw all video besides "
-"consent at the end of the study if necessary (for instance, because someone "
-"was discussing state secrets in the background), and in this case it is "
-"automatically deleted. Privacy settings for completed sessions cannot "
-"automatically be changed retroactively. If you have any questions or "
-"concerns about privacy, please contact our team at <a href=\"mailto:"
-"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
-"                                "
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
 msgstr ""
 "\n"
 "        \t\t\t\t\t\t\t    <p>El personal de Lookit en MIT tendrá acceso a "
@@ -1531,9 +2270,9 @@ msgstr ""
 "rápido en la investigación sobre el desarrollo y el comportamiento humanos. "
 "El equipo de investigación al que se le conceda acceso a la biblioteca de "
 "Databrary debe aceptar tratar los datos con el mismo alto nivel de atención "
-"que usarían en sus propios laboratorios. Más información sobre la <a href="
-"\"https://databrary.org/about.html\">misión</a> de Databrary o los <a href="
-"\"https://databrary.org/about/agreement.html\">requisitos para usuarios "
+"que usarían en sus propios laboratorios. Más información sobre la <a "
+"href=\"https://databrary.org/about.html\">misión</a> de Databrary o los <a "
+"href=\"https://databrary.org/about/agreement.html\">requisitos para usuarios "
 "autorizados</a>.</p>\n"
 "        \t\t\t\t\t\t\t\t<p>A continuación, os preguntamos qué tipo de uso de "
 "vuestro vídeo aceptáis.</p>\n"
@@ -1577,12 +2316,12 @@ msgstr ""
 "lookit@mit.edu\">lookit@mit.edu </a>.</p>\n"
 "        \t\t\t\t\t\t\t"
 
-#: web/templates/frontpages/faq.html:130
+#: web/templates/web/faq.html:269
 msgid "What information do researchers use from our video?"
 msgstr ""
 "¿Qué información de nuestro vídeo utiliza el personal de investigación?"
 
-#: web/templates/frontpages/faq.html:136
+#: web/templates/web/faq.html:278
 msgid ""
 "For children under about two years old, we usually design our studies to let "
 "their eyes do the talking! We're interested in where on the screen your "
@@ -1599,7 +2338,7 @@ msgstr ""
 "saber cuándo vuestro/a hijo/a está mirando hacia la derecha o hacia la "
 "izquierda, para así poder codificar el resto del vídeo."
 
-#: web/templates/frontpages/faq.html:143
+#: web/templates/web/faq.html:290
 msgid ""
 "Here's an example of a few children watching our calibration video--it's "
 "easy to see that they look to one side and then the other."
@@ -1608,7 +2347,7 @@ msgstr ""
 "calibracióin--se puede ver claramente que primero miran hacia un lado y "
 "luego hacia otro."
 
-#: web/templates/frontpages/faq.html:149
+#: web/templates/web/faq.html:302
 msgid ""
 "Your child's decisions about where to look can give us lots of information "
 "about what he or she understands. Here are some of the techniques labs use "
@@ -1618,36 +2357,62 @@ msgstr ""
 "información sobre lo que comprende. Aquí hay algunas técnicas utulizadas en "
 "otros laboratorios para aprender sobre cómo aprenden los/as niños/as."
 
-#: web/templates/frontpages/faq.html:150
+#: web/templates/web/faq.html:304
 msgid "Habituation"
 msgstr "Habituación"
 
-#: web/templates/frontpages/faq.html:151
+#: web/templates/web/faq.html:305
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>In a habituation study, we first show "
+#| "infants many examples of one type of object or event, and they lose "
+#| "interest over time. Infants typically look for a long time at the first "
+#| "pictures, but then they start to look away more quickly. Once their "
+#| "looking times are much less than they were initially, we show either a "
+#| "picture from a new category or a new picture from the familiar category. "
+#| "If infants now look longer to the novel example, we can tell that they "
+#| "understood--and got bored of--the category we showed initially.</p>\n"
+#| "                                <p>Habituation requires waiting for each "
+#| "individual infant to achieve some threshold of \"boredness\"--for "
+#| "instance, looking half as long at a picture as he or she did initially. "
+#| "Sometimes this is impractical, and we use familiarization instead. In a "
+#| "familiarization study, we show all babies the same number of examples, "
+#| "and then see how interested they are in the familiar versus a new "
+#| "category. Younger infants and those who have seen few examples tend to "
+#| "show a familiarity preference--they look longer at images similar to what "
+#| "they have seen before. Older infants and those who have seen many "
+#| "examples tend to show a novelty preference--they look longer at images "
+#| "that are different from the ones they saw before. You probably notice the "
+#| "same phenomenon when you hear a new song on the radio: initially you "
+#| "don't recognize it; after it's played several times you may like it and "
+#| "sing along; after it's played hundreds of times you would choose to "
+#| "listen to anything else.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>In a habituation study, we first show "
-"infants many examples of one type of object or event, and they lose interest "
-"over time. Infants typically look for a long time at the first pictures, but "
-"then they start to look away more quickly. Once their looking times are much "
-"less than they were initially, we show either a picture from a new category "
-"or a new picture from the familiar category. If infants now look longer to "
-"the novel example, we can tell that they understood--and got bored of--the "
-"category we showed initially.</p>\n"
-"                                <p>Habituation requires waiting for each "
-"individual infant to achieve some threshold of \"boredness\"--for instance, "
-"looking half as long at a picture as he or she did initially. Sometimes this "
-"is impractical, and we use familiarization instead. In a familiarization "
-"study, we show all babies the same number of examples, and then see how "
-"interested they are in the familiar versus a new category. Younger infants "
-"and those who have seen few examples tend to show a familiarity preference--"
-"they look longer at images similar to what they have seen before. Older "
-"infants and those who have seen many examples tend to show a novelty "
-"preference--they look longer at images that are different from the ones they "
-"saw before. You probably notice the same phenomenon when you hear a new song "
-"on the radio: initially you don't recognize it; after it's played several "
-"times you may like it and sing along; after it's played hundreds of times "
-"you would choose to listen to anything else.</p>\n"
-"                                "
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
 msgstr ""
 "\n"
 "        \t\t\t\t\t\t\t\t<p>En un estudio de habituación, primero enseñamos a "
@@ -1679,11 +2444,11 @@ msgstr ""
 "casi cualquier otra cosa.</p>\n"
 "        \t\t\t\t\t\t\t\t"
 
-#: web/templates/frontpages/faq.html:156
+#: web/templates/web/faq.html:308
 msgid "Violation of expectation"
 msgstr "Violación de la expectativa"
 
-#: web/templates/frontpages/faq.html:157
+#: web/templates/web/faq.html:310
 msgid ""
 "Infants and children already have rich expectations about how events work. "
 "Children (and adults for that matter) tend to look longer at things they "
@@ -1696,11 +2461,11 @@ msgstr ""
 "sorprendentes, de forma que en algunos casos podemos registrar su tiempo de "
 "mirar como un indicador de cómo de sorpredidos/as están."
 
-#: web/templates/frontpages/faq.html:158
+#: web/templates/web/faq.html:312
 msgid "Preferential looking"
 msgstr "Mirada preferencial"
 
-#: web/templates/frontpages/faq.html:159
+#: web/templates/web/faq.html:314
 msgid ""
 "Even when they seem to be passive observers, children are making lots of "
 "decisions about where to look and what to pay attention to. In this "
@@ -1720,11 +2485,11 @@ msgstr ""
 "pedimos que \"encuentre aplaudir\"; en laparte superior mostramos lo que la "
 "participante está viendo."
 
-#: web/templates/frontpages/faq.html:165
+#: web/templates/web/faq.html:325
 msgid "Predictive looking"
 msgstr "Mirada predictiva"
 
-#: web/templates/frontpages/faq.html:166
+#: web/templates/web/faq.html:327
 msgid ""
 "Children can often make sophisticated predictions about what they expect to "
 "see or hear next. One way we can see those predictions in young children is "
@@ -1749,7 +2514,7 @@ msgstr ""
 "y cómo las generalizan registrando hacia dónde miran en la pantalla cuando "
 "escuchan cada una de las dos sílabas."
 
-#: web/templates/frontpages/faq.html:168
+#: web/templates/web/faq.html:330
 msgid ""
 "Older children may simply be able to answer spoken questions about what they "
 "think is happening. For instance, in a recent study, two women called an "
@@ -1762,7 +2527,7 @@ msgstr ""
 "diferentes (con nombres inventados) y se preguntó a los participantes cuál "
 "creían que era el nombre correcto para el objeto."
 
-#: web/templates/frontpages/faq.html:174
+#: web/templates/web/faq.html:342
 msgid ""
 "Another way we can learn about how older children (and adults) think is to "
 "measure their reaction times. For instance, we might ask you to help your "
@@ -1777,103 +2542,7 @@ msgstr ""
 "después analizar qué factores influyen sonre cómo de rápido presionan las "
 "teclas."
 
-#: web/templates/frontpages/faq.html:181
-msgid "Why are you running studies online instead of in person?"
-msgstr ""
-"¿Por qué realizáis estos estudios on-line, en lugar de hacerlo en persona?"
-
-#: web/templates/frontpages/faq.html:186
-msgid ""
-"Traditionally, developmental studies happen in a quiet room in a university "
-"lab. Researchers call or email local parents to see if they'd like to take "
-"part and schedule an appointment for them to come visit the lab. Why "
-"complement these in-lab studies with online ones? We're hoping to..."
-msgstr ""
-"Tradicionalmente, los estudios sobre desarrollo se realizan en una sala "
-"silenciosa en un laboradorio de una universidad. El equipo de investigación "
-"llama o envía un correo electrónico a la familia, invitándoles a participar "
-"y preparan una cita para que vengan a visitar el laboratorio. ¿Por qué "
-"complementar estos estudios en el laboratorio con estudios on-line? "
-"Esperamos..."
-
-#: web/templates/frontpages/faq.html:187
-msgid ""
-"\n"
-"                                <ul>\n"
-"                                    <li>Make it easier for you to take part "
-"in research, especially for families without a stay-at-home parent</li>\n"
-"                                    <li>Work with more kids when needed--"
-"right now a limiting factor in designing studies is the time it takes to "
-"recruit participants</li>\n"
-"                                    <li>Draw conclusions from a more "
-"representative population of families--not just those who live near a "
-"university and are able to visit the lab during the day.\n"
-"                                    </li>\n"
-"                                    <li>Make it easier for families to "
-"continue participating in longitudinal studies, which may involve multiple "
-"testing sessions separated by months or years</li>\n"
-"                                    <li>Observe more natural behavior "
-"because children are at home rather than in an unfamiliar place</li>\n"
-"                                    <li>Create a system for learning about "
-"special populations--for instance, children with specific developmental "
-"disorders</li>\n"
-"                                    <li>Make the procedures we use in doing "
-"research more transparent, and make it easier to replicate our findings</"
-"li>\n"
-"                                    <li>Communicate with families about the "
-"research we're doing and what we can learn from it</li>\n"
-"                                </ul>\n"
-"                                "
-msgstr ""
-"\n"
-"<ul>\n"
-"        \t\t\t\t\t\t\t\t\t<li>Facilitar vuestra participación en nuestros "
-"estudios, especialmente la de familias en las que ningún adulto se queda en "
-"casa durante los días entre semana.</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>Trabajar con más niños/as cuando se necesite--"
-"ahora mismo uno de los factores que más limitan el diseño de un estudios es "
-"el tiempo que se tarda en reclutar participantes.</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>Extraer conclusiones desde una población de "
-"familias más representativa-- no solo incluyendo aquellas familias que viven "
-"cerca de la universidad y pueden visitar el laboratorio durante el día.\n"
-"        \t\t\t\t\t\t\t\t\t</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>Facilitar que las familias continúen "
-"participando en nuestros estudios longitudinales, lo cual requiere que "
-"participen en más de una sesión, a veces separadas por meses o años.</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>Observar comportamientos más naturales gracias "
-"a que los/as niños/as se encuentren en casa en lugar de en un lugar "
-"desconocido, como un laboratorio.</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>Crear un sistema para aprender sobre "
-"poblaciones especiales--por ejemplo, niños/as con problemas específicos del "
-"desarrollo.</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>Hacer los procedimientos que utilizamos en "
-"nuestros estudios más transparentes y hacer nuestros resultados más fáciles "
-"de replicar.</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>Comunicar a las familias nuestra labor "
-"investigadora y sobre lo que aprendemos de ella.</li>\n"
-"        \t\t\t\t\t\t\t\t</ul>\n"
-"                                "
-
-#: web/templates/frontpages/faq.html:206
-msgid "When will we see the results of the study?"
-msgstr "¿Cuándo podré ver los resultados de mi estudio?"
-
-#: web/templates/frontpages/faq.html:211
-msgid ""
-"The process of publishing a scientific study, from starting data collection "
-"to seeing the paper in a journal, can take several years. You can check the "
-"Lookit home page for updates on papers, or set your communication "
-"preferences to be notified when we have results from studies you "
-"participated in."
-msgstr ""
-"El proceso de publicar un estudio científico desde la recogida de datos "
-"hasta su publicación en versión impresa u on-line puede llevar varios años. "
-"Puedes echar un vistazo a la página de inicio de Lookit para ver "
-"actualizaciones sobre nuestros estudios o cambiar las preferencias de "
-"notificaciones para que se os avise cuando tengamos los resultados de "
-"estudios en los que habéis participado."
-
-#: web/templates/frontpages/faq.html:218
+#: web/templates/web/faq.html:355
 msgid ""
 "My child wasn't paying attention, or we were interrupted. Can we try the "
 "study again?"
@@ -1881,7 +2550,7 @@ msgstr ""
 "Mi hijo/a no estaba prestando atención o fuimos interrumpidos durante el "
 "estudio. ¿Podemos hacer el estudio otra vez?"
 
-#: web/templates/frontpages/faq.html:223
+#: web/templates/web/faq.html:364
 msgid ""
 "Certainly--thanks for your dedication! You may see a warning that you have "
 "already participated in the study when you go to try it again, but you can "
@@ -1894,7 +2563,7 @@ msgstr ""
 "intentado hacer el estudio antes; vuestro intento anterior ya estará "
 "registrado."
 
-#: web/templates/frontpages/faq.html:230
+#: web/templates/web/faq.html:377
 msgid ""
 "My child is outside the age range. Can he/she still participate in this "
 "study?"
@@ -1902,7 +2571,7 @@ msgstr ""
 "Mi hijo/a es mayor/menor de la edad indicada para el estudio. ¿Puede "
 "participar es este estudio?"
 
-#: web/templates/frontpages/faq.html:235
+#: web/templates/web/faq.html:386
 msgid ""
 "Sure! We may not be able to use his or her data in our research directly, "
 "but if you're curious you're welcome to try the study anyway. (Sometimes big "
@@ -1916,13 +2585,13 @@ msgstr ""
 "está justo por debajo de la edad mínima, nos gustaría que esperáseis un poco "
 "para que podamos utilizar vuestros datos."
 
-#: web/templates/frontpages/faq.html:242
+#: web/templates/web/faq.html:399
 msgid "My child was born prematurely. Should we use his/her adjusted age?"
 msgstr ""
 "Mi hijo/a nació de forma prematura. ¿Deberíamos tener en cuenta su edad "
 "ajustada?"
 
-#: web/templates/frontpages/faq.html:247
+#: web/templates/web/faq.html:408
 msgid ""
 "For study eligibility, we usually use the child's chronological age (time "
 "since birth), even for premature babies. If adjusted age is important for a "
@@ -1933,7 +2602,7 @@ msgstr ""
 "prematuros. Si la edad ajustada es importante para un estudio particular, os "
 "lo haremos saber en los criterios de eligibilidad del estudio."
 
-#: web/templates/frontpages/faq.html:254
+#: web/templates/web/faq.html:421
 msgid ""
 "Our family speaks a language other than English at home. Can my child "
 "participate?"
@@ -1941,7 +2610,7 @@ msgstr ""
 "Nuestra familia habla una lengua distinta del español en casa. ¿Podemos "
 "participar aun así?"
 
-#: web/templates/frontpages/faq.html:259
+#: web/templates/web/faq.html:430
 msgid ""
 "Sure! Right now, instructions for children and parents are written only in "
 "English, so some of them may be confusing to a child who does not hear "
@@ -1960,7 +2629,7 @@ msgstr ""
 "ellas. También puedes indicar qué lenguas habla o está aprendiendo tu hijo/a "
 "en vuestro cuestionario demográfico."
 
-#: web/templates/frontpages/faq.html:266
+#: web/templates/web/faq.html:443
 msgid ""
 "My child has been diagnosed with a developmental disorder or has special "
 "needs. Can he/she still participate?"
@@ -1968,20 +2637,32 @@ msgstr ""
 "Mi hijo/a ha sido diagnosticado/a con un trastorno del desarrollo o tiene "
 "necesidad especiales. ¿Puede participar aun así?"
 
-#: web/templates/frontpages/faq.html:271
+#: web/templates/web/faq.html:451
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Of course! We're interested in how all "
+#| "children learn and grow. If you'd like, you can make a note of any "
+#| "developmental disorders in the comments section at the end of the study. "
+#| "We are excited that in the future, online studies may help more families "
+#| "participate in research to better understand their own children's "
+#| "diagnoses.</p>\n"
+#| "                                <p>One note: most of our studies include "
+#| "both images and sound, and may be hard to understand if your child is "
+#| "blind or deaf. If you can, please feel free to help out by describing "
+#| "images or signing.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Of course! We're interested in how all "
-"children learn and grow. If you'd like, you can make a note of any "
-"developmental disorders in the comments section at the end of the study. We "
-"are excited that in the future, online studies may help more families "
-"participate in research to better understand their own children's diagnoses."
-"</p>\n"
-"                                <p>One note: most of our studies include "
-"both images and sound, and may be hard to understand if your child is blind "
-"or deaf. If you can, please feel free to help out by describing images or "
-"signing.</p>\n"
-"                                "
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
 msgstr ""
 "\n"
 "<p>¡Por supuesto! Nos interesa saber cómo crecen y se desarrollan todos/as "
@@ -1996,7 +2677,7 @@ msgstr ""
 "signando.</p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:281
+#: web/templates/web/faq.html:466
 msgid ""
 "I have multiple children in the age range for a study. Can they participate "
 "together?"
@@ -2004,7 +2685,7 @@ msgstr ""
 "Tengo varios/as hijos/as que tienen la edad del estudio. ¿Pueden participar "
 "juntos?"
 
-#: web/templates/frontpages/faq.html:286
+#: web/templates/web/faq.html:475
 msgid ""
 "If possible, we ask that each child participate separately. When children "
 "participate together they generally influence each other. That's a "
@@ -2016,26 +2697,40 @@ msgstr ""
 "un tema de investigación de por sí muy interesante, pero no es el objetivo "
 "de nuestros estudios."
 
-#: web/templates/frontpages/faq.html:293
+#: web/templates/web/faq.html:488
 msgid "But I've heard that young children should avoid 'screen time.'"
 msgstr ""
 "¡Pero he escuchado que los/las niños/as pequeños/as debería evitar las "
 "\"pantallas\"!"
 
-#: web/templates/frontpages/faq.html:298
+#: web/templates/web/faq.html:496
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>We agree with the American Academy of "
+#| "Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
+#| "e20162591\" target=\"_blank\">advice</a> that children learn best from "
+#| "people, not screens! However, our studies are not intended to educate "
+#| "children, but to learn from them.</p>\n"
+#| "                                <p>As part of a child's limited screen "
+#| "time, we hope that our studies will foster family conversation and "
+#| "engagement with science that offsets the few minutes spent watching a "
+#| "video instead of playing. And we do \"walk the walk\"--our own young "
+#| "children provide lots of feedback on our studies!</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>We agree with the American Academy of "
-"Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
-"e20162591\" target=\"_blank\">advice</a> that children learn best from "
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
 "people, not screens! However, our studies are not intended to educate "
 "children, but to learn from them.</p>\n"
-"                                <p>As part of a child's limited screen time, "
-"we hope that our studies will foster family conversation and engagement with "
-"science that offsets the few minutes spent watching a video instead of "
-"playing. And we do \"walk the walk\"--our own young children provide lots of "
-"feedback on our studies!</p>\n"
-"                                "
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
 msgstr ""
 "\n"
 "<p>Estamos de acuerdo con las <a href=\"https://pediatrics.aappublications."
@@ -2051,11 +2746,11 @@ msgstr ""
 "a menudo en nuestros estudios!</p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:308
+#: web/templates/web/faq.html:510
 msgid "Will we be paid for our participation?"
 msgstr "¿Se nos pagará por participar?"
 
-#: web/templates/frontpages/faq.html:313
+#: web/templates/web/faq.html:518
 msgid ""
 "Some research groups provide gift cards or other compensation for completing "
 "their studies, and others rely on volunteers. (This often depends on the "
@@ -2068,80 +2763,185 @@ msgstr ""
 "unversidad en la que se lleva a cabo el estudio). Podréis encontrar esta "
 "información en la desscripción del estudio."
 
-#: web/templates/frontpages/faq.html:320
-msgid "Can I get my child's results?"
-msgstr "¿Puedo obtener los resultados de mi hijo/a?"
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
 
-#: web/templates/frontpages/faq.html:325
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
 #, python-format
 msgid ""
 "\n"
-"                                <p>For some studies, yes! Usually, "
-"developmental researchers only interpret children's abilities and "
-"developmental trends at a group level, and the individual data collected "
-"just isn't very interpretable. But for \"Your baby, the physicist\" and "
-"other longitudinal studies (where you come back for more than one session), "
-"we can sometimes collect enough data to give you a report of your child's "
-"responses after you complete all the sessions.</p>\n"
-"                                <p>Please note that none of the measures we "
-"collect are diagnostic! For instance, while we hope you'll be interested to "
-"learn that your child looked 70%% of the time at videos where things fell up "
-"versus falling down, we won't be able to tell you whether this means your "
-"child is going to be especially good at physics.</p>\n"
-"                                <p>If you're interested in getting "
-"individual results right away, please see our <a href='resources'>Resources</"
-"a> section for fun at-home activities you can try with your child.</p>\n"
-"                                "
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
 msgstr ""
-"\n"
-"<p>Para algunos estudios, ¡sí! Normalmente, en estudios sobre desarrollo "
-"infantil el equipo de investigación sólo intepreta las habilidades y "
-"trayectorias de desarrollo de los participantes en el nivel de grupo, ya que "
-"los datos recogidos de un/a sólo/a participante son difíciles de "
-"interpretar. Para estudios como \"Your baby, the physicist\" y otros "
-"estudios longitudinales (en los que participáis en más de una sesión) a "
-"veces recogemos información suficiente para entregaros un informe sobre las "
-"respuestas de vuestro/a hijo/a una vez hayáis completado todas las sesiones."
-"</p>\n"
-"        \t\t\t\t\t\t\t    <p>Por favor, ¡tened en cuenta que ninguna de las "
-"medidas que tomamos son diagnósticas! Por ejemplo, aunque esperamos que "
-"estés interesado/a en que vuestro/a hijo/a haya mirado un 70%% del tiempo a "
-"un vídeo en el que algunos objectos se caían hacia arriba, mientras que ojos "
-"objetos se caían hacia abajo, esto no querrá decir que tu hijo/a vaya a ser "
-"especialmente bueno/a o malo/a en física.</p>\n"
-"        \t\t\t\t\t\t\t\t<p>Si os interesa tener vuestros resultados "
-"individuales en el momento, por favor visitad la sección de <a href=\"/"
-"resources\">Recursos</a> para acceder a actividades divertidas que podéis "
-"hacer desde casa con vuestro/a hijo/a.</p>\n"
-"                                "
 
-#: web/templates/frontpages/faq.html:335
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
 msgid "Technical"
 msgstr "Aspectos técnicos"
 
-#: web/templates/frontpages/faq.html:339
+#: web/templates/web/faq.html:652
 msgid "What browsers are supported?"
 msgstr "¿Qué navegadores soportan los estudios?"
 
-#: web/templates/frontpages/faq.html:344
+#: web/templates/web/faq.html:660
+#, fuzzy
+#| msgid ""
+#| "Lookit supports recent versions of Chrome and Firefox. We are not "
+#| "currently able to support Internet Explorer or Safari."
 msgid ""
-"Lookit supports recent versions of Chrome and Firefox. We are not currently "
-"able to support Internet Explorer or Safari."
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
 msgstr ""
 "Lookit soporta versiones recientes de Chrome y Firefox. Actualmente no "
 "soporta Internet Explorer o Safari."
 
-#: web/templates/frontpages/faq.html:351
+#: web/templates/web/faq.html:672
 msgid "Can we do a study on my phone or tablet?"
 msgstr "¿Podemos participar desde un móvil o una tablet?"
 
-#: web/templates/frontpages/faq.html:357
+#: web/templates/web/faq.html:679
+#, fuzzy
+#| msgid ""
+#| "Not yet! Because we're measuring kids' looking patterns, we need a "
+#| "reasonably stable view of their eyes and a big enough screen that we can "
+#| "tell whether they're looking at the left or the right side of it. We're "
+#| "excited about the potential for touchscreen studies that allow us to "
+#| "observe infants and toddlers exploring, though!"
 msgid ""
-"Not yet! Because we're measuring kids' looking patterns, we need a "
-"reasonably stable view of their eyes and a big enough screen that we can "
-"tell whether they're looking at the left or the right side of it. We're "
-"excited about the potential for touchscreen studies that allow us to observe "
-"infants and toddlers exploring, though!"
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
 msgstr ""
 "¡Aún no! Al estar interesados en los patrones de mirada de los/as "
 "participantes, necesitamos que el dispositivo tenga una visión estable de "
@@ -2151,71 +2951,293 @@ msgstr ""
 "estudios ¡ya que nos permitiría observar cómo bebés y niños/as exploran la "
 "pantalla!"
 
-#: web/templates/frontpages/home.html:11
-msgid "the online child lab"
-msgstr "el laboratorio de infancia online"
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
 
-#: web/templates/frontpages/home.html:12
-msgid "A project of the MIT Early Childhood Cognition Lab"
-msgstr "Un proyecto del Early Childhood Cognition Lab"
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
 
-#: web/templates/frontpages/home.html:12
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "¿En qué provincia vivís?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "For researchers"
+msgid "For Researchers"
+msgstr "Para personal de investigación"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "¿Qué edad tienes?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Inicie sesión para participar"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Los científicos"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
 msgid "Participate in a Study"
 msgstr "Participa en un estudio"
 
-#: web/templates/frontpages/home.html:22
-msgid "Bringing science home"
-msgstr "Llevando la ciencia a casa"
-
-#: web/templates/frontpages/home.html:23
-msgid ""
-"Here at MIT's Early Childhood Cognition Lab, we're trying a new approach in "
-"developmental psychology: bringing the experiments to you."
+#: web/templates/web/home.html:52
+msgid "Help Science"
 msgstr ""
-"Aquí en el Early Childhood Cognition Lab del MIT estamos probando una nueva "
-"forma de investigar la psicología del desarrollo: llevando nuestros estudios "
-"a vosotros/as."
 
-#: web/templates/frontpages/home.html:29
-msgid "Help us understand how your child thinks"
-msgstr "Ayúdanos a comprender cómo piensan los/as niños/as"
-
-#: web/templates/frontpages/home.html:30
+#: web/templates/web/home.html:54
 msgid ""
-"Your family can contribute to research about how children learn by doing fun "
-"activities together, right in your web browser."
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
 msgstr ""
-"Tu familia puede contribuir a la investigación sobre como los/as niños/as "
-"aprenden haciendo actividades divertidas juntos/as en nuestro navegador."
 
-#: web/templates/frontpages/home.html:36
-msgid "Participate whenever and wherever"
-msgstr "Participa donde y cuando quieras"
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Inicio"
 
-#: web/templates/frontpages/home.html:37
+#: web/templates/web/home.html:61
 msgid ""
-"Log in or create an account at the top right to get started! You can "
-"participate with your child from any computer with a webcam."
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
 msgstr ""
-"¡Inicia sesión o regístrate arriba a la derecha para empezar! Puedes "
-"participar con tu hijo/a desde cualquier ordenador con una webcam."
 
-#: web/templates/frontpages/privacy.html:11
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
+msgid "I would like to be contacted when:"
+msgstr "Me gustaría ser contactado/a cuando:"
+
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Inicie sesión para participar"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Crear una cuenta"
+
+#: web/templates/web/participant-signup.html:13
+msgid "Create Participant Account"
+msgstr "Crear cuenta de participante"
+
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "Para registrarte como investigador/a, utiliza"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead"
+msgid "instead."
+msgstr "en lugar de"
+
+#: web/templates/web/participant-signup.html:28
+msgid ""
+"By clicking 'Create Account', I agree that I have read and accepted the "
+msgstr "Al hacer clic en 'Crear cuenta', acepto que he leído y aceptado el "
+
+#: web/templates/web/participant-signup.html:28
+msgid "Privacy Statement"
+msgstr "Declaracion de privacidad"
+
+#: web/templates/web/privacy.html:9
 msgid "Privacy statement"
 msgstr "Declaración de privacidad"
 
-#: web/templates/frontpages/privacy.html:17
+#: web/templates/web/privacy.html:11
 msgid "Introduction"
 msgstr "Introducción"
 
-#: web/templates/frontpages/privacy.html:18
+#: web/templates/web/privacy.html:14
+#, fuzzy
+#| msgid ""
+#| "Lookit is committed to supporting the privacy of individuals who enroll "
+#| "on our Platform to conduct\n"
+#| "                research or serve as research subjects. This Privacy "
+#| "Statement explains how we handle and use the\n"
+#| "                personal information we collect about our researchers and "
+#| "research participant community."
 msgid ""
 "Lookit is committed to supporting the privacy of individuals who enroll on "
 "our Platform to conduct\n"
-"                research or serve as research subjects. This Privacy "
-"Statement explains how we handle and use the\n"
-"                personal information we collect about our researchers and "
-"research participant community."
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
 msgstr ""
 "Lookit se compromete a respaldar la privacidad de las personas que se "
 "inscriben en nuestra Plataforma para realizar investigaciones o servir como "
@@ -2223,19 +3245,28 @@ msgstr ""
 "manejamos y usamos la información personal que recopilamos sobre nuestros/as "
 "investigadores/as y la comunidad de participantes de la investigación."
 
-#: web/templates/frontpages/privacy.html:22
+#: web/templates/web/privacy.html:19
 msgid "For participants"
 msgstr "Para participantes"
 
-#: web/templates/frontpages/privacy.html:24
+#: web/templates/web/privacy.html:22
+#, fuzzy
+#| msgid ""
+#| "Lookit is a platform that many different researchers use to conduct "
+#| "studies about how children learn and\n"
+#| "                develop. It is run by the MIT Early Childhood Cognition "
+#| "Lab, which has access to all of the data\n"
+#| "                collected on Lookit. Researchers using Lookit to conduct "
+#| "studies only access your personal information\n"
+#| "                if you choose to participate in their study."
 msgid ""
 "Lookit is a platform that many different researchers use to conduct studies "
 "about how children learn and\n"
-"                develop. It is run by the MIT Early Childhood Cognition Lab, "
-"which has access to all of the data\n"
-"                collected on Lookit. Researchers using Lookit to conduct "
-"studies only access your personal information\n"
-"                if you choose to participate in their study."
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
 msgstr ""
 "Lookit es una plataforma que utilizan muchos investigadores/as para realizar "
 "estudios sobre cómo los/as niños/as aprenden y se desarrollan. Está dirigido "
@@ -2244,35 +3275,54 @@ msgstr ""
 "Lookit para realizar estudios solo acceden a tu información personal si "
 "decides participar en su estudio."
 
-#: web/templates/frontpages/privacy.html:29
-#: web/templates/frontpages/privacy.html:142
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
 msgid "What personal information we collect"
 msgstr "Qué información personal recopilamos"
 
-#: web/templates/frontpages/privacy.html:31
+#: web/templates/web/privacy.html:30
 msgid "We collect the following kinds of personal information:"
 msgstr "Recopilamos los siguientes tipos de información personal:"
 
-#: web/templates/frontpages/privacy.html:32
+#: web/templates/web/privacy.html:33
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Account data: basic contact information that may "
+#| "include your email address, nickname, mailing\n"
+#| "                    address, and contact preferences.</li>\n"
+#| "                <li>Child data: basic biographical information about your "
+#| "child(ren), including nickname, date of birth,\n"
+#| "                    and gestational age at birth.</li>\n"
+#| "                <li>Demographic data: background and biographical "
+#| "information such as your native language, race, age,\n"
+#| "                    educational background, and family history of "
+#| "particular medical conditions.</li>\n"
+#| "                <li>Study data: responses collected during particular "
+#| "studies conducted on Lookit, including webcam\n"
+#| "                    video of your family participating in the study, text "
+#| "entered in forms, the particular images that\n"
+#| "                    were shown, the timing of progression through the "
+#| "study, etc.</li>\n"
+#| "            </ul>"
 msgid ""
 "<ul>\n"
-"                <li>Account data: basic contact information that may include "
-"your email address, nickname, mailing\n"
-"                    address, and contact preferences.</li>\n"
-"                <li>Child data: basic biographical information about your "
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
 "child(ren), including nickname, date of birth,\n"
-"                    and gestational age at birth.</li>\n"
-"                <li>Demographic data: background and biographical "
-"information such as your native language, race, age,\n"
-"                    educational background, and family history of particular "
-"medical conditions.</li>\n"
-"                <li>Study data: responses collected during particular "
-"studies conducted on Lookit, including webcam\n"
-"                    video of your family participating in the study, text "
-"entered in forms, the particular images that\n"
-"                    were shown, the timing of progression through the study, "
-"etc.</li>\n"
-"            </ul>"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
 msgstr ""
 "<ul>\n"
 "<li>Datos de la cuenta: información de contacto básica que puede incluir tu "
@@ -2291,31 +3341,37 @@ msgstr ""
 "etc.</li>\n"
 "</ul>"
 
-#: web/templates/frontpages/privacy.html:44
-#: web/templates/frontpages/privacy.html:147
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
 msgid "How we collect personal information about you"
 msgstr "Cómo recopilamos información personal sobre vosotros/as"
 
-#: web/templates/frontpages/privacy.html:46
+#: web/templates/web/privacy.html:48
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is the information you "
+#| "provide to us when registering\n"
+#| "                for a Lookit account, registering your children, updating "
+#| "your account or your children’s profiles,\n"
+#| "                completing or updating surveys, or participating in "
+#| "individual Lookit studies."
 msgid ""
 "The information we collect and maintain about you is the information you "
 "provide to us when registering\n"
-"                for a Lookit account, registering your children, updating "
-"your account or your children’s profiles,\n"
-"                completing or updating surveys, or participating in "
-"individual Lookit studies."
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
 msgstr ""
 "La información que recopilamos y mantenemos sobre tí es la información que "
 "proporcionas cuando creas una cuenta en Lookit, registras a tu(s) hijos/"
 "a(s), actualizas tu cuenta o los perfiles de tu(s) hijo/a(s), completas o "
 "actualizas encuestas o participas en estudios individuales de Lookit."
 
-#: web/templates/frontpages/privacy.html:50
-#: web/templates/frontpages/privacy.html:167
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
 msgid "When we share your personal information"
 msgstr "Cuándo compartimos tu información personal"
 
-#: web/templates/frontpages/privacy.html:52
+#: web/templates/web/privacy.html:56
 msgid ""
 "When you participate in a Lookit study, we share the following information "
 "with the research group conducting the study:"
@@ -2323,15 +3379,26 @@ msgstr ""
 "Cuando participas en un estudio de Lookit, compartimos la siguiente "
 "información con el grupo de investigación que realiza el estudio:"
 
-#: web/templates/frontpages/privacy.html:54
+#: web/templates/web/privacy.html:60
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>Your account data </li>\n"
+#| "                <li>The child data for the child who is participating</"
+#| "li>\n"
+#| "                <li>Your demographic data</i>\n"
+#| "                <li>The study data for this particular study session</"
+#| "li>\n"
+#| "            </ul>"
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>Your account data </li>\n"
-"                <li>The child data for the child who is participating</li>\n"
-"                <li>Your demographic data</i>\n"
-"                <li>The study data for this particular study session</li>\n"
-"            </ul>"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
 msgstr ""
 "\n"
 "<ul>\n"
@@ -2341,7 +3408,7 @@ msgstr ""
 "<li>Los datos del estudio para esta sesión del estudio en particular</li>\n"
 "</ul>"
 
-#: web/templates/frontpages/privacy.html:61
+#: web/templates/web/privacy.html:68
 msgid ""
 "Your email address is not shared directly with the research group, although "
 "they can contact you via Lookit in accordance with your contact preferences."
@@ -2350,13 +3417,20 @@ msgstr ""
 "de investigación, aunque pueden contactar contigo a través de Lookit, de "
 "acuerdo con tus preferencias de contacto."
 
-#: web/templates/frontpages/privacy.html:63
+#: web/templates/web/privacy.html:71
+#, fuzzy
+#| msgid ""
+#| "Researchers may publish the results of a study, including individual "
+#| "responses. However, although they\n"
+#| "                may publish the ages of participants, they may not "
+#| "publish participant birthdates (or information that\n"
+#| "                could be used to calculate birthdates)."
 msgid ""
 "Researchers may publish the results of a study, including individual "
 "responses. However, although they\n"
-"                may publish the ages of participants, they may not publish "
+"        may publish the ages of participants, they may not publish "
 "participant birthdates (or information that\n"
-"                could be used to calculate birthdates)."
+"    could be used to calculate birthdates)."
 msgstr ""
 "Los/as investigadores/as pueden publicar los resultados de un estudio, "
 "incluidas las respuestas individuales. Sin embargo, aunque pueden publicar "
@@ -2364,20 +3438,33 @@ msgstr ""
 "nacimiento de los/as participantes (o información que podría usarse para "
 "calcular las fechas de nacimiento)."
 
-#: web/templates/frontpages/privacy.html:67
+#: web/templates/web/privacy.html:76
+#, fuzzy
+#| msgid ""
+#| "We and/or the researchers responsible for a study may share video of your "
+#| "family’s participation for\n"
+#| "                scientific, educational, and/or publicity purposes, but "
+#| "only if you choose at the conclusion of a study\n"
+#| "                to allow such usage. Researchers may also share your "
+#| "video and other data with Databrary if you choose\n"
+#| "                at the conclusion of a study to allow that. We don’t "
+#| "publish video of participants such that it can be\n"
+#| "                linked to individual demographic data (e.g., household "
+#| "income or number of parents/guardians), and\n"
+#| "                researchers must also agree not to do so in order to use "
+#| "Lookit."
 msgid ""
 "We and/or the researchers responsible for a study may share video of your "
 "family’s participation for\n"
-"                scientific, educational, and/or publicity purposes, but only "
-"if you choose at the conclusion of a study\n"
-"                to allow such usage. Researchers may also share your video "
-"and other data with Databrary if you choose\n"
-"                at the conclusion of a study to allow that. We don’t publish "
-"video of participants such that it can be\n"
-"                linked to individual demographic data (e.g., household "
-"income or number of parents/guardians), and\n"
-"                researchers must also agree not to do so in order to use "
-"Lookit."
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
 msgstr ""
 "Nosotros/as y/o los/as investigadores/as responsables de un estudio podemos "
 "compartir videos de la participación de tu familia con fines científicos, "
@@ -2389,13 +3476,20 @@ msgstr ""
 "padres/madres/tutores), y los equipos de investigación también deben aceptar "
 "no hacerlo para poder utilizar Lookit."
 
-#: web/templates/frontpages/privacy.html:74
+#: web/templates/web/privacy.html:84
+#, fuzzy
+#| msgid ""
+#| "We don’t share, sell, publish, or otherwise disclose your contact "
+#| "information (email and/or mailing\n"
+#| "                address) to anyone but the researchers involved in a "
+#| "study. Researchers must also agree not to disclose\n"
+#| "                your contact information in order to use Lookit."
 msgid ""
 "We don’t share, sell, publish, or otherwise disclose your contact "
 "information (email and/or mailing\n"
-"                address) to anyone but the researchers involved in a study. "
+"        address) to anyone but the researchers involved in a study. "
 "Researchers must also agree not to disclose\n"
-"                your contact information in order to use Lookit."
+"        your contact information in order to use Lookit."
 msgstr ""
 "No compartimos, vendemos, publicamos o revelamos tu información de contacto "
 "(email y/o dirección postal) a nadie o con nadie excepto el personal de "
@@ -2403,12 +3497,11 @@ msgstr ""
 "también debe comprometerse a no revelar tu información de contacto para "
 "utilizar Lookit."
 
-#: web/templates/frontpages/privacy.html:78
-#: web/templates/frontpages/privacy.html:152
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
 msgid "How we use your personal information"
 msgstr "Cómo usamos tu información personal"
 
-#: web/templates/frontpages/privacy.html:80
+#: web/templates/web/privacy.html:92
 msgid ""
 "We may use your personal information (account, child, demographic, and study "
 "data) for a variety of purposes, including to:"
@@ -2416,35 +3509,63 @@ msgstr ""
 "Podemos utilizar tu información personal (cuenta, niños, datos demográficos "
 "y de estudio) para una variedad de propósitos, que incluyen:"
 
-#: web/templates/frontpages/privacy.html:81
+#: web/templates/web/privacy.html:94
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Provide you with the research studies you have "
+#| "enrolled in, and information about which studies your\n"
+#| "                    children are eligible for</li>\n"
+#| "                <li>Send you information about studies you may be "
+#| "interested in, reminders to participate in multi-part\n"
+#| "                    studies, and/or results of studies you have "
+#| "participated in, subject to your contact preferences\n"
+#| "                </li>\n"
+#| "                <li>Improve the Lookit platform: e.g., detect and fix "
+#| "technical problems or identify new features that\n"
+#| "                    would be helpful</li>\n"
+#| "                <li>Develop data analysis tools for Lookit researchers </"
+#| "li>\n"
+#| "                <li>Provide technical support to study researchers</li>\n"
+#| "                <li>Assess the quality of data collected on the platform "
+#| "(e.g., how well an observer can tell which\n"
+#| "                    direction children are looking)</li>\n"
+#| "                <li>Evaluate recruitment and family engagement efforts (e."
+#| "g., see how many participants come from rural\n"
+#| "                    vs. urban areas)</li>\n"
+#| "                <li>Recruit participants or researchers to use Lookit (e."
+#| "g., sharing a short video clip of your child\n"
+#| "                    having fun – ONLY if you have chosen to allow use of "
+#| "the video for publicity)</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research studies you have enrolled "
-"in, and information about which studies your\n"
-"                    children are eligible for</li>\n"
-"                <li>Send you information about studies you may be interested "
-"in, reminders to participate in multi-part\n"
-"                    studies, and/or results of studies you have participated "
-"in, subject to your contact preferences\n"
-"                </li>\n"
-"                <li>Improve the Lookit platform: e.g., detect and fix "
-"technical problems or identify new features that\n"
-"                    would be helpful</li>\n"
-"                <li>Develop data analysis tools for Lookit researchers </"
-"li>\n"
-"                <li>Provide technical support to study researchers</li>\n"
-"                <li>Assess the quality of data collected on the platform (e."
-"g., how well an observer can tell which\n"
-"                    direction children are looking)</li>\n"
-"                <li>Evaluate recruitment and family engagement efforts (e."
-"g., see how many participants come from rural\n"
-"                    vs. urban areas)</li>\n"
-"                <li>Recruit participants or researchers to use Lookit (e.g., "
-"sharing a short video clip of your child\n"
-"                    having fun – ONLY if you have chosen to allow use of the "
-"video for publicity)</li>\n"
-"            </ul>\n"
-"            "
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "<li>Proporcionarte los estudios de investigación en los que te has inscrito "
@@ -2471,17 +3592,28 @@ msgstr ""
 "</ul>\n"
 "            "
 
-#: web/templates/frontpages/privacy.html:100
+#: web/templates/web/privacy.html:113
+#, fuzzy
+#| msgid ""
+#| "Researchers use the data collected in their studies to address particular "
+#| "scientific questions. It may\n"
+#| "                also turn out that data collected for one study can help "
+#| "to answer a related question later on. If\n"
+#| "                researchers are using any additional information about "
+#| "you in their study, beyond what is collected on\n"
+#| "                Lookit – for instance, if you are participating in a "
+#| "follow-up online session for an in-person study –\n"
+#| "                they must tell you that in the study consent form."
 msgid ""
 "Researchers use the data collected in their studies to address particular "
 "scientific questions. It may\n"
-"                also turn out that data collected for one study can help to "
+"            also turn out that data collected for one study can help to "
 "answer a related question later on. If\n"
-"                researchers are using any additional information about you "
-"in their study, beyond what is collected on\n"
-"                Lookit – for instance, if you are participating in a follow-"
-"up online session for an in-person study –\n"
-"                they must tell you that in the study consent form."
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
 msgstr ""
 "Los/as investigadores/as utilizan los datos recopilados en sus estudios para "
 "abordar cuestiones científicas particulares. También puede resultar que los "
@@ -2492,7 +3624,7 @@ msgstr ""
 "para un estudio en persona, deben informarte en el formulario de "
 "consentimiento del estudio."
 
-#: web/templates/frontpages/privacy.html:106
+#: web/templates/web/privacy.html:120
 msgid ""
 "There are some basic rules about how personal information may be used that "
 "all Lookit researchers agree to, including:"
@@ -2500,17 +3632,28 @@ msgstr ""
 "Existen algunas reglas básicas sobre cómo se puede usar la información "
 "personal que todos los/as investigadores/as de Lookit aceptan, que incluyen:"
 
-#: web/templates/frontpages/privacy.html:107
+#: web/templates/web/privacy.html:122
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>They may not use usernames, child nicknames, or "
+#| "contact information as a subject of research.</li>\n"
+#| "                <li>They may contact families by postal mail only in "
+#| "order to send compensation for study participation\n"
+#| "                    or materials needed for participation.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>They may not use usernames, child nicknames, or contact "
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
 "information as a subject of research.</li>\n"
-"                <li>They may contact families by postal mail only in order "
-"to send compensation for study participation\n"
-"                    or materials needed for participation.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "\n"
 "<ul>\n"
@@ -2521,26 +3664,31 @@ msgstr ""
 "necesarios para participar.</li>\n"
 "</ul>"
 
-#: web/templates/frontpages/privacy.html:114
-#: web/templates/frontpages/privacy.html:163
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+#, fuzzy
+#| msgid ""
+#| "If you have concerns about any of these purposes, or how we communicate "
+#| "with you, please contact us at\n"
+#| "                dataprotection@mit.edu. We will always respect a request "
+#| "by you to stop processing your personal\n"
+#| "                information (subject to our legal obligations)."
 msgid ""
 "If you have concerns about any of these purposes, or how we communicate with "
 "you, please contact us at\n"
-"                dataprotection@mit.edu. We will always respect a request by "
-"you to stop processing your personal\n"
-"                information (subject to our legal obligations)."
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
 msgstr ""
 "Si tienes inquietudes sobre alguno de estos propósitos o sobre cómo nos "
 "comunicamos contigo, comunícate con nosotros en dataprotection@mit.edu. "
 "Siempre respetaremos tu solicitud de dejar de procesar tu información "
 "personal (sujeto a nuestras obligaciones legales)."
 
-#: web/templates/frontpages/privacy.html:118
-#: web/templates/frontpages/privacy.html:171
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
 msgid "How your information is stored and secured"
 msgstr "Cómo se almacena y protege tu información"
 
-#: web/templates/frontpages/privacy.html:120
+#: web/templates/web/privacy.html:138
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2565,23 +3713,23 @@ msgstr "Cómo se almacena y protege tu información"
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection, "
-"and all video data is encrypted at rest on\n"
-"                the storage systems used by Lookit to provide data to "
-"researchers. Researchers are responsible for their\n"
-"                own secure storage of data once they obtain it from Lookit. "
-"You should be aware, however, that since the\n"
-"                internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be accessed,\n"
-"                disclosed, altered, or destroyed by breach of any of our "
-"physical, technical, or managerial safeguards.\n"
-"                It's your responsibility to protect the security of your "
-"account details, including your username and\n"
-"                password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
 msgstr ""
 "Hemos implementado salvaguardas de seguridad estándar de la industria "
 "diseñadas para proteger la información personal que puedas proporcionar. "
@@ -2600,25 +3748,37 @@ msgstr ""
 "proteger la seguridad de los detalles de tu cuenta, incluidos su nombre de "
 "usuario y contraseña."
 
-#: web/templates/frontpages/privacy.html:131
-#: web/templates/frontpages/privacy.html:182
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
 msgid "How long we keep your personal information"
 msgstr "Cuánto tiempo conservamos tu información personal"
 
-#: web/templates/frontpages/privacy.html:133
+#: web/templates/web/privacy.html:153
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you wish\n"
+#| "                to remove your account, we will retain a core set of "
+#| "information about you to fulfill administrative\n"
+#| "                tasks and legal obligations. If you have participated in "
+#| "Lookit studies, the personal information\n"
+#| "                already shared with those researchers may not generally "
+#| "be ‘taken back,’ as it is part of a scientific\n"
+#| "                dataset and removing your data could affect already "
+#| "published findings."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you wish\n"
-"                to remove your account, we will retain a core set of "
-"information about you to fulfill administrative\n"
-"                tasks and legal obligations. If you have participated in "
-"Lookit studies, the personal information\n"
-"                already shared with those researchers may not generally be "
-"‘taken back,’ as it is part of a scientific\n"
-"                dataset and removing your data could affect already "
-"published findings."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
 msgstr ""
 "Consideramos que nuestra relación con nuestra comunidad de investigación es "
 "de por vida. Esto significa que mantendremos un registro hasta el momento en "
@@ -2630,29 +3790,40 @@ msgstr ""
 "\"recuperada\", ya que es parte de un conjunto de datos científicos y la "
 "eliminación de sus datos podría afectar los hallazgos ya publicados."
 
-#: web/templates/frontpages/privacy.html:144
+#: web/templates/web/privacy.html:165
+#, fuzzy
+#| msgid ""
+#| "We may collect basic biographic/contact information about you and your "
+#| "representative organization,\n"
+#| "                including name, title, business addresses, phone numbers, "
+#| "and email addresses."
 msgid ""
 "We may collect basic biographic/contact information about you and your "
 "representative organization,\n"
-"                including name, title, business addresses, phone numbers, "
-"and email addresses."
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
 msgstr ""
 "Podemos recopilar información biográfica / de contacto básica sobre usted y "
 "su organización representativa, incluido el nombre, cargo, direcciones "
 "comerciales, números de teléfono y direcciones de correo electrónico."
 
-#: web/templates/frontpages/privacy.html:149
+#: web/templates/web/privacy.html:172
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is that which you have "
+#| "provided to us when registering\n"
+#| "                to use Lookit, updating your profile, or creating or "
+#| "editing a study."
 msgid ""
 "The information we collect and maintain about you is that which you have "
 "provided to us when registering\n"
-"                to use Lookit, updating your profile, or creating or editing "
-"a study."
+"        to use Lookit, updating your profile, or creating or editing a study."
 msgstr ""
 "La información que recopilamos y mantenemos sobre ti es la que nos has "
 "proporcionado al registrarte para usar Lookit, actualizar tu perfil o crear "
 "o editar un estudio."
 
-#: web/templates/frontpages/privacy.html:154
+#: web/templates/web/privacy.html:179
 msgid ""
 "We use your personal information for a number of legitimate purposes, "
 "including the performance of contractual obligations. Specifically, we use "
@@ -2662,18 +3833,30 @@ msgstr ""
 "cumplimiento de obligaciones contractuales. Específicamente, usamos tu "
 "información personal para:"
 
-#: web/templates/frontpages/privacy.html:155
+#: web/templates/web/privacy.html:181
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Provide you with the research services for which you "
+#| "have enrolled. </li>\n"
+#| "                <li>Perform administrative tasks and for internal record "
+#| "keeping purposes.</li>\n"
+#| "                <li>Create and analyze aggregated (fully anonymized) "
+#| "information about our users for statistical\n"
+#| "                    research purposes in support of our mission.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research services for which you "
-"have enrolled. </li>\n"
-"                <li>Perform administrative tasks and for internal record "
-"keeping purposes.</li>\n"
-"                <li>Create and analyze aggregated (fully anonymized) "
-"information about our users for statistical\n"
-"                    research purposes in support of our mission.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "                <li>Brindarte los servicios de investigación para los que te "
@@ -2686,11 +3869,11 @@ msgstr ""
 "        </ul>\n"
 "           "
 
-#: web/templates/frontpages/privacy.html:169
+#: web/templates/web/privacy.html:196
 msgid "We do not share your personal information with any third parties."
 msgstr "No compartimos tu información personal con terceros."
 
-#: web/templates/frontpages/privacy.html:173
+#: web/templates/web/privacy.html:201
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2711,19 +3894,19 @@ msgstr "No compartimos tu información personal con terceros."
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection. "
-"You should be aware, however, that since\n"
-"                the internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be\n"
-"                accessed, disclosed, altered, or destroyed by breach of any "
-"of our physical, technical, or managerial\n"
-"                safeguards. It's your responsibility to protect the security "
-"of your account details, including your\n"
-"                username and password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
 msgstr ""
 "Hemos implementado salvaguardas de seguridad estándar de la industria "
 "diseñadas para proteger la información personal que puedas proporcionar. "
@@ -2742,15 +3925,24 @@ msgstr ""
 "proteger la seguridad de los detalles de tu cuenta, incluidos su nombre de "
 "usuario y contraseña."
 
-#: web/templates/frontpages/privacy.html:184
+#: web/templates/web/privacy.html:214
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you no\n"
+#| "                longer wish to hear from Lookit, we will retain a core "
+#| "set of information about you to fulfill\n"
+#| "                administrative tasks and legal obligations."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you no\n"
-"                longer wish to hear from Lookit, we will retain a core set "
-"of information about you to fulfill\n"
-"                administrative tasks and legal obligations."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
 msgstr ""
 "Consideramos que nuestra relación con nuestra comunidad de investigación es "
 "de por vida. Esto significa que mantendremos un registro hasta el momento en "
@@ -2758,25 +3950,36 @@ msgstr ""
 "deseas recibir noticias de Lookit, conservaremos un información básica sobre "
 "ti para cumplir con las tareas administrativas y las obligaciones legales."
 
-#: web/templates/frontpages/privacy.html:189
+#: web/templates/web/privacy.html:220
 msgid "For everyone"
 msgstr "Para todos/as"
 
-#: web/templates/frontpages/privacy.html:191
+#: web/templates/web/privacy.html:221
 msgid "Rights for individuals in the European Economic Area"
 msgstr "Derechos de las personas en el Espacio Económico Europeo"
 
-#: web/templates/frontpages/privacy.html:192
+#: web/templates/web/privacy.html:224
+#, fuzzy
+#| msgid ""
+#| "You have the right in certain circumstances to (1) access your personal "
+#| "information; (2) to correct or\n"
+#| "                erase information; (3) restrict processing; and (4) "
+#| "object to communications, direct marketing, or\n"
+#| "                profiling. To the extent applicable, the EU’s General "
+#| "Data Protection Regulation provides further\n"
+#| "                information about your rights. You also have the right to "
+#| "lodge complaints with your national or\n"
+#| "                regional data protection authority."
 msgid ""
 "You have the right in certain circumstances to (1) access your personal "
 "information; (2) to correct or\n"
-"                erase information; (3) restrict processing; and (4) object "
-"to communications, direct marketing, or\n"
-"                profiling. To the extent applicable, the EU’s General Data "
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
 "Protection Regulation provides further\n"
-"                information about your rights. You also have the right to "
-"lodge complaints with your national or\n"
-"                regional data protection authority."
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
 msgstr ""
 "En determinadas circunstancias, tienes derecho a (1) acceder a tu "
 "información personal; (2) corregir o borrar información; (3) restringir el "
@@ -2786,23 +3989,40 @@ msgstr ""
 "tus derechos. También tienes derecho a presentar quejas ante tu autoridad de "
 "protección de datos nacional o regional."
 
-#: web/templates/frontpages/privacy.html:198
+#: web/templates/web/privacy.html:231
+#, fuzzy
+#| msgid ""
+#| "If you are inclined to exercise these rights, we request an opportunity "
+#| "to discuss with you any concerns\n"
+#| "                you may have. To protect the personal information we "
+#| "hold, we may also request further information to\n"
+#| "                verify your identify when exercising these rights. Upon a "
+#| "request to erase information, we will maintain\n"
+#| "                a core set of personal data to ensure we do not contact "
+#| "you inadvertently in the future, as well as any\n"
+#| "                information necessary for archival purposes. We may also "
+#| "need to retain some financial information for\n"
+#| "                legal purposes, including US IRS compliance. In the event "
+#| "of an actual or threatened legal claim, we may\n"
+#| "                retain your information for purposes of establishing, "
+#| "defending against or exercising our rights with\n"
+#| "                respect to such claim."
 msgid ""
 "If you are inclined to exercise these rights, we request an opportunity to "
 "discuss with you any concerns\n"
-"                you may have. To protect the personal information we hold, "
-"we may also request further information to\n"
-"                verify your identify when exercising these rights. Upon a "
-"request to erase information, we will maintain\n"
-"                a core set of personal data to ensure we do not contact you "
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
 "inadvertently in the future, as well as any\n"
-"                information necessary for archival purposes. We may also "
-"need to retain some financial information for\n"
-"                legal purposes, including US IRS compliance. In the event of "
-"an actual or threatened legal claim, we may\n"
-"                retain your information for purposes of establishing, "
-"defending against or exercising our rights with\n"
-"                respect to such claim."
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
 msgstr ""
 "Si estás dispuesto/a a ejercer estos derechos, te ofrecemos la oportunidad "
 "de discutir con nosotros cualquier inquietud que puedas tener. Para proteger "
@@ -2817,15 +4037,24 @@ msgstr ""
 "o amenazado, podemos retener tu información con el fin de establecer, "
 "defender o ejercer nuestros derechos con respecto a dicho reclamo."
 
-#: web/templates/frontpages/privacy.html:207
+#: web/templates/web/privacy.html:241
+#, fuzzy
+#| msgid ""
+#| "By providing information directly to Lookit, you consent to the transfer "
+#| "of your personal information\n"
+#| "                outside of the European Economic Area to the United "
+#| "States. You understand that the current laws and\n"
+#| "                regulations of the United States may not provide the same "
+#| "level of protection as the data and privacy\n"
+#| "                laws and regulations of the EEA."
 msgid ""
 "By providing information directly to Lookit, you consent to the transfer of "
 "your personal information\n"
-"                outside of the European Economic Area to the United States. "
-"You understand that the current laws and\n"
-"                regulations of the United States may not provide the same "
-"level of protection as the data and privacy\n"
-"                laws and regulations of the EEA."
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
 msgstr ""
 "Al proporcionar información directamente a Lookit, aceptas la transferencia "
 "de tu información personal fuera del Espacio Económico Europeo a los Estados "
@@ -2833,7 +4062,7 @@ msgstr ""
 "Unidos pueden no proporcionar el mismo nivel de protección que las leyes y "
 "regulaciones de privacidad y datos del EEE."
 
-#: web/templates/frontpages/privacy.html:212
+#: web/templates/web/privacy.html:246
 msgid ""
 "You are under no statutory or contractual obligation to provide any personal "
 "data to us."
@@ -2841,23 +4070,29 @@ msgstr ""
 "No tienes ninguna obligación legal o contractual de proporcionarnos datos "
 "personales."
 
-#: web/templates/frontpages/privacy.html:214
+#: web/templates/web/privacy.html:248
 msgid "Additional Information"
 msgstr "Información Adicional"
 
-#: web/templates/frontpages/privacy.html:216
+#: web/templates/web/privacy.html:251
+#, fuzzy
+#| msgid ""
+#| "We may change this Privacy Statement from time to time. If we make any "
+#| "significant changes in the way we\n"
+#| "                treat your personal information we will make this clear "
+#| "on our website or by contacting you directly."
 msgid ""
 "We may change this Privacy Statement from time to time. If we make any "
 "significant changes in the way we\n"
-"                treat your personal information we will make this clear on "
-"our website or by contacting you directly."
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
 msgstr ""
 "Podemos cambiar esta Declaración de privacidad de vez en cuando. Si "
 "realizamos cambios significativos en la forma en que tratamos tu información "
 "personal, lo dejaremos claro en nuestro sitio web o comunicándonos contigo "
 "directamente."
 
-#: web/templates/frontpages/privacy.html:220
+#: web/templates/web/privacy.html:255
 msgid ""
 "The controller for your personal information is MIT. We can be contacted at "
 "dataprotection@mit.edu."
@@ -2865,642 +4100,131 @@ msgstr ""
 "MIT controla tu información personal. Puede ser contactado en "
 "dataprotection@mit.edu."
 
-#: web/templates/frontpages/privacy.html:222
+#: web/templates/web/privacy.html:257
 msgid "This policy was last updated in June 2018."
 msgstr "Esta política se actualizó por última vez en junio de 2018."
 
-#: web/templates/frontpages/scientists.html:27
-msgid "Meet the Lookit team"
-msgstr "Conoce al equipo de Lookit"
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
 
-#: web/templates/frontpages/scientists.html:33
-msgid "Core Team"
-msgstr "Equipo principal"
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
 
-#: web/templates/frontpages/scientists.html:38
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
 msgid ""
-"Rico is Lookit's lead software engineer, working on planning and adding "
-"features for both participants and researchers."
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
 msgstr ""
-"Rico es el líder en ingeniería de software de Rico y trabaja en la "
-"planificación y adición de nuevas aplicaciones para participantes y personal "
-"de investigación."
 
-#: web/templates/frontpages/scientists.html:43
-msgid ""
-"Laura is the PI of the Early Childhood Cognition Lab. She conducts research "
-"about how children arrive at a common-sense understanding of the physical "
-"and social world through exploration and instruction."
-msgstr ""
-"Laura es la investigadora principal del Early Childhood Cognition Lab. "
-"Investiga sobre cómo los/as niños/as llegan a comprender el mundo físico y "
-"social que les rodea a través de la exploración y la instrucción."
-
-#: web/templates/frontpages/scientists.html:49
-msgid ""
-"Kim started Lookit as a graduate student, and now runs the project as a "
-"research scientist in the Early Childhood Cognition Lab. Her three children "
-"frequently provide feedback on studies."
-msgstr ""
-"Kim comenzó Lookit como doctoranda y ahora gestiona el proyecto como "
-"investigadora en el Early Childhood Cognition Lab. Sus tres hijos/as dan su "
-"opinión sobre los estudio con frecuencia."
-
-#: web/templates/frontpages/scientists.html:54
-msgid ""
-"Mark organizes the Lookit Working Groups, which are groups of researchers "
-"working to improve Lookit in a variety of ways."
-msgstr ""
-"Mark organiza los Grupos de Trabajo de Lookit, en los que se trabaja para "
-"mejorar Lookit de diversas formas."
-
-#: web/templates/frontpages/scientists.html:58
-msgid ""
-"\n"
-"                <h3>Alumni &amp; Collaborators</h3>\n"
-"                <hr>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/joseph.jpg\"></div>\n"
-"                    <h3>Joseph Alvarez (Summer 2015)</h3>\n"
-"                    <p>Undergraduate, Skidmore College</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/daniela.jpg\"></div>\n"
-"                    <h3>Daniela Carrasco (Sp 2015)</h3>\n"
-"                    <p>Undergraduate, MIT</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/jean.jpg\"></div>\n"
-"                    <h3>Jean Chow (Fa 2014)</h3>\n"
-"                    <p>Undergraduate, MIT</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/junyi.jpg\"></div>\n"
-"                    <h3>Junyi Chu</h3>\n"
-"                    <p>Junyi runs the \"Your baby, the physicist\" study. "
-"She's working on answering all the amazing\n"
-"                        questions we can only answer with longitudinal data "
-"like this.</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/annie.jpg\"></div>\n"
-"                    <h3>Annie Dai (IAP, Sp 2015)</h3>\n"
-"                    <p>Undergraduate, MIT</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/molly.jpg\"></div>\n"
-"                    <h3>Moira (Molly) Dillon</h3>\n"
-"                    <p>Molly is an Assistant Professor of Psychology and the "
-"PI of the Lab for the Developing Mind at\n"
-"                        NYU. She ran the study \"Baby Euclid\" on Lookit.</"
-"p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/hope.jpg\"></div>\n"
-"                    <h3>Hope Fuller-Becker (Sp 2015, Sp 2016)</h3>\n"
-"                    <p>Undergraduate, Wellesley College</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img src=\"https://s3."
-"amazonaws.com/lookitcontents/website/kamaria.jpg\">\n"
-"                    </div>\n"
-"                    <h3>Kamaria Kaalund (Fall 2019)</h3>\n"
-"                    <p>Undergraduate, Wellesley College</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/melissa.png\"></div>\n"
-"                    <h3>Melissa Kline</h3>\n"
-"                    <p>Postdoc, MIT</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/rachel.png\"></div>\n"
-"                    <h3>Rachel Magid</h3>\n"
-"                    <p>As ECCL lab coordinator (and then graduate student) "
-"she helped get Lookit off the ground!</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/audrey.jpg\"></div>\n"
-"                    <h3>Audrey Ricks (Summer 2016)</h3>\n"
-"                    <p>Undergraduate, MIT</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/rianna.jpg\"></div>\n"
-"                    <h3>Rianna Shah (IAP, Sp, Fall 2015; IAP, Sp 2016; Sp "
-"2018)</h3>\n"
-"                    <p>Undergraduate, MIT </p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img src=\"https://s3."
-"amazonaws.com/lookitcontents/website/alice.jpg\"></div>\n"
-"                    <h3>Alice Wang (Summer 2017)</h3>\n"
-"                    <p>Undergraduate, Wellesley</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img src=\"https://s3."
-"amazonaws.com/lookitcontents/website/erica.jpg\"></div>\n"
-"                    <h3>Erica Yoon</h3>\n"
-"                    <p>Erica is a graduate student in Mike Frank's lab at "
-"Stanford University. She ran the study \"Mind\n"
-"                        and Manners\" on Lookit.</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/jeanyu.jpg\"></div>\n"
-"                    <h3>Jean Yu (IAP, Sp 2015)</h3>\n"
-"                    <p>Undergraduate, Wellesley College</p>\n"
-"                </div>\n"
-"                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-lg-3\">\n"
-"                    <div class=\"profile-img\"><img\n"
-"                            src=\"https://storage.googleapis.com/lookit-"
-"staging/static/images/jessica.jpg\"></div>\n"
-"                    <h3>Jessica Zhu (Fall 2016)</h3>\n"
-"                    <p>Undergraduate, MIT</p>\n"
-"                </div>\n"
-"                "
-msgstr ""
-"\n"
-"&nbsp;\n"
-"                "
-
-#: web/templates/registration/logged_out.html:6
-msgid "You've successfully logged out."
-msgstr "Has cerrado la sesión correctamente."
-
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr ""
-"Tus credenciales de inicio de sesión no funcionaron. Inténtalo de nuevo."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:45
-msgid "Login"
-msgstr "Iniciar sesión"
-
-#: web/templates/registration/login.html:34
-msgid "Forgot password?"
-msgstr "¿Has olvidado tu contraseña?"
-
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "¿Nuevo/a en Lookit?"
-
-#: web/templates/registration/login.html:36
-msgid "Register your family!"
-msgstr "¡Registra tu familia!"
-
-#: web/templates/registration/password_change_done.html:11
-msgid "Password changed"
-msgstr "Contraseña cambiada"
-
-#: web/templates/registration/password_change_done.html:15
-msgid "Your password was changed."
-msgstr "Tu contraseña se ha cambiado."
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Documentation"
-msgstr "Documentación"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Change password"
-msgstr "Cambia la contraseña"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Log out"
-msgstr "Cerrar sesión"
-
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
-msgid "Home"
-msgstr "Inicio"
-
-#: web/templates/registration/password_change_form.html:8
-msgid "Password change"
-msgstr "Cambio de contraseña"
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the error below."
-msgstr "Por favor, corrige el error a continuación."
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the errors below."
-msgstr "Por favor, corrige los errores a continuación."
-
-#: web/templates/registration/password_change_form.html:26
-msgid ""
-"Please enter your old password, for security's sake, and then enter your new "
-"password twice so we can verify you typed it in correctly."
-msgstr ""
-"Introduce su contraseña anterior, por motivos de seguridad, y luego "
-"introduzca su nueva contraseña dos veces para que podamos verificar que la "
-"ingresó correctamente."
-
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
-msgid "Change my password"
-msgstr "Cambiar mi contraseña"
-
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Restablecimiento de contraseña completado"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr ""
-"Tu contraseña ha sido establecida. Puedes continuar e iniciar sesión ahora."
-
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "Iniciar sesión"
-
-#: web/templates/registration/password_reset_confirm.html:11
-msgid "Password reset confirmation"
-msgstr "Confirmación de restablecimiento de contraseña"
-
-#: web/templates/registration/password_reset_confirm.html:17
-msgid ""
-"Please enter your new password twice so we can verify you typed it in "
-"correctly."
-msgstr ""
-"Introduce tu nueva contraseña dos veces para que podamos verificar que la "
-"has introducido correctamente."
-
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nueva contraseña:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Confirmar contraseña:"
-
-#: web/templates/registration/password_reset_confirm.html:37
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"El enlace de restablecimiento de contraseña no es válido, posiblemente "
-"porque ya se ha utilizado. Por favor, solicita un nuevo restablecimiento de "
-"contraseña."
-
-#: web/templates/registration/password_reset_done.html:11
-msgid "Password reset link sent"
-msgstr "Se envió el enlace para restablecer la contraseña"
-
-#: web/templates/registration/password_reset_done.html:15
-msgid ""
-"If an account exists with the email you entered, we've emailed instructions "
-"for resetting your password and you should receive them shortly."
-msgstr ""
-"Si existe una cuenta con el correo electrónico que has ingresado, te "
-"enviaremos instrucciones por correo electrónico para restablecer tu "
-"contraseña y deberías recibirlas en breve."
-
-#: web/templates/registration/password_reset_done.html:17
-msgid ""
-"If you don't receive an email, please check your spam folder and make sure "
-"you've entered the address you registered with. (You won't get an email "
-"unless there's already an account for that email address!)"
-msgstr ""
-"Si no recibes un correo electrónico, verifica tu carpeta de correo no "
-"deseado y asegúrate de haber ingresado la dirección con la que te has "
-"registrado. (¡No recibirás un correo electrónico a menos que ya haya una "
-"cuenta para esa dirección de correo electrónico!)"
-
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
-msgid ""
-"You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
-msgstr ""
-"Recibiste este correo electrónico porque has solicitado un restablecimiento "
-"de contraseña para tu cuenta de usuario/a en %(site_name)s."
-
-#: web/templates/registration/password_reset_email.html:4
-msgid "Please go to the following page and choose a new password:"
-msgstr "Ve a la página siguiente y elige una nueva contraseña:"
-
-#: web/templates/registration/password_reset_email.html:8
-msgid "Your username, in case you've forgotten:"
-msgstr "Tu nombre de usuario/a, en caso de que lo hayas olvidado:"
-
-#: web/templates/registration/password_reset_email.html:10
-msgid "Thanks for using our site!"
-msgstr "¡Gracias por usar nuestra página web!"
-
-#: web/templates/registration/password_reset_email.html:12
-#, python-format
-msgid "The %(site_name)s team"
-msgstr "El equipo de %(site_name)s"
-
-#: web/templates/registration/password_reset_form.html:11
-msgid "Password reset"
-msgstr "Restablecimiento de contraseña"
-
-#: web/templates/registration/password_reset_form.html:15
-msgid ""
-"Forgotten your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"¿Olvidaste tu contraseña? Introduce tu dirección de correo electrónico a "
-"continuación y te enviaremos las instrucciones para configurar una nueva."
-
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Dirección de correo electrónico:"
-
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Restablecer mi contraseña"
-
-#: web/templates/web/_navigation.html:17
-msgid "Experimenter"
-msgstr "Experimentador"
-
-#: web/templates/web/_navigation.html:28 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Estudios"
-
-#: web/templates/web/_navigation.html:29
-msgid "FAQ"
-msgstr "Preguntas más frecuentes"
-
-#: web/templates/web/_navigation.html:30
-msgid "The Scientists"
-msgstr "Los científicos"
-
-#: web/templates/web/_navigation.html:31
-msgid "Resources"
-msgstr "Recursos"
-
-#: web/templates/web/_navigation.html:40
-msgid "Hi"
-msgstr "Hola"
-
-#: web/templates/web/_navigation.html:42
-msgid "Logout"
-msgstr "Cerrar sesión"
-
-#: web/templates/web/_navigation.html:44
-msgid "Sign up"
-msgstr "Regístrese"
-
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
-msgid "Child"
-msgstr "Niño"
-
-#: web/templates/web/child-update.html:26
-msgid "Back to Children List"
-msgstr "Volver a la lista de niños/as"
-
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Actualizar"
-
-#: web/templates/web/child-update.html:41
-msgid "Delete"
-msgstr "Eliminar"
-
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Fecha de nacimiento vacía"
-
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " día"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " dias"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " mes"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " meses"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " año"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " años"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Agregar niño/a"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Ocultar formulario"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nombre"
-
-#: web/templates/web/children-list.html:121
-msgid "Update child"
-msgstr "Actualizar niño/a"
-
-#: web/templates/web/children-list.html:128
-msgid "No child profiles registered!"
-msgstr "¡No hay perfiles de niños/as registrados/as!"
-
-#: web/templates/web/demographic-data-update.html:4
-msgid "Update demographics"
-msgstr "Actualizar datos demográficos"
-
-#: web/templates/web/demographic-data-update.html:89
-msgid ""
-"One reason we are developing Internet-based experiments is to represent a "
-"more diverse group of families in our research. Your answers to these "
-"questions will help us understand what audience we reach, as well as how "
-"factors like speaking multiple languages or having older siblings affect "
-"children's learning."
-msgstr ""
-"Una de las razones por la que estamos desarrollando experimentos on-line es "
-"para representar a un grupo más plural de familias en nuestra investigación. "
-"Sus respuestas a estas preguntas nos ayudarán a comprender a qué población "
-"llegamos, y cómo factores como hablar varios idiomas o tener hermanos "
-"mayores afectan el aprendizaje de los/as niños/as."
-
-#: web/templates/web/demographic-data-update.html:90
-msgid ""
-"Even if you allow your study videos to be published for scientific or "
-"publicity purposes, your demographic information is never published in "
-"conjunction with your video."
-msgstr ""
-"Incluso si permite que sus vídeos del estudio se publiquen con fines "
-"científicos o publicitarios, su información demográfica nunca será publicada "
-"junto con su vídeo."
-
-#: web/templates/web/participant-email-preferences.html:27
-msgid "I would like to be contacted when:"
-msgstr "Me gustaría ser contactado/a cuando:"
-
-#: web/templates/web/participant-signup.html:18
-msgid "Create Participant Account"
-msgstr "Crear cuenta de participante"
-
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
-msgstr ""
-"¡Crea una cuenta familiar para empezar a participar en los estudios Lookit!"
-
-#: web/templates/web/participant-signup.html:31
-msgid ""
-"By clicking 'Create Account', I agree that I have read and accepted the "
-msgstr "Al hacer clic en 'Crear cuenta', acepto que he leído y aceptado el "
-
-#: web/templates/web/participant-signup.html:31
-msgid "Privacy Statement"
-msgstr "Declaracion de privacidad"
-
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Crear una cuenta"
-
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Estudios pasados"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
+#: web/templates/web/studies-history.html:15
+#, fuzzy
+#| msgid "Video"
+msgid "Next Video"
+msgstr "Vídeo"
+
+#: web/templates/web/studies-history.html:31
 msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
 msgstr ""
-"Su cuenta no tiene acceso a esta página. Para continuar, inicie sesión con "
-"una cuenta que tenga acceso."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Inicie sesión para ver esta página."
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Estudios actuales"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Sus estudios anteriores"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Aquí puede ver sus estudios y ver los comentarios dejados por los/as "
 "investigadores/as:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Vista previa del estudio"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Requisitos:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contacto:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "¿Seguimos recogiendo datos?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Sí"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "No"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Compensación: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Compensación"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Respuestas del estudio"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "Vídeo"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Fecha"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Estado de consentimiento"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Aprobado"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Su vídeo de consentimiento fue revisado por un/a investigador/a y es válido."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "Pendiente"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr ""
 "Su vídeo de consentimiento aún no ha sido revisado por un/a investigador/a."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Inválido"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -3510,178 +4234,179 @@ msgstr ""
 "la declaración de consentimiento en voz alta. Los investigadores del estudio "
 "no verán ni utilizarán el resto de datos de esta sesión."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr ""
 "No hay información sobre el estado de revisión del video de consentimiento."
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "Feedback"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "Ninguno"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Aún no ha participado en ningún estudio."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Estudios actuales"
+#: web/templates/web/studies-history.html:147
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Aún no ha participado en ningún estudio."
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Estudios"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Tenga en cuenta que necesitará un ordenador portátil o de escritorio (no un "
-"dispositivo móvil) con Chrome o Firefox para participar."
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Ver detalles"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "¡No estamos realizando ningún estudio en este momento!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"¿Busca más formas de contribuir a la investigación desde casa? ¡Consulte <a "
-"href=\"https://childrenhelpingscience.com/\" target=\"_blank\" rel="
-"\"noreferrer noopener\"> Niños ayudando a la ciencia </a> para obtener aún "
-"más estudios!"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "días"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " hasta "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " cuando "
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Recursos"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Resumen del estudio"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Volver a la lista"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Criterios de selección"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Duración"
-
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Compensación"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Qué sucede"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Qué estamos estudiando"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Este estudio es realizado por"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "¿Le gustaría participar en este estudio?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Inicie sesión para participar"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "Añadir perfil de niño/a para "
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "vista previa"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "participar"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "ahora"
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr ""
+"Crea un espacio de ejecución de experimentos para obtener una vista previa"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Inicie sesión para participar"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "Añadir perfil de niño/a para "
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "Completar encuesta demográfica para "
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Participar"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Qué sucede"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Qué estamos estudiando"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Duración"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Este estudio es realizado por"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "¿Le gustaría participar en este estudio?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Seleccione un/a niño/a:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Ninguno/a seleccionado/a"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Su hijo aún demasiado pequeño para el rango de edad recomendado para este "
 "estudio. Si puede esperar <span id = 'wait-until'> hasta que </span> él o "
 "ella tenga la edad suficiente, ¡podremos usar los datos recogidos en nuestra "
 "investigación!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Su hijo es demasiado mayor para el rango de edad recomendado para este "
 "estudio. Puede probar el estudio de todos modos, pero no podremos utilizar "
 "los datos recogidos en nuestra investigación."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Su hijo/a no cumple con los criterios de selección de este estudio. Puede "
 "probar a realizar el estudio de todos modos, pero no podremos utilizar los "
 "datos recogidos en nuestra investigación. Póngase en contacto con los/as "
 "investigadores/as del estudio."
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr ""
-"Crea un espacio de ejecución de experimentos para obtener una vista previa"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Participar"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "ahora"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -3689,31 +4414,89 @@ msgstr ""
 "Para ver fácilmente lo que sucede a medida que actualiza el protocolo de su "
 "estudio, guarde la URL a la que le envía el botón de arriba."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Regístrese"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Tenga en cuenta que necesitará un ordenador portátil o de escritorio (no un "
+"dispositivo móvil) con Chrome o Firefox para participar."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "Participante creado/a."
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "Datos demográficos guardados."
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "Niño/a añadido/a."
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "Niño/a eliminado/a."
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "Niño/a actualizado/a."
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "Preferencias de email guardadas."
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -3724,14 +4507,558 @@ msgstr ""
 "sido completado o pausado. Si crees que es un error, por favor contacta con "
 "{study.contact_info}"
 
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr "Tu contraseña no puede ser muy similar a la información personal."
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "Tu contraseña debe contener al menos 16 caracteres."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "Tu contraseña no puede ser una contraseña de uso común."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "Tu contraseña no puede ser completamente numérica."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "¿Con qué categoría(s) se identifica tu familia?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Sólo respuestas numéricas - ¡una aproximación es suficiente!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "¿Qué idioma(s) habla vuestra familia en casa?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "¿Cuál es el máximo nivel educativo que ha completado tu pareja?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Aproximadamente ¿cuántos libros infantiles hay en vuestra casa?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Si la respuesta varía debido a asuntos de custodia compartida o viajes, "
+#~ "introduce el número de madres/padres/tutores con los que viven "
+#~ "habitualmente tus hijos/as o explícanoslo."
+
+#~ msgid "other"
+#~ msgstr "otro"
+
+#~ msgid "3 or more"
+#~ msgstr "3 o más"
+
+#~ msgid "varies"
+#~ msgstr "varía"
+
+#~ msgid "My Account"
+#~ msgstr "Mi cuenta"
+
+#~ msgid "Last Active:"
+#~ msgstr "Activo por última vez:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "ID global de participante:"
+
+#~ msgid "Dashboard"
+#~ msgstr "Panel de control"
+
+#~ msgid "Argentinian Spanish"
+#~ msgstr "Español argentino"
+
+#~ msgid "Canadian French"
+#~ msgstr "Francés canadiense"
+
+#~ msgid "Norwegian Bokmål"
+#~ msgstr "Noruego bokmål"
+
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "Portugués brasileño"
+
+#~ msgid "Simplified Chinese"
+#~ msgstr "Chino simplificado"
+
+#~ msgid "Yue"
+#~ msgstr "Yue"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#~ msgid "How can we participate online?"
+#~ msgstr "¿Cómo podemos participar on-line?"
+
+#~ msgid ""
+#~ "\n"
+#~ "                            <p>If you have a child and would like to "
+#~ "participate, create an account and take a look at what we have available "
+#~ "for your child's age range. You'll need a working webcam to participate.</"
+#~ "p>\n"
+#~ "                                <p>When you select a study, you'll be "
+#~ "asked to read a consent form and record yourself stating that you and "
+#~ "your child agree to participate. Then we'll guide you through what will "
+#~ "happen during the study. Depending on your child's age, your child may "
+#~ "answer questions directly or we may be looking for indirect signs of what "
+#~ "she thinks is going on--like how long she looks at a surprising outcome.</"
+#~ "p>\n"
+#~ "                                <p>Some portions of the study will be "
+#~ "automatically recorded using your webcam and sent securely to the Lookit "
+#~ "platform. Trained researchers will watch the video and record your "
+#~ "child's responses--for instance, which way he pointed, or how long she "
+#~ "looked at each image. We'll put these together with responses from lots "
+#~ "of other children to learn more about how kids think!</p>\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ "        \t\t\t\t\t\t\t\t<p>Si tienes un/a hijo/a y te gustaría "
+#~ "participar, crea una cuenta y echa un vistazo a los estudios que tenemos "
+#~ "disponibles para el rango de edad de tu hijo/a. Necesitarás una webcam "
+#~ "que funcione para participar.</p>\n"
+#~ "        \t\t\t\t\t\t\t\t<p>Cuando selecciones un estudio te pediremos que "
+#~ "leas un consentimiento informado y te grabes declarando que tú y tu hijo/"
+#~ "a aceptáis participar. Después os explicaremos lo que haréis durante el "
+#~ "estudio. Dependiendo de su edad, tu hijo/a responderá las preguntas "
+#~ "directamente o buscará pistas indirectas de lo que piensa que ocurrirá--"
+#~ "como por ejemplo cuánto tiempo mira hacia un evento sorprendente.</p>\n"
+#~ "        \t\t\t\t\t\t\t\t<p>Algunas partes del estudio serán grabadas "
+#~ "automáticamente utilizando vuestra webcam y se enviarán de forma segura a "
+#~ "la plataforma de Lookit. Investigadores/as entrenados/as verán el video y "
+#~ "registrarán las respuestas de tu hijo/a--por ejemplo, hacia qué lado "
+#~ "señala o cuánto tiempo mira a cada imagen. ¡Juntaremos estas respuestas "
+#~ "con respuestas de muchos otros niños/as para conocer más sobre cómo "
+#~ "piensan los bebés!</p>\n"
+#~ "        \t\t\t\t\t\t\t"
+
+#~ msgid ""
+#~ "Any researcher with questions about how kids learn and grow can propose a "
+#~ "Lookit study! Each institution using Lookit has to sign a contract with "
+#~ "MIT where they agree to the <a href='/termsofuse'>Terms of Use</a> and "
+#~ "certify that their studies will be reviewed and approved by an "
+#~ "institutional review board. Studies are also subject to approval by "
+#~ "Lookit. As of June 2020 we have agreements with 20 universities!"
+#~ msgstr ""
+#~ "¡Cualquier investigador/a con preguntas sobre cómo aprenden y crecen los/"
+#~ "as niños/as puede proponer un estudio en Lookit! Cada institución que "
+#~ "utilice Lookit debe firmar un contrato con el MIT donde aceptan los <a "
+#~ "href='/termsofuse'>Términos de Uso</a> y certificar que sus estudios "
+#~ "serán revisados y aprobados por un comité revisor institucional. Los "
+#~ "estudios serán aprobados por Lookit. ¡Lookit tiene acuerdos con 20 "
+#~ "universidades desde junio de 2020!"
+
+#~ msgid ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+#~ msgstr ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+
+#~ msgid ""
+#~ "Traditionally, developmental studies happen in a quiet room in a "
+#~ "university lab. Researchers call or email local parents to see if they'd "
+#~ "like to take part and schedule an appointment for them to come visit the "
+#~ "lab. Why complement these in-lab studies with online ones? We're hoping "
+#~ "to..."
+#~ msgstr ""
+#~ "Tradicionalmente, los estudios sobre desarrollo se realizan en una sala "
+#~ "silenciosa en un laboradorio de una universidad. El equipo de "
+#~ "investigación llama o envía un correo electrónico a la familia, "
+#~ "invitándoles a participar y preparan una cita para que vengan a visitar "
+#~ "el laboratorio. ¿Por qué complementar estos estudios en el laboratorio "
+#~ "con estudios on-line? Esperamos..."
+
+#~ msgid "When will we see the results of the study?"
+#~ msgstr "¿Cuándo podré ver los resultados de mi estudio?"
+
+#~ msgid ""
+#~ "The process of publishing a scientific study, from starting data "
+#~ "collection to seeing the paper in a journal, can take several years. You "
+#~ "can check the Lookit home page for updates on papers, or set your "
+#~ "communication preferences to be notified when we have results from "
+#~ "studies you participated in."
+#~ msgstr ""
+#~ "El proceso de publicar un estudio científico desde la recogida de datos "
+#~ "hasta su publicación en versión impresa u on-line puede llevar varios "
+#~ "años. Puedes echar un vistazo a la página de inicio de Lookit para ver "
+#~ "actualizaciones sobre nuestros estudios o cambiar las preferencias de "
+#~ "notificaciones para que se os avise cuando tengamos los resultados de "
+#~ "estudios en los que habéis participado."
+
+#~ msgid "Can I get my child's results?"
+#~ msgstr "¿Puedo obtener los resultados de mi hijo/a?"
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                                <p>For some studies, yes! Usually, "
+#~ "developmental researchers only interpret children's abilities and "
+#~ "developmental trends at a group level, and the individual data collected "
+#~ "just isn't very interpretable. But for \"Your baby, the physicist\" and "
+#~ "other longitudinal studies (where you come back for more than one "
+#~ "session), we can sometimes collect enough data to give you a report of "
+#~ "your child's responses after you complete all the sessions.</p>\n"
+#~ "                                <p>Please note that none of the measures "
+#~ "we collect are diagnostic! For instance, while we hope you'll be "
+#~ "interested to learn that your child looked 70%% of the time at videos "
+#~ "where things fell up versus falling down, we won't be able to tell you "
+#~ "whether this means your child is going to be especially good at physics.</"
+#~ "p>\n"
+#~ "                                <p>If you're interested in getting "
+#~ "individual results right away, please see our <a "
+#~ "href='resources'>Resources</a> section for fun at-home activities you can "
+#~ "try with your child.</p>\n"
+#~ "                                "
+#~ msgstr ""
+#~ "\n"
+#~ "<p>Para algunos estudios, ¡sí! Normalmente, en estudios sobre desarrollo "
+#~ "infantil el equipo de investigación sólo intepreta las habilidades y "
+#~ "trayectorias de desarrollo de los participantes en el nivel de grupo, ya "
+#~ "que los datos recogidos de un/a sólo/a participante son difíciles de "
+#~ "interpretar. Para estudios como \"Your baby, the physicist\" y otros "
+#~ "estudios longitudinales (en los que participáis en más de una sesión) a "
+#~ "veces recogemos información suficiente para entregaros un informe sobre "
+#~ "las respuestas de vuestro/a hijo/a una vez hayáis completado todas las "
+#~ "sesiones.</p>\n"
+#~ "        \t\t\t\t\t\t\t    <p>Por favor, ¡tened en cuenta que ninguna de "
+#~ "las medidas que tomamos son diagnósticas! Por ejemplo, aunque esperamos "
+#~ "que estés interesado/a en que vuestro/a hijo/a haya mirado un 70%% del "
+#~ "tiempo a un vídeo en el que algunos objectos se caían hacia arriba, "
+#~ "mientras que ojos objetos se caían hacia abajo, esto no querrá decir que "
+#~ "tu hijo/a vaya a ser especialmente bueno/a o malo/a en física.</p>\n"
+#~ "        \t\t\t\t\t\t\t\t<p>Si os interesa tener vuestros resultados "
+#~ "individuales en el momento, por favor visitad la sección de <a href=\"/"
+#~ "resources\">Recursos</a> para acceder a actividades divertidas que podéis "
+#~ "hacer desde casa con vuestro/a hijo/a.</p>\n"
+#~ "                                "
+
+#~ msgid "the online child lab"
+#~ msgstr "el laboratorio de infancia online"
+
+#~ msgid "A project of the MIT Early Childhood Cognition Lab"
+#~ msgstr "Un proyecto del Early Childhood Cognition Lab"
+
+#~ msgid "Bringing science home"
+#~ msgstr "Llevando la ciencia a casa"
+
+#~ msgid ""
+#~ "Here at MIT's Early Childhood Cognition Lab, we're trying a new approach "
+#~ "in developmental psychology: bringing the experiments to you."
+#~ msgstr ""
+#~ "Aquí en el Early Childhood Cognition Lab del MIT estamos probando una "
+#~ "nueva forma de investigar la psicología del desarrollo: llevando nuestros "
+#~ "estudios a vosotros/as."
+
+#~ msgid "Help us understand how your child thinks"
+#~ msgstr "Ayúdanos a comprender cómo piensan los/as niños/as"
+
+#~ msgid ""
+#~ "Your family can contribute to research about how children learn by doing "
+#~ "fun activities together, right in your web browser."
+#~ msgstr ""
+#~ "Tu familia puede contribuir a la investigación sobre como los/as niños/as "
+#~ "aprenden haciendo actividades divertidas juntos/as en nuestro navegador."
+
+#~ msgid "Participate whenever and wherever"
+#~ msgstr "Participa donde y cuando quieras"
+
+#~ msgid ""
+#~ "Log in or create an account at the top right to get started! You can "
+#~ "participate with your child from any computer with a webcam."
+#~ msgstr ""
+#~ "¡Inicia sesión o regístrate arriba a la derecha para empezar! Puedes "
+#~ "participar con tu hijo/a desde cualquier ordenador con una webcam."
+
+#~ msgid "Core Team"
+#~ msgstr "Equipo principal"
+
+#~ msgid ""
+#~ "Rico is Lookit's lead software engineer, working on planning and adding "
+#~ "features for both participants and researchers."
+#~ msgstr ""
+#~ "Rico es el líder en ingeniería de software de Rico y trabaja en la "
+#~ "planificación y adición de nuevas aplicaciones para participantes y "
+#~ "personal de investigación."
+
+#~ msgid ""
+#~ "Laura is the PI of the Early Childhood Cognition Lab. She conducts "
+#~ "research about how children arrive at a common-sense understanding of the "
+#~ "physical and social world through exploration and instruction."
+#~ msgstr ""
+#~ "Laura es la investigadora principal del Early Childhood Cognition Lab. "
+#~ "Investiga sobre cómo los/as niños/as llegan a comprender el mundo físico "
+#~ "y social que les rodea a través de la exploración y la instrucción."
+
+#~ msgid ""
+#~ "Kim started Lookit as a graduate student, and now runs the project as a "
+#~ "research scientist in the Early Childhood Cognition Lab. Her three "
+#~ "children frequently provide feedback on studies."
+#~ msgstr ""
+#~ "Kim comenzó Lookit como doctoranda y ahora gestiona el proyecto como "
+#~ "investigadora en el Early Childhood Cognition Lab. Sus tres hijos/as dan "
+#~ "su opinión sobre los estudio con frecuencia."
+
+#~ msgid ""
+#~ "Mark organizes the Lookit Working Groups, which are groups of researchers "
+#~ "working to improve Lookit in a variety of ways."
+#~ msgstr ""
+#~ "Mark organiza los Grupos de Trabajo de Lookit, en los que se trabaja para "
+#~ "mejorar Lookit de diversas formas."
+
+#~ msgid ""
+#~ "\n"
+#~ "                <h3>Alumni &amp; Collaborators</h3>\n"
+#~ "                <hr>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/joseph.jpg\"></div>\n"
+#~ "                    <h3>Joseph Alvarez (Summer 2015)</h3>\n"
+#~ "                    <p>Undergraduate, Skidmore College</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/daniela.jpg\"></div>\n"
+#~ "                    <h3>Daniela Carrasco (Sp 2015)</h3>\n"
+#~ "                    <p>Undergraduate, MIT</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/jean.jpg\"></div>\n"
+#~ "                    <h3>Jean Chow (Fa 2014)</h3>\n"
+#~ "                    <p>Undergraduate, MIT</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/junyi.jpg\"></div>\n"
+#~ "                    <h3>Junyi Chu</h3>\n"
+#~ "                    <p>Junyi runs the \"Your baby, the physicist\" study. "
+#~ "She's working on answering all the amazing\n"
+#~ "                        questions we can only answer with longitudinal "
+#~ "data like this.</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/annie.jpg\"></div>\n"
+#~ "                    <h3>Annie Dai (IAP, Sp 2015)</h3>\n"
+#~ "                    <p>Undergraduate, MIT</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/molly.jpg\"></div>\n"
+#~ "                    <h3>Moira (Molly) Dillon</h3>\n"
+#~ "                    <p>Molly is an Assistant Professor of Psychology and "
+#~ "the PI of the Lab for the Developing Mind at\n"
+#~ "                        NYU. She ran the study \"Baby Euclid\" on Lookit."
+#~ "</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/hope.jpg\"></div>\n"
+#~ "                    <h3>Hope Fuller-Becker (Sp 2015, Sp 2016)</h3>\n"
+#~ "                    <p>Undergraduate, Wellesley College</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img src=\"https://s3."
+#~ "amazonaws.com/lookitcontents/website/kamaria.jpg\">\n"
+#~ "                    </div>\n"
+#~ "                    <h3>Kamaria Kaalund (Fall 2019)</h3>\n"
+#~ "                    <p>Undergraduate, Wellesley College</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/melissa.png\"></div>\n"
+#~ "                    <h3>Melissa Kline</h3>\n"
+#~ "                    <p>Postdoc, MIT</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/rachel.png\"></div>\n"
+#~ "                    <h3>Rachel Magid</h3>\n"
+#~ "                    <p>As ECCL lab coordinator (and then graduate "
+#~ "student) she helped get Lookit off the ground!</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/audrey.jpg\"></div>\n"
+#~ "                    <h3>Audrey Ricks (Summer 2016)</h3>\n"
+#~ "                    <p>Undergraduate, MIT</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/rianna.jpg\"></div>\n"
+#~ "                    <h3>Rianna Shah (IAP, Sp, Fall 2015; IAP, Sp 2016; Sp "
+#~ "2018)</h3>\n"
+#~ "                    <p>Undergraduate, MIT </p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img src=\"https://s3."
+#~ "amazonaws.com/lookitcontents/website/alice.jpg\"></div>\n"
+#~ "                    <h3>Alice Wang (Summer 2017)</h3>\n"
+#~ "                    <p>Undergraduate, Wellesley</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img src=\"https://s3."
+#~ "amazonaws.com/lookitcontents/website/erica.jpg\"></div>\n"
+#~ "                    <h3>Erica Yoon</h3>\n"
+#~ "                    <p>Erica is a graduate student in Mike Frank's lab at "
+#~ "Stanford University. She ran the study \"Mind\n"
+#~ "                        and Manners\" on Lookit.</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/jeanyu.jpg\"></div>\n"
+#~ "                    <h3>Jean Yu (IAP, Sp 2015)</h3>\n"
+#~ "                    <p>Undergraduate, Wellesley College</p>\n"
+#~ "                </div>\n"
+#~ "                <div class=\"lookit-scientist col-xs-6 col-sm-4 col-"
+#~ "lg-3\">\n"
+#~ "                    <div class=\"profile-img\"><img\n"
+#~ "                            src=\"https://storage.googleapis.com/lookit-"
+#~ "staging/static/images/jessica.jpg\"></div>\n"
+#~ "                    <h3>Jessica Zhu (Fall 2016)</h3>\n"
+#~ "                    <p>Undergraduate, MIT</p>\n"
+#~ "                </div>\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "&nbsp;\n"
+#~ "                "
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr ""
+#~ "Tus credenciales de inicio de sesión no funcionaron. Inténtalo de nuevo."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "¿Nuevo/a en Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nueva contraseña:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Confirmar contraseña:"
+
+#, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "El equipo de %(site_name)s"
+
+#~ msgid "Email address:"
+#~ msgstr "Dirección de correo electrónico:"
+
+#~ msgid "FAQ"
+#~ msgstr "Preguntas más frecuentes"
+
+#~ msgid "Hi"
+#~ msgstr "Hola"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Fecha de nacimiento vacía"
+
+#~ msgid " day"
+#~ msgstr " día"
+
+#~ msgid " days"
+#~ msgstr " dias"
+
+#~ msgid " month"
+#~ msgstr " mes"
+
+#~ msgid " months"
+#~ msgstr " meses"
+
+#~ msgid " year"
+#~ msgstr " año"
+
+#~ msgid " years"
+#~ msgstr " años"
+
+#~ msgid "Hide Form"
+#~ msgstr "Ocultar formulario"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr ""
+#~ "¡Crea una cuenta familiar para empezar a participar en los estudios "
+#~ "Lookit!"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Su cuenta no tiene acceso a esta página. Para continuar, inicie sesión "
+#~ "con una cuenta que tenga acceso."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Inicie sesión para ver esta página."
+
+#~ msgid "Compensation: "
+#~ msgstr "Compensación: "
+
+#~ msgid "None"
+#~ msgstr "Ninguno"
+
+#~ msgid "Current Studies"
+#~ msgstr "Estudios actuales"
+
+#~ msgid "See details"
+#~ msgstr "Ver detalles"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "¡No estamos realizando ningún estudio en este momento!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "¿Busca más formas de contribuir a la investigación desde casa? ¡Consulte "
+#~ "<a href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\"> Niños ayudando a la ciencia </a> para "
+#~ "obtener aún más estudios!"
+
+#~ msgid "days"
+#~ msgstr "días"
+
+#~ msgid " until "
+#~ msgstr " hasta "
+
+#~ msgid " when "
+#~ msgstr " cuando "
+
+#~ msgid "Study overview"
+#~ msgstr "Resumen del estudio"
+
+#~ msgid "Back to list"
+#~ msgstr "Volver a la lista"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Criterios de selección"
+
 #~ msgid "Alumni &amp; Collaborators"
 #~ msgstr "Colaboradores/as y antiguos/as colaboradores/as"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "Para registrarte como investigador/a, utiliza"
-
 #~ msgid "this form"
 #~ msgstr "este formulario"
-
-#~ msgid "instead"
-#~ msgstr "en lugar de"

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -3322,10 +3322,8 @@ msgstr "Duración"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Este estudio es realizado por"
+msgstr "Este estudio es realizado por %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -2,33 +2,48 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: es-ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Correo electrónico"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Apodo"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "Es hora de otra sesión de un estudio en el que estamos participando"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Un nuevo estudio está disponible para uno de mis hijos/as"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -36,7 +51,7 @@ msgstr ""
 "Hay notificaciones sobre un estudio en el que participamos (por ejemplo, se "
 "han publicado los resultados)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -44,100 +59,92 @@ msgstr ""
 "Un/a investigador/a tiene preguntas sobre mis respuestas individuales (por "
 "ejemplo, si reporto un problema técnico durante el estudio)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "¿Con qué categoría(s) se identifica su familia?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "País"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Introduzca una lista separada por comas: AAAA-MM-DD, AAAA-MM-DD, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Sólo respuestas numéricas - ¡una aproximación es suficiente!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "¿En qué país vive?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "¿En qué estado vive?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "¿Cómo describiría la zona donde vive?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "¿Qué idiomas habla su familia en casa?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "¿Cuántos hijos/as tiene?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Para cada hijo/a, introduzca su fecha de nacimiento:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "¿Con cuántos/as madres/padres/tutores viven sus hijos?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "¿Qué edad tiene?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "¿Cuál es su género?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "¿Cuál es su género?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "¿Cuál es el máximo nivel educativo que usted ha completado?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "¿Cuál es el máximo nivel educativo completado por su pareja?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "¿Cuáles son sus ingresos anuales aproximados (en dólares americanos)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Aproximadamente, ¿cuántos libros para niños hay en su casa?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "¿Hay algo más que le gustaría decirnos?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "¿Cómo se enteró de Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Si la respuesta varía debido a asuntos de custodia compartida o viajes, "
-"introduzca el número de madres/padres/tutores con los que viven usualmente "
-"sus hijos/as o explíquenoslo."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Fecha de nacimiento"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Otra raza, etnia, u origen"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -147,33 +154,36 @@ msgstr ""
 "en un estudio. Nunca publicamos las fechas de nacimiento de los/as niños/as "
 "ni información que permita al lector calcular la fecha de nacimiento."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Las fechas de nacimiento no pueden ser en el futuro."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Nombre"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Fecha de nacimiento"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Género"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Semanas de gestación al nacer"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Cualquier información adicional que le gustaría que sepamos"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Características y condiciones"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -181,7 +191,7 @@ msgstr ""
 "Idiomas a los/las que el/la niño/a está expuesto en casa, la escuela o con "
 "otro/a cuidador/a o tutor."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -194,505 +204,613 @@ msgstr ""
 "un nuevo estudio disponible para María!\") pero nunca publicaremos nombres "
 "ni los usaremos en nuestra investigación."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Por ejemplo, trastornos del desarrollo diagnosticados o problemas de visión "
 "o audición"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Redondee a la semana completa de embarazo completada más cercana"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Estudios"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Estudios actuales"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Sus estudios anteriores"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Estudios actuales"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "No estoy seguro/a o prefiero no contestar"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Menos de 24 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 o más semanas"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Puede ver la organización"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Puede editar la organización"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Puede crear la organización"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Puede eliminar la organización"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Puede ver al investigador"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Puede ver los análisis"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Puede crear un usuario"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Puede ver al usuario"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Puede editar al usuario"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Puede eliminar al usuario"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Puede ver los permisos de usuario"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Puede editar permisos de usuario"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Puede leer todos los datos de usuario"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Puede leer los nombres de usuario"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "masculino"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "femenino"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "otro"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "prefiero no responder"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Puede ver la organización"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Puede editar la organización"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Puede crear la organización"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Puede eliminar la organización"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Puede ver al investigador"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Puede ver los análisis"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Puede crear un usuario"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Puede ver al usuario"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Puede editar al usuario"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Puede eliminar al usuario"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Puede ver los permisos de usuario"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Puede editar permisos de usuario"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Puede leer todos los datos de usuario"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Puede leer los nombres de usuario"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Blanco"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Origen hispano, latino o español"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Negro / a o afroamericano / a"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asiático / a"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Indio / a americano / a o nativo / a de Alaska"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Medio Oriente o África del Norte"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Nativo / a de Hawai u otra isla del Pacífico"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Otra raza, etnia, u origen"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "Algunos años o actualmente asistiendo a la escuela secundaria"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "Título de bachillerato o GED"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "Algunos años o actualmente asistiendo a la universidad"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "Título universitario de 2 años"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "Título universitario de 4 años"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr ""
 "Algunos años o actualmente asistiendo a la escuela de postgrado o escuela "
 "profesional"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "Título de maestría o posgrado "
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "No aplica - sin cónyuge o pareja"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Más de 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "menores de 18 años"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 o más"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 o más"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "varía"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "más de 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "urbano"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "suburbano"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "rural"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Seleccione un Estado"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Información de la cuenta"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Encuesta demográfica"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Cuéntenos más sobre usted."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Información sobre los/as niños/as"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Agregue o edite la información del/de la participante."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Preferencias de correo electrónico"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Edite cuándo puede ser contactado/a."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Mi cuenta"
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr "Actualizar información de la cuenta"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Guardar"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Cambiar su contraseña"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Todos los participantes"
 
@@ -700,76 +818,83 @@ msgstr "Todos los participantes"
 msgid "Participant ID"
 msgstr "ID del participante"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Activo por última vez:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "ID global del participante:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Niños / as"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Edad"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Información adicional"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "¡No hay perfiles de niños / as registrados/as!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Últimos datos demográficos"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "País"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Estado"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Descripción del área"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Idiomas que se hablan en casa"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Número de niños/as"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Edad actual de los/as niños/as"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Respuestas del estudio"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Número de tutores/as legales"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Explicación sobre tutores/as legales: "
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Raza/Etnia"
 
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Panel de control"
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
 
-#: project/settings.py:243 studies/fields.py:97
-#, fuzzy
-#| msgid "Asian"
-msgid "Russian"
-msgstr "Asiático / a"
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
 
 #: studies/fields.py:45
 msgid "Twin"
@@ -799,35 +924,269 @@ msgstr "Septillizo"
 msgid "Octuplet"
 msgstr "Octillizos"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
 #: studies/fields.py:69
 #, fuzzy
 #| msgid "Duration"
 msgid "Gujarati"
 msgstr "Duración"
 
-#: studies/fields.py:115
-#, fuzzy
-#| msgid "Yes"
-msgid "Yue"
-msgstr "Sí"
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+#, fuzzy
+#| msgid "Duration"
+msgid "Marathi"
+msgstr "Duración"
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+#, fuzzy
+#| msgid "Asian"
+msgid "Russian"
+msgstr "Asiático / a"
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "No respondido"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Otro"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Masculino"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Femenino"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -836,153 +1195,68 @@ msgstr ""
 "laboratorio podrá crear estudios asociados con este laboratorio y se puede "
 "agregar a los estudios de este laboratorio."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Los usuarios que han solicitado unirse a este laboratorio."
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-#, fuzzy
-#| msgid "researcher login"
-msgid "For researchers"
-msgstr "inicio de sesión del investigador"
-
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-#, fuzzy
-#| msgid "Contact:"
-msgid "Contact us"
-msgstr "Contacto:"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Participante"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Iniciar sesión para participar"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Iniciar sesión para participar"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "¿Cuál es su género?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Duración"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "¡No estamos realizando ningún estudio en este momento!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Participante"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Declaración de privacidad"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Todos los participantes"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Información adicional"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Ha cerrado la sesión correctamente."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-#, fuzzy
-#| msgid "Your username and password didn't match. Please try again."
-msgid "Your login credentials didn't work. Please try again."
-msgstr "Su nombre de usuario y contraseña no coinciden. Inténtelo de nuevo."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Iniciar sesión"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "¿Olvidó su contraseña?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "¿Nuevo/a en Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Contraseña cambiada"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Su contraseña ha sido cambiada."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Documentación"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Cambiar contraseña"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Cerrar sesión"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Inicio"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Cambio de contraseña"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Corrija el error a continuación."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Por favor corrija los errores a continuación."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -991,29 +1265,29 @@ msgstr ""
 "nueva contraseña dos veces para que podamos verificar que la ingresó "
 "correctamente."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Cambiar mi contraseña"
 
-#: web/templates/registration/password_reset_complete.html:11
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "Iniciar sesión"
+
+#: web/templates/registration/password_reset_complete.html:10
 msgid "Password reset complete"
 msgstr "Restablecimiento de contraseña completado"
 
-#: web/templates/registration/password_reset_complete.html:15
+#: web/templates/registration/password_reset_complete.html:12
 msgid "Your password has been set.  You may go ahead and log in now."
 msgstr ""
 "Su contraseña ha sido establecida. Puede continuar e iniciar sesión ahora."
 
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "Iniciar sesión"
-
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Confirmación de restablecimiento de contraseña"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1021,15 +1295,7 @@ msgstr ""
 "Ingrese su nueva contraseña dos veces para que podamos verificar que la "
 "ingresó correctamente."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nueva contraseña:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Confirmar contraseña:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1038,13 +1304,13 @@ msgstr ""
 "porque ya ha sido utilizado. Por favor, solicite un nuevo enlace de "
 "restablecimiento de contraseña."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset link sent"
 msgstr "Restablecimiento de contraseña completado"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 #, fuzzy
 #| msgid ""
 #| "We've emailed you instructions for setting your password, if an account "
@@ -1057,7 +1323,7 @@ msgstr ""
 "contraseña, si es que existe una cuenta con el correo electrónico que "
 "ingresó. Debería recibirlas en breve."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 #, fuzzy
 #| msgid ""
 #| "If you don't receive an email, please make sure you've entered the "
@@ -1070,11 +1336,14 @@ msgstr ""
 "Si no recibe un correo electrónico, asegúrese de haber ingresado la "
 "dirección con la que se registró y verifique su carpeta de spam."
 
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Recibió este correo electrónico porque solicitó un restablecimiento de "
 "contraseña para su cuenta de usuario en %(site_name)s."
@@ -1087,23 +1356,25 @@ msgstr "Vaya a la página siguiente y elija una nueva contraseña:"
 msgid "Your username, in case you've forgotten:"
 msgstr "Su nombre de usuario, en caso de que lo haya olvidado:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "¡Gracias por usar nuestra página web!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "El equipo de %(site_name)"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Restablecer mi contraseña"
+
+#: web/templates/registration/password_reset_form.html:8
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset"
 msgstr "Restablecimiento de contraseña completado"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1111,129 +1382,257 @@ msgstr ""
 "¿Olvidó su contraseña? Ingrese su dirección de correo electrónico a "
 "continuación y le enviaremos las instrucciones para configurar una nueva."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Dirección de correo electrónico:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset complete"
+msgid "Password reset on Children Helping Science"
+msgstr "Restablecimiento de contraseña completado"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Restablecer mi contraseña"
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Investigador"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Estudios"
+#: web/templates/web/_footer.html:17
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact us"
+msgstr "Contacto:"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "Preguntas más frecuentes"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Los científicos"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Recursos"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Hola"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "Regístrese"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Investigador"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Niños / as"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Agregar niño/a"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Niño/a"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 #| msgid "Back to list"
 msgid "Back to Children List"
 msgstr "Volver a la lista"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Actualizar"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Eliminar"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Cancelar"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Guardar"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Fecha de nacimiento vacía"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Actualizar"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " día"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " días"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " mes"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " meses"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " año"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " años"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Agregar niño/a"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Ocultar formulario"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nombre"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Actualizar niño/a"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nombre"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "¡No hay perfiles de niños/as registrados/as!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+#, fuzzy
+#| msgid "researcher login"
+msgid "For researchers"
+msgstr "inicio de sesión del investigador"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Documentación"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Actualizar datos demográficos"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1247,7 +1646,7 @@ msgstr ""
 "logramos contactar, y cómo factores como hablar varios idiomas o tener "
 "hermanos mayores afectan el aprendizaje de los/as niños/as."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1257,127 +1656,1553 @@ msgstr ""
 "científicos o publicitarios, su información demográfica nunca será publicada "
 "junto con su video."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Participante"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Sus estudios anteriores"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "¡No estamos realizando ningún estudio en este momento!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Iniciar sesión para participar"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "¿Cuál es su género?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Duración"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "¿En qué estado vive?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "researcher login"
+msgid "For Researchers"
+msgstr "inicio de sesión del investigador"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "¿Qué edad tiene?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Iniciar sesión para participar"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Los científicos"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Participante"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Inicio"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Me gustaría ser contactado/a cuando:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Iniciar sesión para participar"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Crear una cuenta"
+
+#: web/templates/web/participant-signup.html:13
 #, fuzzy
 #| msgid "Participant account"
 msgid "Create Participant Account"
 msgstr "Cuenta del participante"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead?"
+msgid "instead."
+msgstr "¿En lugar?"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "Al hacer clic en 'Crear cuenta', acepto que he leído y aceptado la "
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Declaración de privacidad"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Crear una cuenta"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Declaración de privacidad"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Todos los participantes"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Información adicional"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Estudios anteriores"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
 msgstr ""
-"Su cuenta no tiene acceso a esta página. Para continuar, inicie sesión con "
-"una cuenta que tenga acceso."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Inicie sesión para ver esta página."
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Estudios actuales"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Sus estudios anteriores"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Aquí puede ver sus estudios y ver los comentarios dejados por los/as "
 "investigadores/as:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Vista previa del estudio"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Requisitos:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contacto:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "¿Seguimos recopilando datos?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Sí"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "No"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Compensación: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Compensación"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Respuestas del estudio"
 
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Fecha"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Estado de consentimiento"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Aprobado"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Su vídeo de consentimiento fue revisado por un/a investigador/a y es válido."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "Pendiente"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr ""
 "Su vídeo de consentimiento aún no ha sido revisado por un/a investigador/a."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Inválido"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1387,159 +3212,183 @@ msgstr ""
 "la declaración de consentimiento en voz alta. Los investigadores del estudio "
 "no verán ni utilizarán el resto de datos de esta sesión."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr ""
 "No hay información sobre el estado de revisión del video de consentimiento."
 
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Aún no ha participado en ningún estudio."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Estudios actuales"
-
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
-msgstr ""
-"Tenga en cuenta que necesitará una computadora portátil o de escritorio (no "
-"un dispositivo móvil) con Chrome o Firefox para participar."
-
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Ver detalles"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "¡No estamos realizando ningún estudio en este momento!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
-msgstr ""
-"¿Busca más formas de participar en investigaciones desde casa? ¡Visite <a "
-"href=\"https://childrenhelpingscience.com/\" target=\"_blank\" rel="
-"\"noreferrer noopener\"> Niños/as ayudando a la ciencia </a> para tener "
-"acceso a aún más estudios!"
-
-#: web/templates/web/study-detail.html:53
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-#| msgid " days"
-msgid "days"
-msgstr " días"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Aún no ha participado en ningún estudio."
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Resumen del estudio"
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Estudios"
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Volver a la lista"
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Criterios de elegibilidad"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
 
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Duración"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Compensación"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Qué sucede"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Recursos"
 
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Qué estamos estudiando"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Este estudio es realizado por"
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
 
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "¿Le gustaría participar en este estudio?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Iniciar sesión para participar"
-
-#: web/templates/web/study-detail.html:142
-#, fuzzy
-#| msgid "No child profiles registered!"
-msgid "Add child profile to "
-msgstr "¡No hay perfiles de niños/as registrados/as!"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 #, fuzzy
 #| msgid "Participate"
 msgid "participate"
 msgstr "Participante"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Iniciar simulador de experimentos para obtener una vista previa"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Iniciar sesión para participar"
+
+#: web/templates/web/study-detail.html:22
+#, fuzzy
+#| msgid "No child profiles registered!"
+msgid "Add child profile to "
+msgstr "¡No hay perfiles de niños/as registrados/as!"
+
+#: web/templates/web/study-detail.html:23
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Complete demographic survey to "
 msgstr "Encuesta demográfica"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Participante"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Qué sucede"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Qué estamos estudiando"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Duración"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Este estudio es realizado por"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "¿Le gustaría participar en este estudio?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Seleccione un/a niño/a:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Ninguno/a ha sido seleccionado/a"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Su hijo/a aún no tiene la edad recomendada para este estudio. ¡Si puede "
 "esperar <span id = 'wait-until'> hasta que </span> él o ella tenga la edad "
 "suficiente, podremos usar los datos colectados en nuestra investigación!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Su hijo/a es mayor de la edad recomendada para este estudio. Puede "
 "participar en el estudio de todos modos, pero no podremos utilizar los datos "
 "recogidos en nuestra investigación."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Su hijo/a no cumple con los criterios de selección de este estudio. Puede "
 "participar en el estudio de todos modos, pero no podremos utilizar los datos "
 "recogidos en nuestra investigación. Póngase en contacto con los/as "
 "investigadores/as del estudio."
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Iniciar simulador de experimentos para obtener una vista previa"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Participante"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1547,34 +3396,264 @@ msgstr ""
 "Para ver fácilmente lo que sucede a medida que actualiza el protocolo de su "
 "estudio, guarde el enlace adjuntado al botón de arriba."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Regístrese"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Tenga en cuenta que necesitará una computadora portátil o de escritorio (no "
+"un dispositivo móvil) con Chrome o Firefox para participar."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 #, fuzzy
 #| msgid "Participant account"
 msgid "Participant created."
 msgstr "Cuenta del participante"
 
-#: web/views.py:88
+#: web/views.py:157
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Demographic data saved."
 msgstr "Encuesta demográfica"
 
-#: web/views.py:156
+#: web/views.py:223
 #, fuzzy
 #| msgid "Children"
 msgid "Child added."
 msgstr "Niños / as"
 
-#: web/views.py:217
+#: web/views.py:264
+#, fuzzy
+#| msgid "Children"
+msgid "Child deleted."
+msgstr "Niños / as"
+
+#: web/views.py:266
+#, fuzzy
+#| msgid "Children"
+msgid "Child updated."
+msgstr "Niños / as"
+
+#: web/views.py:294
 #, fuzzy
 #| msgid "Email Preferences"
 msgid "Email preferences saved."
 msgstr "Preferencias de correo electrónico"
 
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "¿Con qué categoría(s) se identifica su familia?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Sólo respuestas numéricas - ¡una aproximación es suficiente!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "¿Qué idiomas habla su familia en casa?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "¿Cuál es el máximo nivel educativo completado por su pareja?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Aproximadamente, ¿cuántos libros para niños hay en su casa?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Si la respuesta varía debido a asuntos de custodia compartida o viajes, "
+#~ "introduzca el número de madres/padres/tutores con los que viven "
+#~ "usualmente sus hijos/as o explíquenoslo."
+
+#~ msgid "other"
+#~ msgstr "otro"
+
+#~ msgid "3 or more"
+#~ msgstr "3 o más"
+
+#~ msgid "varies"
+#~ msgstr "varía"
+
+#~ msgid "My Account"
+#~ msgstr "Mi cuenta"
+
+#~ msgid "Last Active:"
+#~ msgstr "Activo por última vez:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "ID global del participante:"
+
+#~ msgid "Dashboard"
+#~ msgstr "Panel de control"
+
 #, fuzzy
-#~| msgid "instead?"
-#~ msgid "instead"
-#~ msgstr "¿En lugar?"
+#~| msgid "Yes"
+#~ msgid "Yue"
+#~ msgstr "Sí"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Iniciar sesión para participar"
+
+#, fuzzy
+#~| msgid "Your username and password didn't match. Please try again."
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "Su nombre de usuario y contraseña no coinciden. Inténtelo de nuevo."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "¿Nuevo/a en Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nueva contraseña:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Confirmar contraseña:"
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "El equipo de %(site_name)"
+
+#~ msgid "Email address:"
+#~ msgstr "Dirección de correo electrónico:"
+
+#~ msgid "FAQ"
+#~ msgstr "Preguntas más frecuentes"
+
+#~ msgid "Hi"
+#~ msgstr "Hola"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Fecha de nacimiento vacía"
+
+#~ msgid " day"
+#~ msgstr " día"
+
+#~ msgid " days"
+#~ msgstr " días"
+
+#~ msgid " month"
+#~ msgstr " mes"
+
+#~ msgid " months"
+#~ msgstr " meses"
+
+#~ msgid " year"
+#~ msgstr " año"
+
+#~ msgid " years"
+#~ msgstr " años"
+
+#~ msgid "Hide Form"
+#~ msgstr "Ocultar formulario"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Su cuenta no tiene acceso a esta página. Para continuar, inicie sesión "
+#~ "con una cuenta que tenga acceso."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Inicie sesión para ver esta página."
+
+#~ msgid "Compensation: "
+#~ msgstr "Compensación: "
+
+#~ msgid "Current Studies"
+#~ msgstr "Estudios actuales"
+
+#~ msgid "See details"
+#~ msgstr "Ver detalles"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "¡No estamos realizando ningún estudio en este momento!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "¿Busca más formas de participar en investigaciones desde casa? ¡Visite <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\"> Niños/as ayudando a la ciencia </a> para "
+#~ "tener acceso a aún más estudios!"
+
+#, fuzzy
+#~| msgid " days"
+#~ msgid "days"
+#~ msgstr " días"
+
+#~ msgid "Study overview"
+#~ msgstr "Resumen del estudio"
+
+#~ msgid "Back to list"
+#~ msgstr "Volver a la lista"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Criterios de elegibilidad"
 
 #~ msgid "Login Unsuccessful"
 #~ msgstr "Inicio de sesión fallido"
@@ -1649,6 +3728,3 @@ msgstr "Preferencias de correo electrónico"
 
 #~ msgid "Signup"
 #~ msgstr "Regístrese"
-
-#~ msgid "Update account information"
-#~ msgstr "Actualizar información de la cuenta"

--- a/locale/eu/LC_MESSAGES/django.po
+++ b/locale/eu/LC_MESSAGES/django.po
@@ -1,0 +1,3300 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-09 19:36-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
+msgid "Email address"
+msgstr ""
+
+#: accounts/forms.py:223
+msgid "Nickname"
+msgstr ""
+
+#: accounts/forms.py:286
+msgid ""
+"It's time for another session of a study we are currently participating in"
+msgstr ""
+
+#: accounts/forms.py:288
+msgid "A new study is available for one of my children"
+msgstr ""
+
+#: accounts/forms.py:290
+msgid ""
+"There's an update about a study we participated in (for example, results are "
+"published)"
+msgstr ""
+
+#: accounts/forms.py:293
+msgid ""
+"A researcher has questions about my individual responses (for example, if I "
+"report a technical problem during the study)"
+msgstr ""
+
+#: accounts/forms.py:323
+msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
+msgstr ""
+
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
+
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
+msgid "What country do you live in?"
+msgstr ""
+
+#: accounts/forms.py:335
+msgid "What state do you live in?"
+msgstr ""
+
+#: accounts/forms.py:336
+msgid "How would you describe the area where you live?"
+msgstr ""
+
+#: accounts/forms.py:337
+msgid "How many children do you have?"
+msgstr ""
+
+#: accounts/forms.py:338
+msgid "For each child, please enter his or her birthdate:"
+msgstr ""
+
+#: accounts/forms.py:340
+msgid "How many parents/guardians do your children live with?"
+msgstr ""
+
+#: accounts/forms.py:342
+msgid "What is your age?"
+msgstr ""
+
+#: accounts/forms.py:343
+msgid "What is your gender?"
+msgstr ""
+
+#: accounts/forms.py:344
+msgid "Describe your gender"
+msgstr ""
+
+#: accounts/forms.py:346
+msgid "What is the highest level of education you've completed?"
+msgstr ""
+
+#: accounts/forms.py:349
+msgid "What is your approximate family yearly income (in US dollars)?"
+msgstr ""
+
+#: accounts/forms.py:351
+msgid "Anything else you'd like us to know?"
+msgstr ""
+
+#: accounts/forms.py:352
+msgid "How did you hear about Lookit?"
+msgstr ""
+
+#: accounts/forms.py:354
+msgid ""
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
+msgstr ""
+
+#: accounts/forms.py:357
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr ""
+
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
+msgid ""
+"This lets us figure out exactly how old your child is when they participate "
+"in a study. We never publish children's birthdates or information that would "
+"allow a reader to calculate the birthdate."
+msgstr ""
+
+#: accounts/forms.py:386
+msgid "Birthdays cannot be in the future."
+msgstr ""
+
+#: accounts/forms.py:403
+msgid "First Name"
+msgstr ""
+
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr ""
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
+msgid "Gender"
+msgstr ""
+
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
+msgid "Gestational Age at Birth"
+msgstr ""
+
+#: accounts/forms.py:408
+msgid "Any additional information you'd like us to know"
+msgstr ""
+
+#: accounts/forms.py:410
+msgid "Characteristics and conditions"
+msgstr ""
+
+#: accounts/forms.py:412
+msgid ""
+"Languages this child is exposed to at home, school, or with another "
+"caregiver."
+msgstr ""
+
+#: accounts/forms.py:418
+msgid ""
+"This lets you select the correct child to participate in a particular study. "
+"A nickname or initials are fine! We may include your child's name in email "
+"to you (for instance, \"There's a new study available for Molly!\") but will "
+"never publish names or use them in our research."
+msgstr ""
+
+#: accounts/forms.py:421
+msgid ""
+"For instance, diagnosed developmental disorders or vision or hearing problems"
+msgstr ""
+
+#: accounts/forms.py:424
+msgid "Please round down to the nearest full week of pregnancy completed"
+msgstr ""
+
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+msgid "All studies"
+msgstr ""
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+msgid "Scheduled studies"
+msgstr ""
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+msgid "Lookit studies"
+msgstr ""
+
+#: accounts/forms.py:517
+msgid "External studies"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:12
+#: accounts/models.py:339 studies/fields.py:136
+msgid "Not sure or prefer not to answer"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:13
+#: accounts/models.py:340 studies/fields.py:137
+msgid "Under 24 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:14
+#: accounts/models.py:341 studies/fields.py:138
+msgid "24 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:15
+#: accounts/models.py:342 studies/fields.py:139
+msgid "25 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:16
+#: accounts/models.py:343 studies/fields.py:140
+msgid "26 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:17
+#: accounts/models.py:344 studies/fields.py:141
+msgid "27 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:18
+#: accounts/models.py:345 studies/fields.py:142
+msgid "28 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:19
+#: accounts/models.py:346 studies/fields.py:143
+msgid "29 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:20
+#: accounts/models.py:347 studies/fields.py:144
+msgid "30 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:21
+#: accounts/models.py:348 studies/fields.py:145
+msgid "31 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:22
+#: accounts/models.py:349 studies/fields.py:146
+msgid "32 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:23
+#: accounts/models.py:350 studies/fields.py:147
+msgid "33 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:24
+#: accounts/models.py:351 studies/fields.py:148
+msgid "34 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:25
+#: accounts/models.py:352 studies/fields.py:149
+msgid "35 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:26
+#: accounts/models.py:353 studies/fields.py:150
+msgid "36 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:27
+#: accounts/models.py:354 studies/fields.py:151
+msgid "37 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:28
+#: accounts/models.py:355 studies/fields.py:152
+msgid "38 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:29
+#: accounts/models.py:356 studies/fields.py:153
+msgid "39 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:30
+#: accounts/models.py:357 studies/fields.py:154
+msgid "40 or more weeks"
+msgstr ""
+
+#: accounts/models.py:45
+msgid "male"
+msgstr ""
+
+#: accounts/models.py:46
+msgid "female"
+msgstr ""
+
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
+
+#: accounts/models.py:48 accounts/models.py:510
+msgid "prefer not to answer"
+msgstr ""
+
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr ""
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr ""
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr ""
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr ""
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr ""
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr ""
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr ""
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr ""
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr ""
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr ""
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr ""
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr ""
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr ""
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr ""
+
+#: accounts/models.py:425
+msgid "White"
+msgstr ""
+
+#: accounts/models.py:426
+msgid "Hispanic, Latino, or Spanish origin"
+msgstr ""
+
+#: accounts/models.py:427
+msgid "Black or African American"
+msgstr ""
+
+#: accounts/models.py:428
+msgid "Asian"
+msgstr ""
+
+#: accounts/models.py:429
+msgid "American Indian or Alaska Native"
+msgstr ""
+
+#: accounts/models.py:430
+msgid "Middle Eastern or North African"
+msgstr ""
+
+#: accounts/models.py:431
+msgid "Native Hawaiian or Other Pacific Islander"
+msgstr ""
+
+#: accounts/models.py:432
+msgid "Another race, ethnicity, or origin"
+msgstr ""
+
+#: accounts/models.py:435 accounts/models.py:444
+msgid "some or attending high school"
+msgstr ""
+
+#: accounts/models.py:436 accounts/models.py:445
+msgid "high school diploma or GED"
+msgstr ""
+
+#: accounts/models.py:437 accounts/models.py:446
+msgid "some or attending college"
+msgstr ""
+
+#: accounts/models.py:438 accounts/models.py:447
+msgid "2-year college degree"
+msgstr ""
+
+#: accounts/models.py:439 accounts/models.py:448
+msgid "4-year college degree"
+msgstr ""
+
+#: accounts/models.py:440 accounts/models.py:449
+msgid "some or attending graduate or professional school"
+msgstr ""
+
+#: accounts/models.py:441 accounts/models.py:450
+msgid "graduate or professional degree"
+msgstr ""
+
+#: accounts/models.py:451
+msgid "not applicable - no spouse or partner"
+msgstr ""
+
+#: accounts/models.py:454 accounts/models.py:487
+msgid "0"
+msgstr ""
+
+#: accounts/models.py:455 accounts/models.py:481
+msgid "1"
+msgstr ""
+
+#: accounts/models.py:456 accounts/models.py:482
+msgid "2"
+msgstr ""
+
+#: accounts/models.py:457 accounts/models.py:483
+msgid "3"
+msgstr ""
+
+#: accounts/models.py:458
+msgid "4"
+msgstr ""
+
+#: accounts/models.py:459
+msgid "5"
+msgstr ""
+
+#: accounts/models.py:460
+msgid "6"
+msgstr ""
+
+#: accounts/models.py:461
+msgid "7"
+msgstr ""
+
+#: accounts/models.py:462
+msgid "8"
+msgstr ""
+
+#: accounts/models.py:463
+msgid "9"
+msgstr ""
+
+#: accounts/models.py:464
+msgid "10"
+msgstr ""
+
+#: accounts/models.py:465
+msgid "More than 10"
+msgstr ""
+
+#: accounts/models.py:468
+msgid "under 18"
+msgstr ""
+
+#: accounts/models.py:469
+msgid "18-21"
+msgstr ""
+
+#: accounts/models.py:470
+msgid "22-24"
+msgstr ""
+
+#: accounts/models.py:471
+msgid "25-29"
+msgstr ""
+
+#: accounts/models.py:472
+msgid "30-34"
+msgstr ""
+
+#: accounts/models.py:473
+msgid "35-39"
+msgstr ""
+
+#: accounts/models.py:474
+msgid "40-44"
+msgstr ""
+
+#: accounts/models.py:475
+msgid "45-49"
+msgstr ""
+
+#: accounts/models.py:476
+msgid "50-59"
+msgstr ""
+
+#: accounts/models.py:477
+msgid "60-69"
+msgstr ""
+
+#: accounts/models.py:478
+msgid "70 or over"
+msgstr ""
+
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
+
+#: accounts/models.py:488
+msgid "5000"
+msgstr ""
+
+#: accounts/models.py:489
+msgid "10000"
+msgstr ""
+
+#: accounts/models.py:490
+msgid "15000"
+msgstr ""
+
+#: accounts/models.py:491
+msgid "20000"
+msgstr ""
+
+#: accounts/models.py:492
+msgid "30000"
+msgstr ""
+
+#: accounts/models.py:493
+msgid "40000"
+msgstr ""
+
+#: accounts/models.py:494
+msgid "50000"
+msgstr ""
+
+#: accounts/models.py:495
+msgid "60000"
+msgstr ""
+
+#: accounts/models.py:496
+msgid "70000"
+msgstr ""
+
+#: accounts/models.py:497
+msgid "80000"
+msgstr ""
+
+#: accounts/models.py:498
+msgid "90000"
+msgstr ""
+
+#: accounts/models.py:499
+msgid "100000"
+msgstr ""
+
+#: accounts/models.py:500
+msgid "110000"
+msgstr ""
+
+#: accounts/models.py:501
+msgid "120000"
+msgstr ""
+
+#: accounts/models.py:502
+msgid "130000"
+msgstr ""
+
+#: accounts/models.py:503
+msgid "140000"
+msgstr ""
+
+#: accounts/models.py:504
+msgid "150000"
+msgstr ""
+
+#: accounts/models.py:505
+msgid "160000"
+msgstr ""
+
+#: accounts/models.py:506
+msgid "170000"
+msgstr ""
+
+#: accounts/models.py:507
+msgid "180000"
+msgstr ""
+
+#: accounts/models.py:508
+msgid "190000"
+msgstr ""
+
+#: accounts/models.py:509
+msgid "over 200000"
+msgstr ""
+
+#: accounts/models.py:513
+msgid "urban"
+msgstr ""
+
+#: accounts/models.py:513
+msgid "suburban"
+msgstr ""
+
+#: accounts/models.py:513
+msgid "rural"
+msgstr ""
+
+#: accounts/models.py:567
+msgid "Select a State"
+msgstr ""
+
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
+msgid "Account Information"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
+msgid "Demographic Survey"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:12
+msgid "Tell us more about yourself."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:15
+msgid "Children Information"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:17
+msgid "Add or edit participant information."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
+msgid "Email Preferences"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:40
+msgid "Edit when you can be contacted."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:28
+msgid "Change Your Password"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
+msgid "All Participants"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:23
+msgid "Participant ID"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:40
+msgid "Age"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:52
+msgid "Additional Info"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:57
+msgid "No children profiles registered!"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:62
+msgid "Latest Demographic Data"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:68
+msgid "State"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:72
+msgid "Area description"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:76
+msgid "Languages Spoken at Home"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:80
+msgid "Number of Children"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:84
+msgid "Children current ages"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:90
+msgid "No Response"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:95
+msgid "Number of Guardians"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:99
+msgid "Explanation for Guardians:"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:103
+msgid "Race"
+msgstr ""
+
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
+
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
+
+#: studies/fields.py:45
+msgid "Twin"
+msgstr ""
+
+#: studies/fields.py:46
+msgid "Triplet"
+msgstr ""
+
+#: studies/fields.py:47
+msgid "Quadruplet"
+msgstr ""
+
+#: studies/fields.py:48
+msgid "Quintuplet"
+msgstr ""
+
+#: studies/fields.py:49
+msgid "Sextuplet"
+msgstr ""
+
+#: studies/fields.py:50
+msgid "Septuplet"
+msgstr ""
+
+#: studies/fields.py:51
+msgid "Octuplet"
+msgstr ""
+
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
+#: studies/fields.py:69
+msgid "Gujarati"
+msgstr ""
+
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
+
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+msgid "Marathi"
+msgstr ""
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+msgid "Russian"
+msgstr ""
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
+msgid "Not answered"
+msgstr ""
+
+#: studies/fields.py:125
+msgid "Other"
+msgstr ""
+
+#: studies/fields.py:126
+msgid "Male"
+msgstr ""
+
+#: studies/fields.py:127
+msgid "Female"
+msgstr ""
+
+#: studies/models.py:143
+msgid ""
+"The Users who belong to this Lab. A user in this lab will be able to create "
+"studies associated with this Lab and can be added to this Lab's studies."
+msgstr ""
+
+#: studies/models.py:152
+msgid "The Users who have requested to join this Lab."
+msgstr ""
+
+#: web/templates/registration/logged_out.html:5
+msgid "You've successfully logged out."
+msgstr ""
+
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
+msgid "Login"
+msgstr ""
+
+#: web/templates/registration/login.html:25
+msgid "Forgot password?"
+msgstr ""
+
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
+
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
+msgid "Password changed"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:12
+msgid "Your password was changed."
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:12
+msgid "Documentation"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Change password"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Log out"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:18
+msgid "Home"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:19
+msgid "Password change"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:36
+msgid "Please correct the error below."
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:38
+msgid "Please correct the errors below."
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:43
+msgid ""
+"Please enter your old password, for security's sake, and then enter your new "
+"password twice so we can verify you typed it in correctly."
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
+msgid "Change my password"
+msgstr ""
+
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr ""
+
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr ""
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr ""
+
+#: web/templates/registration/password_reset_confirm.html:8
+msgid "Password reset confirmation"
+msgstr ""
+
+#: web/templates/registration/password_reset_confirm.html:11
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly."
+msgstr ""
+
+#: web/templates/registration/password_reset_confirm.html:21
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+
+#: web/templates/registration/password_reset_done.html:6
+msgid "Password reset link sent"
+msgstr ""
+
+#: web/templates/registration/password_reset_done.html:9
+msgid ""
+"If an account exists with the email you entered, we've emailed instructions "
+"for resetting your password and you should receive them shortly."
+msgstr ""
+
+#: web/templates/registration/password_reset_done.html:12
+msgid ""
+"If you don't receive an email, please check your spam folder and make sure "
+"you've entered the address you registered with. (You won't get an email "
+"unless there's already an account for that email address!)"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:3
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at Children Helping Science."
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:4
+msgid "Please go to the following page and choose a new password:"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:8
+msgid "Your username, in case you've forgotten:"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:9
+msgid "Thanks for using our site!"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:8
+msgid "Password reset"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:11
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll email "
+"instructions for setting a new one."
+msgstr ""
+
+#: web/templates/registration/password_reset_subject_1.txt:2
+msgid "Password reset on Children Helping Science"
+msgstr ""
+
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
+
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
+
+#: web/templates/web/_footer.html:17
+msgid "Contact us"
+msgstr ""
+
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
+
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr ""
+
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr ""
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr ""
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr ""
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr ""
+
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr ""
+
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr ""
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr ""
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr ""
+
+#: web/templates/web/children-list.html:9
+msgid "Update child"
+msgstr ""
+
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr ""
+
+#: web/templates/web/children-list.html:64
+msgid "No child profiles registered!"
+msgstr ""
+
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr ""
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+msgid "documentation"
+msgstr ""
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
+msgid "Update demographics"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
+msgid ""
+"One reason we are developing Internet-based experiments is to represent a "
+"more diverse group of families in our research. Your answers to these "
+"questions will help us understand what audience we reach, as well as how "
+"factors like speaking multiple languages or having older siblings affect "
+"children's learning."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:47
+msgid ""
+"Even if you allow your study videos to be published for scientific or "
+"publicity purposes, your demographic information is never published in "
+"conjunction with your video."
+msgstr ""
+
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+msgid "Participation"
+msgstr ""
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+msgid "Who creates the studies?"
+msgstr ""
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+msgid "Why are you running studies online instead of in person?"
+msgstr ""
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+msgid "How do we provide consent to participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+msgid "Who will see our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+msgid "Habituation"
+msgstr ""
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+msgid "What security measures do you implement?"
+msgstr ""
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+msgid "For Researchers"
+msgstr ""
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+msgid "What is Project Garden?"
+msgstr ""
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+msgid "How to Participate"
+msgstr ""
+
+#: web/templates/web/garden/scientists.html:13
+msgid "Meet the GARDEN Scientists"
+msgstr ""
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+msgid "Participate in a Study"
+msgstr ""
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+msgid "From Home"
+msgstr ""
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
+msgid "I would like to be contacted when:"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:7
+msgid "Sign up to participate"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:13
+msgid "Create Participant Account"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+msgid "instead."
+msgstr ""
+
+#: web/templates/web/participant-signup.html:28
+msgid ""
+"By clicking 'Create Account', I agree that I have read and accepted the "
+msgstr ""
+
+#: web/templates/web/participant-signup.html:28
+msgid "Privacy Statement"
+msgstr ""
+
+#: web/templates/web/privacy.html:9
+msgid "Privacy statement"
+msgstr ""
+
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+msgid "For participants"
+msgstr ""
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+msgid "Additional Information"
+msgstr ""
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
+msgid "Past Studies"
+msgstr ""
+
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
+msgstr ""
+
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
+
+#: web/templates/web/studies-history.html:33
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
+msgid "Study Thumbnail"
+msgstr ""
+
+#: web/templates/web/studies-history.html:55
+msgid "Eligibility"
+msgstr ""
+
+#: web/templates/web/studies-history.html:59
+msgid "Contact"
+msgstr ""
+
+#: web/templates/web/studies-history.html:63
+msgid "Still collecting data?"
+msgstr ""
+
+#: web/templates/web/studies-history.html:65
+msgid "Yes"
+msgstr ""
+
+#: web/templates/web/studies-history.html:67
+msgid "No"
+msgstr ""
+
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr ""
+
+#: web/templates/web/studies-history.html:78
+msgid "Study Responses"
+msgstr ""
+
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
+msgid "Date"
+msgstr ""
+
+#: web/templates/web/studies-history.html:114
+msgid "Consent status"
+msgstr ""
+
+#: web/templates/web/studies-history.html:116
+msgid "Approved"
+msgstr ""
+
+#: web/templates/web/studies-history.html:117
+msgid "Your consent video was reviewed by a researcher and is valid."
+msgstr ""
+
+#: web/templates/web/studies-history.html:119
+msgid "Pending"
+msgstr ""
+
+#: web/templates/web/studies-history.html:120
+msgid "Your consent video has not yet been reviewed by a researcher."
+msgstr ""
+
+#: web/templates/web/studies-history.html:122
+msgid "Invalid"
+msgstr ""
+
+#: web/templates/web/studies-history.html:123
+msgid ""
+"There was a technical problem with your consent video, or it did not show "
+"you reading the consent statement out loud. Your other data from this "
+"session will not be viewed or used by the study researchers."
+msgstr ""
+
+#: web/templates/web/studies-history.html:125
+msgid "No information about consent video review status."
+msgstr ""
+
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+msgid "You have not yet participated in any Lookit studies."
+msgstr ""
+
+#: web/templates/web/studies-history.html:147
+msgid "You have not yet participated in any external studies."
+msgstr ""
+
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr ""
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
+
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
+
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
+
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
+
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr ""
+
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
+
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
+
+#: web/templates/web/study-detail.html:18
+msgid "participate"
+msgstr ""
+
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr ""
+
+#: web/templates/web/study-detail.html:21
+msgid "Schedule a time to participate"
+msgstr ""
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr ""
+
+#: web/templates/web/study-detail.html:23
+msgid "Complete demographic survey to "
+msgstr ""
+
+#: web/templates/web/study-detail.html:54
+msgid "Who Can Participate"
+msgstr ""
+
+#: web/templates/web/study-detail.html:60
+msgid "What Happens"
+msgstr ""
+
+#: web/templates/web/study-detail.html:66
+msgid "What We're Studying"
+msgstr ""
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr ""
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, python-format
+msgid "This study is conducted by %(contact)s."
+msgstr ""
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr ""
+
+#: web/templates/web/study-detail.html:108
+msgid "Select a child:"
+msgstr ""
+
+#: web/templates/web/study-detail.html:119
+msgid "None Selected"
+msgstr ""
+
+#: web/templates/web/study-detail.html:132
+msgid ""
+"Your child is still younger than the recommended age range for this study. "
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
+msgstr ""
+
+#: web/templates/web/study-detail.html:135
+msgid ""
+"Your child is older than the recommended age range for this study. You're "
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
+msgstr ""
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, python-format
+msgid ""
+"Your child does not meet the eligibility criteria listed for this study. "
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
+msgstr ""
+
+#: web/templates/web/study-detail.html:153
+msgid ""
+"For an easy way to see what happens as you update your study protocol, "
+"bookmark the URL the button above sends you to."
+msgstr ""
+
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr ""
+
+#: web/templatetags/web_extras.py:191
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
+msgid "Participant created."
+msgstr ""
+
+#: web/views.py:157
+msgid "Demographic data saved."
+msgstr ""
+
+#: web/views.py:223
+msgid "Child added."
+msgstr ""
+
+#: web/views.py:264
+msgid "Child deleted."
+msgstr ""
+
+#: web/views.py:266
+msgid "Child updated."
+msgstr ""
+
+#: web/views.py:294
+msgid "Email preferences saved."
+msgstr ""
+
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr ""
 "Saisir un mot de passe valide à usage unique de 6 chiffres depuis Google "
@@ -33,46 +33,25 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "Ce compte est inactif."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr ""
-"Votre mot de passe ne doit pas être trop similaire à vos autres informations "
-"personnelles."
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "Votre mot de passe doit contenir au moins 16 caractères."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr ""
-"Votre mot de passe ne peut pas être un mot de passe couramment utilisé."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "Votre mot de passe ne peut pas être entièrement numérique (chiffres)."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Adresse e-mail"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Surnom"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr ""
 "Il est temps de participer à une autre session pour l'une de nos études"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Une nouvelle étude est disponible pour l'un de mes enfants"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -80,7 +59,7 @@ msgstr ""
 "Il y a une mise à jour concernant une étude à laquelle nous avons participé "
 "(par exemple, les résultats ont été publiés)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -88,104 +67,94 @@ msgstr ""
 "Un chercheur a des questions concernant mes réponses individuelles (par "
 "exemple, si je signale un problème technique pendant l'étude)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "À quelle(s) catégorie(s) votre famille correspond-elle ?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Pays"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr ""
 "Saisir sous forme de liste séparée par des virgules: AAAA-MM-JJ, AAAA-MM-"
 "JJ, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
 msgstr ""
-"Réponses numériques uniquement - une estimation approximative est "
-"suffisante !"
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "Dans quel pays habitez-vous ?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "Dans quel état habitez-vous ?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Comment décririez-vous la région dans laquelle vous vivez?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Quelle(s) langue(s) votre famille parle-t-elle à la maison?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Combien d'enfants avez-vous?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Pour chaque enfant, veuillez saisir sa date de naissance :"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Avec combien de parents / tuteurs vos enfants vivent-ils?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Quel âge avez-vous?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Quel est votre sexe?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Quel est votre sexe?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Quel est le niveau d'études le plus élevé que vous avez obtenu ?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Quel est le niveau d'études le plus élevé obtenu par votre conjoint?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Quel est approximativement votre revenu familial annuel (en euros) ?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Environ combien y a-t-il de livres pour enfants dans votre foyer ?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Y a-t-il autre chose que vous aimeriez nous transmettre ?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Comment avez-vous entendu parler de Lookit ?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Si la réponse varie en raison d'ententes de garde partagée ou de voyages, "
-"veuillez saisir le nombre de parents / tuteurs avec lesquels vos enfants "
-"vivent habituellement (ou expliquer)."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Date de naissance"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Autre ethnie ou origine"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -195,33 +164,36 @@ msgstr ""
 "participe à une étude. Nous ne publions jamais les dates de naissance des "
 "enfants ou quelque information qui permettrait à un lecteur de les calculer."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "La date d'anniversaire ne peut se situer dans le futur."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Prénom"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Date de naissance"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Sexe"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Âge gestationnel à la naissance"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Toute information supplémentaire que vous souhaitez nous transmettre"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Caractéristiques et conditions"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -229,7 +201,7 @@ msgstr ""
 "Langues auxquelles cet enfant est exposé à la maison, à l'école ou avec un "
 "autre proche."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -242,512 +214,599 @@ msgstr ""
 "\"Une nouvelle étude est disponible pour Manon !\") mais ne publierons "
 "jamais les noms ni ne les utiliserons dans nos recherches."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Par exemple, des troubles du développement diagnostiqués ou des problèmes de "
 "vision ou d'audition"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Veuillez arrondir à la semaine complète de grossesse la plus proche"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Études"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Études actuelles"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Vos études antérieures"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Études actuelles"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Je ne suis pas sûr(e) ou préfère ne pas répondre"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Moins de 24 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 semaines ou plus"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Peut consulter l'organisation"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Peut modifier l'organisation"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Peut créer une organisation"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Peut supprimer l'organisation"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Peut consulter Experimenter"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Peut consulter les analyses"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Peut créer un utilisateur"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Peut consulter l'utilisateur"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Peut modifier l'utilisateur"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Peut supprimer l'utilisateur"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Peut consulter les autorisations des utilisateurs"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Peut modifier les autorisations des utilisateurs"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Peut lire toutes les données utilisateur"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Peut lire les noms d'utilisateur"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "masculin"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "féminin"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "autre"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "préfère ne pas répondre"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Peut consulter l'organisation"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Peut modifier l'organisation"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Peut créer une organisation"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Peut supprimer l'organisation"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Peut consulter Experimenter"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Peut consulter les analyses"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Peut créer un utilisateur"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Peut consulter l'utilisateur"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Peut modifier l'utilisateur"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Peut supprimer l'utilisateur"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Peut consulter les autorisations des utilisateurs"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Peut modifier les autorisations des utilisateurs"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Peut lire toutes les données utilisateur"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Peut lire les noms d'utilisateur"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Blanc"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Origine hispanique, latine ou espagnole"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Noir ou afro-américain"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asiatique"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Amérindien ou natif de l'Alaska"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Moyen-Orient ou Afrique du Nord"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Natif d'Hawaï ou insulaire d'une autre île du Pacifique"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Autre ethnie ou origine"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "a fréquenté ou fréquentant le lycée"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "Baccalauréat ou équivalent"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "a fréquenté ou fréquentant l'uiversité"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "Licence ou diplôme équivalent à Bac+3"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "Master ou diplôme équivalent à Bac+5"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr ""
 "a préparé ou préparant un master, un doctorat ou un diplôme professionnel"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "master, doctorat ou diplôme professionnel"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "non applicable - pas de conjoint ou partenaire"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Plus que 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "moins de 18 ans"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 ans et plus"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 et plus"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "varie"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10 000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15 000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20 000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30 000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40 000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50 000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60 000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70 000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80 000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90 000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100 000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110 000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120 000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130 000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140 000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150 000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160 000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170 000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180 000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190 000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "plus de 200 000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "urbain"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "de banlieue"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "rural"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Sélectionner un département"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "Gan"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Information sur le compte"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "Modifiez vos identifiants et/ou votre pseudonyme."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Enquête démographique"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Dites-nous en plus à propos de vous."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informations sur les enfants"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Ajoutez ou modifiez les informations des participants."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Préférences de messagerie"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Modifiez quand vous pouvez être contacté."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Mon compte"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Information sur le compte"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Enregistrer"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Changez votre mot de passe"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "Gérer l'authentification à deux facteurs"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -756,11 +815,18 @@ msgstr ""
 "facteurs ici. Il vous suffit d'entrer votre mot de passe unique ici, de "
 "cliquer sur \"Envoyer\" et il sera supprimé pour vous !"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "Configurer l'authentification à deux facteurs"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Tous les participants"
 
@@ -768,130 +834,65 @@ msgstr "Tous les participants"
 msgid "Participant ID"
 msgstr "ID de participant"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Dernière activité :"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "ID global du participant :"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Enfants"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Âge"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Information additionnelle"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Aucun profil enfant enregistré !"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Dernières données démographiques"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Pays"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Etat"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Description de la zone"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Langues parlées à la maison"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Nombre d'enfants"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Âge actuel des enfants"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Réponses de l'étude"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Nombre de tuteurs"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr ""
 "Dans la situation où il y aurait des tuteurs en plus des parents, pourriez-"
 "vous décrire brièvement la situation ?"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Ethnicité"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Tableau de bord"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "Allemand"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "Anglais"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "Espagnol"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "Français"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "Italien"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "Japonais"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "Coréen"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "Polonais"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "Portugais"
-
-#: project/settings.py:241
-#, fuzzy
-#| msgid "Portuguese"
-msgid "Brazilian Portuguese"
-msgstr "Portugais"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "Roumain"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "Russe"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "Turc"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "Néerlandais"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -941,6 +942,10 @@ msgstr "Septuplet"
 msgid "Octuplet"
 msgstr "Octuplet"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "Anglais"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "Amharique"
@@ -965,13 +970,25 @@ msgstr "Cebuano"
 msgid "Chhattisgarhi"
 msgstr "Chhattisgarhi"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "Néerlandais"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "Arabe égyptien"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "Français"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "Gan"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "Allemand"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -986,162 +1003,204 @@ msgid "Hausa"
 msgstr "Haoussa (Hausa)"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "Hindi"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "Igbo"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "Indonésien"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "Persan iranien"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "Italien"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "Japonais"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "Javanais"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "Jin (Jinyu)"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "Kannada"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "Khmer"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "Coréen"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "Magahi"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "Maïthili"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "Malais"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "Mandarin"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "Marathi (Marathe)"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "Minnan"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "Arabe marocain"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "Pachto du nord"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "Ouzbek du nord "
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "Odia"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "Polonais"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "Portugais"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "Roumain"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "Russe"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "Saraiki"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "Sindhi "
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "Somali"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "Espagnol"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "Soudanais"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "Tagalog (tagal)"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "Tamoul (tamil)"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "Télougou"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "Thailandais"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "Turc"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "Ourdou"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "Vietnamien"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "Pendjabi occidental"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "Wu (wugniu , nggniu)"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "Xiang (hunanais)"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "Yue"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Non répondu"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Autre"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Masculin"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Féminin"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -1150,173 +1209,68 @@ msgstr ""
 "laboratoire pourra créer des études associées à ce laboratoire et pourra "
 "être ajouté aux études de ce laboratoire."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Les utilisateurs qui ont demandé à rejoindre ce laboratoire."
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:53
-msgid ""
-"This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
-"findings, and conclusions or recommendations expressed in this material are "
-"those of the authors(s) and do not necessarily reflect the views of the "
-"National Science Foundation."
-msgstr ""
-"Ce document est basé sur des travaux soutenus par la National Science "
-"Foundation (NSF) dans le cadre des bourses 1429216 et 1823919 ; le Center "
-"for Brains, Minds and Machines (CBMM), financé par la bourse CCF-1231216 de "
-"la NSF STC, et par la Graduate Research Fellowship de la NSF dans le cadre "
-"de la bourse n° 1122374. Les opinions, résultats et conclusions ou "
-"recommandations exprimés dans ce document sont ceux des auteurs et ne "
-"reflètent pas nécessairement les vues de la National Science Foundation."
-
-#: web/templates/frontpages/default.html:60 web/templates/frontpages/home.html:48
-msgid "Privacy"
-msgstr "Politique de confidentialité"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-msgid "Contact us"
-msgstr "Contactez-nous"
-
-#: web/templates/frontpages/default.html:63
-msgid "Connect"
-msgstr "Connexion"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Participer"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Connectez-vous pour participer"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Connectez-vous pour participer"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Quel est votre sexe?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Durée"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "Nous ne menons aucune étude pour le moment!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Participer"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Politique de confidentialité"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Tous les participants"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Information additionnelle"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Vous vous êtes déconnecté avec succès."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr ""
-"Vos identifiants de connexion n'ont pas fonctionné. Veuillez réessayer."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "S'identifier"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Mot de passe oublié ?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Nouveau sur Lookit ?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/login.html:36
+#: web/templates/registration/login.html:28
 msgid "Register your family!"
 msgstr "Enregistrez votre famille !"
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Mot de passe changé"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Votre mot de passe a été changé."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Documentation"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Changer le mot de passe"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Se déconnecter"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Accueil"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Changement de mot de passe"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Veuillez corriger l'erreur ci-dessous."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Veuillez corriger les erreurs ci-dessous."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -1325,30 +1279,30 @@ msgstr ""
 "puis entrez votre nouveau mot de passe deux fois afin que nous puissions "
 "vérifier que vous l'avez saisi correctement."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Changer mon mot de passe"
 
-#: web/templates/registration/password_reset_complete.html:11
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "S'identifier"
+
+#: web/templates/registration/password_reset_complete.html:10
 msgid "Password reset complete"
 msgstr "Réinitialisation du mot de passe terminée"
 
-#: web/templates/registration/password_reset_complete.html:15
+#: web/templates/registration/password_reset_complete.html:12
 msgid "Your password has been set.  You may go ahead and log in now."
 msgstr ""
 "Votre mot de passe a été défini. Vous pouvez à présent continuer et vous "
 "connecter."
 
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "S'identifier"
-
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Confirmation de réinitialisation du mot de passe"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1356,15 +1310,7 @@ msgstr ""
 "Veuillez saisir votre nouveau mot de passe deux fois afin que nous puissions "
 "vérifier que vous l'avez saisi correctement."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nouveau mot de passe :"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Confirmez le mot de passe :"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1373,11 +1319,11 @@ msgstr ""
 "parce qu'il a déjà été utilisé. Veuillez demander une nouvelle "
 "réinitialisation du mot de passe."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 msgid "Password reset link sent"
 msgstr "Lien de réinitialisation du mot de passe envoyé"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 msgid ""
 "If an account exists with the email you entered, we've emailed instructions "
 "for resetting your password and you should receive them shortly."
@@ -1386,7 +1332,7 @@ msgstr ""
 "avons envoyé par e-mail les instructions pour réinitialiser votre mot de "
 "passe et vous devriez les recevoir prochainement."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 msgid ""
 "If you don't receive an email, please check your spam folder and make sure "
 "you've entered the address you registered with. (You won't get an email "
@@ -1397,11 +1343,14 @@ msgstr ""
 "vous vous êtes inscrit. (Vous ne recevrez pas d'e-mail à moins qu'il y ait "
 "déjà un compte pour cette adresse e-mail !)."
 
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Vous recevez cet e-mail car vous avez demandé la réinitialisation du mot de "
 "passe de votre compte utilisateur à %(site_name)s."
@@ -1415,20 +1364,23 @@ msgstr ""
 msgid "Your username, in case you've forgotten:"
 msgstr "Votre nom d'utilisateur, au cas où vous l'auriez oublié :"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Merci d'utiliser notre site !"
 
-#: web/templates/registration/password_reset_email.html:12
-#, python-format
-msgid "The %(site_name)s team"
-msgstr "L'équipe de %(site_name)s"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Réinitialiser mon mot de passe"
+
+#: web/templates/registration/password_reset_form.html:8
 msgid "Password reset"
 msgstr "Réinitialisation du mot de passe"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1436,127 +1388,267 @@ msgstr ""
 "Mot de passe oublié ? Entrez votre adresse e-mail ci-dessous, et nous vous "
 "enverrons par e-mail des instructions pour en définir un nouveau."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Adresse e-mail :"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "Lien de réinitialisation du mot de passe envoyé"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Réinitialiser mon mot de passe"
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
+"Ce document est basé sur des travaux soutenus par la National Science "
+"Foundation (NSF) dans le cadre des bourses 1429216 et 1823919 ; le Center "
+"for Brains, Minds and Machines (CBMM), financé par la bourse CCF-1231216 de "
+"la NSF STC, et par la Graduate Research Fellowship de la NSF dans le cadre "
+"de la bourse n° 1122374. Les opinions, résultats et conclusions ou "
+"recommandations exprimés dans ce document sont ceux des auteurs et ne "
+"reflètent pas nécessairement les vues de la National Science Foundation."
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Experimenter"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr "Politique de confidentialité"
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Études"
+#: web/templates/web/_footer.html:17
+msgid "Contact us"
+msgstr "Contactez-nous"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "FAQ"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr "Connexion"
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Les scientifiques"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Ressources"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Salut"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Se déconnecter"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "S'inscrire"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Experimenter"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
-msgid "Child"
-msgstr "Enfant"
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
 
-#: web/templates/web/child-update.html:26
-msgid "Back to Children List"
-msgstr "Retour à la liste des enfants"
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Mettre à jour"
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
 
-#: web/templates/web/child-update.html:41
-msgid "Delete"
-msgstr "Supprimer"
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Enfants"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
 msgid "Cancel"
 msgstr "Annuler"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Anniversaire vide"
-
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " journée"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " journées"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " mois"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " mois"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " an"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " années"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
 msgid "Add Child"
 msgstr "Ajouter un enfant"
 
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Masquer le formulaire"
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr "Enfant"
 
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nom"
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr "Retour à la liste des enfants"
 
-#: web/templates/web/children-list.html:121
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr "Supprimer"
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Enregistrer"
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Mettre à jour"
+
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Mettre à jour l'enfant"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nom"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Aucun profil enfant enregistré !"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr ""
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Documentation"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Mettre à jour les données démographiques"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1571,7 +1663,7 @@ msgstr ""
 "plusieurs langues ou avoir des frères et sœurs plus âgés affectent "
 "l'apprentissage des enfants."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1581,134 +1673,1553 @@ msgstr ""
 "ou publicitaires, vos informations démographiques ne sont jamais publiées en "
 "même temps que votre vidéo."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Participer"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Vos études antérieures"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "Nous ne menons aucune étude pour le moment!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Connectez-vous pour participer"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Quel est votre sexe?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Durée"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "Dans quel état habitez-vous ?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+msgid "For Researchers"
+msgstr ""
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Quel âge avez-vous?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Connectez-vous pour participer"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Les scientifiques"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Participer"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Accueil"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Je souhaite être contacté lorsque :"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Connectez-vous pour participer"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Créer un compte"
+
+#: web/templates/web/participant-signup.html:13
 msgid "Create Participant Account"
 msgstr "Créer un compte participant"
 
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
 msgstr ""
-"Créez un compte famille pour commencer à participer aux études Lookit !"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "Pour vous inscrire en tant que chercheur, veuillez utiliser"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead"
+msgid "instead."
+msgstr "à la place"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "En cliquant sur 'Créer un compte', j'accepte d'avoir lu et accepté le "
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Politique de confidentialité"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Créer un compte"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Politique de confidentialité"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Tous les participants"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Information additionnelle"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Études antérieures"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
+#: web/templates/web/studies-history.html:15
+#, fuzzy
+#| msgid "Video"
+msgid "Next Video"
+msgstr "Vidéo"
+
+#: web/templates/web/studies-history.html:31
 msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
 msgstr ""
-"Votre compte n'a pas accès à cette page. Pour continuer, veuillez vous "
-"connecter avec un compte qui y a accès."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Veuillez vous connecter pour voir cette page."
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Études actuelles"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Vos études antérieures"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Ici, vous pouvez consulter vos études et voir les commentaires laissés par "
 "les chercheurs :"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Vignette d'étude"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Eligibilité :"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contact :"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Vous continuez à collecter des données?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Oui"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Non"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Compensation: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Compensation"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Réponses de l'étude"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "Vidéo"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Date"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Statut du consentement"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Approuvé"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Votre vidéo de consentement a été examinée par un chercheur et est valide."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "En attente"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr ""
 "Votre vidéo de consentement n'a pas encore été examinée par un chercheur."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Invalide"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1719,177 +3230,177 @@ msgstr ""
 "Vos autres données de cette session ne seront ni consultées ni utilisées par "
 "les chercheurs de l'étude."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr "Aucune information sur l'état de l'examen de la vidéo de consentement."
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "Commentaire"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "Aucun"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Vous n'avez encore participé à aucune étude."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Études actuelles"
+#: web/templates/web/studies-history.html:147
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Vous n'avez encore participé à aucune étude."
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Études"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Veuillez noter que pour participer vous aurez besoin d'un ordinateur "
-"portable ou de bureau (pas d'un appareil mobile) pouvant lancer Chrome ou "
-"Firefox."
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Voir les détails"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "Nous ne menons aucune étude pour le moment!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"Vous cherchez d'autres façons de contribuer à la recherche depuis chez "
-"vous ? Consultez <a href=\"https://childrenhelpingscience.com/\" target="
-"\"_blank\" rel=\"noreferrer noopener\">Children Helping Science</a> pour "
-"encore plus d'études!"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "jours"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr "jusqu'à"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr "quand"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressources"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Aperçu de l'étude"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Retour à la liste"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Critère d'éligibilité"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Durée"
-
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Compensation"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Ce qu'il se passe"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Ce que nous étudions"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Cette étude est menée par"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Souhaitez-vous participer à cette étude ?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Connectez-vous pour participer"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "Ajouter le profil de l'enfant à"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "aperçu"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "participer"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "maintenant"
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Créer un module d'expérience pour la prévisualisation"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Connectez-vous pour participer"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "Ajouter le profil de l'enfant à"
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "Compléter l'enquête démographique pour"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Participer"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Ce qu'il se passe"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Ce que nous étudions"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Durée"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Cette étude est menée par"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Souhaitez-vous participer à cette étude ?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Sélectionnez un enfant :"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Aucune sélection"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Votre enfant est encore trop jeune pour la tranche d'âge recommandée pour "
 "cette étude. Si vous pouvez attendre <span id = 'wait-until'> jusqu'à </"
 "span> ce qu'il ou elle soit assez vieux, nous pourrons utiliser les données "
 "collectées dans notre recherche!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Votre enfant est plus âgé que la tranche d'âge recommandée pour cette étude. "
 "Vous êtes les bienvenu(e)s pour participer quand même à l'étude, mais nous "
 "ne pourrons pas utiliser les données collectées dans notre recherche."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Votre enfant ne répond pas aux critères d'éligibilité énumérés pour cette "
 "étude. Vous êtes les bienvenu(e)s pour participer quand même à l'étude, mais "
 "nous ne pourrons pas utiliser les données collectées dans notre recherche. "
 "Veuillez contacter les chercheurs de l'étude en question"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Créer un module d'expérience pour la prévisualisation"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Participer"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "maintenant"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1898,31 +3409,90 @@ msgstr ""
 "protocole d'étude, ajoutez à vos favoris l'URL à laquelle le bouton ci-"
 "dessus vous renvoie."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "S'inscrire"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Veuillez noter que pour participer vous aurez besoin d'un ordinateur "
+"portable ou de bureau (pas d'un appareil mobile) pouvant lancer Chrome ou "
+"Firefox."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "Participant créé."
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "Données démographiques sauvegardées."
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "Enfant ajouté."
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "Enfant supprimé."
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "Enfant mis à jour."
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "Préférences d'email sauvegardées"
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -1933,14 +3503,197 @@ msgstr ""
 "soit terminée, soit en pause. Si vous pensez qu'il s'agit d'une erreur, "
 "veuillez contacter {study.contact_info}"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "Pour vous inscrire en tant que chercheur, veuillez utiliser"
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr ""
+#~ "Votre mot de passe ne doit pas être trop similaire à vos autres "
+#~ "informations personnelles."
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "Votre mot de passe doit contenir au moins 16 caractères."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr ""
+#~ "Votre mot de passe ne peut pas être un mot de passe couramment utilisé."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr ""
+#~ "Votre mot de passe ne peut pas être entièrement numérique (chiffres)."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "À quelle(s) catégorie(s) votre famille correspond-elle ?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr ""
+#~ "Réponses numériques uniquement - une estimation approximative est "
+#~ "suffisante !"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Quelle(s) langue(s) votre famille parle-t-elle à la maison?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr ""
+#~ "Quel est le niveau d'études le plus élevé obtenu par votre conjoint?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Environ combien y a-t-il de livres pour enfants dans votre foyer ?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Si la réponse varie en raison d'ententes de garde partagée ou de voyages, "
+#~ "veuillez saisir le nombre de parents / tuteurs avec lesquels vos enfants "
+#~ "vivent habituellement (ou expliquer)."
+
+#~ msgid "other"
+#~ msgstr "autre"
+
+#~ msgid "3 or more"
+#~ msgstr "3 et plus"
+
+#~ msgid "varies"
+#~ msgstr "varie"
+
+#~ msgid "My Account"
+#~ msgstr "Mon compte"
+
+#~ msgid "Last Active:"
+#~ msgstr "Dernière activité :"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "ID global du participant :"
+
+#~ msgid "Dashboard"
+#~ msgstr "Tableau de bord"
+
+#, fuzzy
+#~| msgid "Portuguese"
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "Portugais"
+
+#~ msgid "Yue"
+#~ msgstr "Yue"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Connectez-vous pour participer"
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr ""
+#~ "Vos identifiants de connexion n'ont pas fonctionné. Veuillez réessayer."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Nouveau sur Lookit ?"
+
+#~ msgid "New password:"
+#~ msgstr "Nouveau mot de passe :"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Confirmez le mot de passe :"
+
+#, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "L'équipe de %(site_name)s"
+
+#~ msgid "Email address:"
+#~ msgstr "Adresse e-mail :"
+
+#~ msgid "FAQ"
+#~ msgstr "FAQ"
+
+#~ msgid "Hi"
+#~ msgstr "Salut"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Anniversaire vide"
+
+#~ msgid " day"
+#~ msgstr " journée"
+
+#~ msgid " days"
+#~ msgstr " journées"
+
+#~ msgid " month"
+#~ msgstr " mois"
+
+#~ msgid " months"
+#~ msgstr " mois"
+
+#~ msgid " year"
+#~ msgstr " an"
+
+#~ msgid " years"
+#~ msgstr " années"
+
+#~ msgid "Hide Form"
+#~ msgstr "Masquer le formulaire"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr ""
+#~ "Créez un compte famille pour commencer à participer aux études Lookit !"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Votre compte n'a pas accès à cette page. Pour continuer, veuillez vous "
+#~ "connecter avec un compte qui y a accès."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Veuillez vous connecter pour voir cette page."
+
+#~ msgid "Compensation: "
+#~ msgstr "Compensation: "
+
+#~ msgid "None"
+#~ msgstr "Aucun"
+
+#~ msgid "Current Studies"
+#~ msgstr "Études actuelles"
+
+#~ msgid "See details"
+#~ msgstr "Voir les détails"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Nous ne menons aucune étude pour le moment!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Vous cherchez d'autres façons de contribuer à la recherche depuis chez "
+#~ "vous ? Consultez <a href=\"https://childrenhelpingscience.com/\" "
+#~ "target=\"_blank\" rel=\"noreferrer noopener\">Children Helping Science</"
+#~ "a> pour encore plus d'études!"
+
+#~ msgid "days"
+#~ msgstr "jours"
+
+#~ msgid " until "
+#~ msgstr "jusqu'à"
+
+#~ msgid " when "
+#~ msgstr "quand"
+
+#~ msgid "Study overview"
+#~ msgstr "Aperçu de l'étude"
+
+#~ msgid "Back to list"
+#~ msgstr "Retour à la liste"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Critère d'éligibilité"
 
 #~ msgid "this form"
 #~ msgstr "ce formulaire"
-
-#~ msgid "instead"
-#~ msgstr "à la place"
 
 #~ msgid "Birthday test"
 #~ msgstr "Test d'anniversaire"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -3333,10 +3333,8 @@ msgstr "Durée"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Cette étude est menée par"
+msgstr "Cette étude est menée par %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/fr_CA/LC_MESSAGES/django.po
+++ b/locale/fr_CA/LC_MESSAGES/django.po
@@ -3329,10 +3329,8 @@ msgstr "Durée"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Cette étude est menée par"
+msgstr "Cette étude est menée par %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/fr_CA/LC_MESSAGES/django.po
+++ b/locale/fr_CA/LC_MESSAGES/django.po
@@ -2,35 +2,50 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: fr-ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Courriel"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Surnom"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr ""
 "Il est temps pour une autre session d'une étude à laquelle nous participons "
 "présentement"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Une nouvelle étude est disponible pour l'un de mes enfants"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -38,7 +53,7 @@ msgstr ""
 "Il y a une mise à jour liée à une étude à laquelle nous avons participé (par "
 "exemple, les résultats sont publiés)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -46,104 +61,95 @@ msgstr ""
 "Un chercheur a des questions concernant mes réponses individuelles (par "
 "exemple, si j'ai rapporté un problème technique pendant l'étude)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "À quel(s) groupe(s) votre famille s’identifie-t-elle?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Pays"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr ""
 "Entrez sous forme de liste séparée par des virgules: AAAA-MM-JJ, AAAA-MM-"
 "JJ, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
 msgstr ""
-"Réponses numériques uniquement - une estimation approximative est correct!"
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "Dans quel pays habitez-vous?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "Dans quelle province (ou territoire) habitez-vous?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Comment décririez-vous la région dans laquelle vous vivez?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Quelle (s) langue (s) votre famille parle-t-elle à la maison?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Combien d'enfants avez-vous?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Pour chaque enfant, veuillez saisir sa date de naissance:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Avec combien de parents / tuteurs vos enfants vivent-ils?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Quel est votre âge?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Quel est votre genre?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Quel est votre genre?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Quel est le niveau d'études le plus élevé que vous avez atteint?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Quel est le niveau de scolarité le plus élevé de votre conjoint(e)?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr ""
 "Quel est votre revenu annuel familial approximatif (en dollars canadiens)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Environ combien de livres pour enfants y a-t-il dans votre maison?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Y a-t-il autre chose que vous aimeriez que nous sachions?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Comment avez-vous entendu parler de Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Si la réponse varie en raison d'arrangements de garde partagée ou de "
-"voyages, veuillez entrer le nombre de parents / tuteurs avec lesquels vos "
-"enfants vivent habituellement ou fournir une explication."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Date de naissance"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Une autre race, ethnicité ou origine"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -154,34 +160,37 @@ msgstr ""
 "enfants ou les informations qui permettraient à un lecteur de calculer la "
 "date de naissance."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Les dates de naissance ne peuvent pas être dans le futur."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Prénom"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Date de naissance"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Genre"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Âge gestationnel à la naissance"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr ""
 "Toute autre information supplémentaire que vous souhaitez que nous sachions"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Charactéristiques et conditions"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -189,7 +198,7 @@ msgstr ""
 "Langues auxquelles cet enfant est exposé à la maison, à l'école ou avec "
 "toute autre personne assurant sa garde."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -202,505 +211,613 @@ msgstr ""
 "exemple, \"Une nouvelle étude est disponible pour Léa!\") Mais nous ne "
 "publierons jamais les noms ni ne les utiliserons dans nos recherches."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Par exemple, des troubles du développement diagnostiqués par un "
 "professionnel ou des problèmes de vision ou d'audition"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Veuillez arrondir à la semaine de grossesse terminée la plus proche."
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Études"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Études actuelles"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Vos études passées"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Études actuelles"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Je ne suis pas certain(e) ou je préfère ne pas répondre"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Moins de 24 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 semaines"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 semaines ou plus"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Peut visualiser l'organisation"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Peut modifier l'organisation"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Peut créer une organisation"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Peut supprimer l'organisation"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Peut visualiser l'expérimentateur"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Peut visualiser l'analyse de données"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "peut créer un utilisateur"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "peut visualiser un utilisateur"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "peut éditer un utilisateur"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "peut supprimer un utilisateur"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "peut visualiser les permissions de l'utilisateur"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "peut éditer les permissions de l'utilisateur"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "peut lire toutes les données de l'utilisateur"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "peut lire les noms d'utilisateurs"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "homme"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "femme"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "autre"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "préfère ne pas répondre"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Peut visualiser l'organisation"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Peut modifier l'organisation"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Peut créer une organisation"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Peut supprimer l'organisation"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Peut visualiser l'expérimentateur"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Peut visualiser l'analyse de données"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "peut créer un utilisateur"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "peut visualiser un utilisateur"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "peut éditer un utilisateur"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "peut supprimer un utilisateur"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "peut visualiser les permissions de l'utilisateur"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "peut éditer les permissions de l'utilisateur"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "peut lire toutes les données de l'utilisateur"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "peut lire les noms d'utilisateurs"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Blanc/caucasien"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Origine hispanique, latino ou espagnole"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Noir ou afro-américain"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asiatique"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Autochtone"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Moyen-Orient ou Afrique du Nord"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Hawaïen indigène ou autre insulaire du Pacifique"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Une autre race, ethnicité ou origine"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "partiellement complété l'école secondaire"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "complété l'école secondaire (ou GED)"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "partiellement complété un diplôme universitaire niveau baccalauréat"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "certificat collégial de 2 ans"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "diplôme universitaire niveau baccalauréat"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr ""
 "partiellement complété un diplôme universitaire niveau supérieur (maîtrise, "
 "doctorat)"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "diplôme universitaire niveau maîtrise ou doctorat"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "non applicable - pas de conjoint ou partenaire"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Plus de 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "moins de 18"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 ou plus"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 ou plus"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "varie"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10 000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15 000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20 000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30 000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40 000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50 000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60 000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70 000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80 000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90 000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100 000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110 000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120 000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130 000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140 000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150 000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160 000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170 000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180 000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190 000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "plus de 200 000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "urbain"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "banlieue"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "rural"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Sélectionnez une province ou un territoire"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Information sur le compte"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Questionnaire démographique"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Dites-nous en plus à propos de vous."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Information sur les enfants"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Ajoutez ou modifiez les informations des participants."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Préférences de messagerie"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Modifiez vos disponibilités horaires pour vous joindre."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Mon compte"
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr "Mettre à jour les informations du compte"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Sauvegarder"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Changer votre mot de passe"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Tous les participants"
 
@@ -708,76 +825,83 @@ msgstr "Tous les participants"
 msgid "Participant ID"
 msgstr "ID du participant"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Dernière activité:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "ID global du participant"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Enfants"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Âge"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Information additionnelle"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Aucun profil enfant enregistré!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Dernières données démographiques"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Pays"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Province/territoire"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Description de la zone d'habitation"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Langues parlées à la maison"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Nombre d'enfants"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Âge actuel des enfants"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Réponses de l'étude"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Nombre de gardiens"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Explications pour les gardiens"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Race"
 
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Tableau de bord"
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
 
-#: project/settings.py:243 studies/fields.py:97
-#, fuzzy
-#| msgid "Asian"
-msgid "Russian"
-msgstr "Asiatique"
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
 
 #: studies/fields.py:45
 msgid "Twin"
@@ -807,35 +931,269 @@ msgstr "Septuplé"
 msgid "Octuplet"
 msgstr "Octuplé"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
 #: studies/fields.py:69
 #, fuzzy
 #| msgid "Duration"
 msgid "Gujarati"
 msgstr "Durée"
 
-#: studies/fields.py:115
-#, fuzzy
-#| msgid "Yes"
-msgid "Yue"
-msgstr "Oui"
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+#, fuzzy
+#| msgid "Duration"
+msgid "Marathi"
+msgstr "Durée"
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+#, fuzzy
+#| msgid "Asian"
+msgid "Russian"
+msgstr "Asiatique"
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Non répondu"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Autre"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Homme"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Femme"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -844,155 +1202,68 @@ msgstr ""
 "laboratoire pourra créer des études associées à ce laboratoire et pourra "
 "être ajouté aux études de ce laboratoire."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Les utilisateurs qui ont fait une demande pour joindre ce laboratoire."
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-#, fuzzy
-#| msgid "researcher login"
-msgid "For researchers"
-msgstr "Connexion chercheur"
-
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-#, fuzzy
-#| msgid "Contact:"
-msgid "Contact us"
-msgstr "Contact:"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Participez"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Connectez-vous pour participer"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Connectez-vous pour participer"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Quel est votre genre?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Durée"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "Nous ne menons aucune étude pour le moment!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Participez"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Déclaration de confidentialité"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Tous les participants"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Information additionnelle"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Vous avez réussi à vous déconnecter."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-#, fuzzy
-#| msgid "Your username and password didn't match. Please try again."
-msgid "Your login credentials didn't work. Please try again."
-msgstr ""
-"Votre nom d\"utilisateur et votre mot de passe ne correspondent pas. "
-"Veuillez réessayer."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "S'identifier"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Mot de passe oublié?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Nouveau à Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Le mot de passe est modifié"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Votre mot de passe a été modifié"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "La documentation"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Modifier votre mot de passe"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Déconnecter"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Accueil"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Changement de mot de passe"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Veuillez corriger l'erreur ci-dessous."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Veuillez corriger les erreurs ci-dessous."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -1001,28 +1272,28 @@ msgstr ""
 "ensuite entrer votre nouveau mot de passes deux fois, afin que nous "
 "puissions verifier qu'il est bien écrit."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Modifier mon mot de passe"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Réinitialisation du mot de passe est terminée"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Votre mot de passe a été établi. Veillez y accéder."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 msgid "Log in"
 msgstr "Connexion"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Réinitialisation du mot de passe est terminée"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Votre mot de passe a été établi. Veillez y accéder."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Confirmation de la réinitialisation du mot de passe"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1030,15 +1301,7 @@ msgstr ""
 "Veuillez entrer votre nouveau mot de passe deux fois afin que nous puissions "
 "verifier qu'il est bien écrit."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nouveau mot de passe:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Confirmez le mot de passe:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1047,13 +1310,13 @@ msgstr ""
 "raison qu'il a déjà été accédé. Veuillez refaire la demande pour la "
 "réinitialisation du mot de passe."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset link sent"
 msgstr "Réinitialisation du mot de passe est terminée"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 #, fuzzy
 #| msgid ""
 #| "We've emailed you instructions for setting your password, if an account "
@@ -1066,7 +1329,7 @@ msgstr ""
 "de passe, si un compte existe avec l'adresse courriel que vous avez entré. "
 "Vous devriez les recevoir bientôt."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 #, fuzzy
 #| msgid ""
 #| "If you don't receive an email, please make sure you've entered the "
@@ -1079,11 +1342,11 @@ msgstr ""
 "Si vous ne recevez pas de courriel, veuillez assurez d'avoir entré l'adresse "
 "avec laquelle vous vous êtes inscrit, et vérifiez votre dossier spam."
 
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Vous avez reçu ce courriel car vous avez fait une demande pour la "
 "réinitialisation du mot de passe de votre compte d'utilisateur à "
@@ -1098,22 +1361,25 @@ msgstr ""
 msgid "Your username, in case you've forgotten:"
 msgstr "Votre nom d'utilisateur, au cas qu'il a été oublié:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Nous vous remercions pour avoir utilisé notre site!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-msgid "The %(site_name)s team"
-msgstr "L'équipe %(site_name)s"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Réinitialisation du mot de passe"
+
+#: web/templates/registration/password_reset_form.html:8
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset"
 msgstr "Réinitialisation du mot de passe est terminée"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1121,129 +1387,257 @@ msgstr ""
 "Mot de passe oublié? Entrer votre adresse courriel ci-dessous, et nous vous "
 "enverrons les instructions par courriel pour le rétablir à nouveau. "
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Adresse courriel:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset complete"
+msgid "Password reset on Children Helping Science"
+msgstr "Réinitialisation du mot de passe est terminée"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Réinitialisation du mot de passe"
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Expérimentateur"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Études"
+#: web/templates/web/_footer.html:17
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact us"
+msgstr "Contact:"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "FAQ"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Les scientifiques"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Ressources"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Bonjour"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Se déconnecter"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "S'inscrire"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Expérimentateur"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Enfants"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Annuler"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Ajouter un enfant"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Enfant"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 #| msgid "Back to list"
 msgid "Back to Children List"
 msgstr "Retour à la liste"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Mise à jour"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Supprimer"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Annuler"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Sauvegarder"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Date de naissance non indiquée"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Mise à jour"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr "jour"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr "jours"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr "mois"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr "mois"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr "an"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr "ans"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Ajouter un enfant"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Masquer le formulaire"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nom"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Mettre à jour les informations d'un enfant"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nom"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Aucun profil d'enfant enregistré"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+#, fuzzy
+#| msgid "researcher login"
+msgid "For researchers"
+msgstr "Connexion chercheur"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "La documentation"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Mettre à jour les données démographiques"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1258,7 +1652,7 @@ msgstr ""
 "plusieurs langues ou avoir des frères et sœurs plus âgés affectent "
 "l'apprentissage des enfants."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1268,127 +1662,1553 @@ msgstr ""
 "scientifiques ou publicitaires, vos informations démographiques ne sont "
 "jamais publiées en même temps que votre vidéo."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Participez"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Vos études passées"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "Nous ne menons aucune étude pour le moment!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Connectez-vous pour participer"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Quel est votre genre?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Durée"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "Dans quelle province (ou territoire) habitez-vous?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "researcher login"
+msgid "For Researchers"
+msgstr "Connexion chercheur"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Quel est votre âge?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Connectez-vous pour participer"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Les scientifiques"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Participez"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Accueil"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Je souhaite être contacté lorsque:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Connectez-vous pour participer"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Créer un compte"
+
+#: web/templates/web/participant-signup.html:13
 #, fuzzy
 #| msgid "Participant account"
 msgid "Create Participant Account"
 msgstr "Compte du participant"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead?"
+msgid "instead."
+msgstr "au lieu?"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "En cliquant sur 'Créer un compte', j'accepte d'avoir lu et accepté le"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Déclaration de confidentialité"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Créer un compte"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Déclaration de confidentialité"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Tous les participants"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Information additionnelle"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Études passées"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
 msgstr ""
-"Votre compte n'a pas accès à cette page. Pour continuer, veuillez vous "
-"connecter avec un compte qui y a accès."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Veuillez vous connecter pour voir cette page."
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Études actuelles"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Vos études passées"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Vous pouvez consulter vos études et voir les commentaires laissés par les "
 "chercheurs ici:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Vignette d'étude"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Éligibilité:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contact:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Vous collectez toujours des données?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Oui"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Non"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Compensation:"
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Compensation"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Réponses de l'étude"
 
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Date"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "État du consentement"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Approuvé"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Votre vidéo de consentement a été examinée par un chercheur et est valide."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "En attente"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr ""
 "Votre vidéo de consentement n'a pas encore été examinée par un chercheur."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Invalide"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1399,160 +3219,184 @@ msgstr ""
 "Vos autres données de cette session ne seront ni consultées ni utilisées par "
 "les chercheurs de l'étude."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr ""
 "Aucune information sur l'état de l'examen de la vidéo avec consentement."
 
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Vous n'avez pas encore participé à une étude."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Études actuelles"
-
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
-msgstr ""
-"Veuillez noter que vous aurez besoin d'un ordinateur portable ou de bureau "
-"(et non d'un appareil mobile) exécutant Chrome ou Firefox pour participer."
-
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Voir les détails"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "Nous ne menons aucune étude pour le moment!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
-msgstr ""
-"Vous cherchez d'autres moyens de contribuer à la recherche depuis chez vous? "
-"Consultez  <a href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
-"rel=\"noreferrer noopener\">Children Helping Science</a>  pour encore plus "
-"d'études!"
-
-#: web/templates/web/study-detail.html:53
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-#| msgid " days"
-msgid "days"
-msgstr "jours"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Vous n'avez pas encore participé à une étude."
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Aperçu de l'étude"
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Études"
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Retour à la liste"
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Critère d'éligibilité"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
 
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Durée"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Compensation"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Ce qui se passe"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressources"
 
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Ce que nous étudions"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Cette étude est menée par"
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
 
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Souhaitez-vous participer à cette étude?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Connectez-vous pour participer"
-
-#: web/templates/web/study-detail.html:142
-#, fuzzy
-#| msgid "No child profiles registered!"
-msgid "Add child profile to "
-msgstr "Aucun profil d'enfant enregistré"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 #, fuzzy
 #| msgid "Participate"
 msgid "participate"
 msgstr "Participez"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Créer un exécuteur d'expérience pour prévisualiser"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Connectez-vous pour participer"
+
+#: web/templates/web/study-detail.html:22
+#, fuzzy
+#| msgid "No child profiles registered!"
+msgid "Add child profile to "
+msgstr "Aucun profil d'enfant enregistré"
+
+#: web/templates/web/study-detail.html:23
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Complete demographic survey to "
 msgstr "Questionnaire démographique"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Participez"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Ce qui se passe"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Ce que nous étudions"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Durée"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Cette étude est menée par"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Souhaitez-vous participer à cette étude?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Sélectionner un enfant:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Aucun sélectionné"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Votre enfant est plus jeune que la tranche d'âge recommandée pour cette "
 "étude. Si vous pouvez attendre <span id = 'wait-until'> jusqu'à </span> "
 "qu'il ou elle soit assez grand/e, nous pourrons utiliser les données "
 "collectées dans notre recherche!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Votre enfant est plus âgé que la tranche d'âge recommandée pour cette étude. "
 "Vous pouvez tout de même essayer l'étude, mais nous ne pourrons pas utiliser "
 "les données collectées dans notre recherche."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Votre enfant ne répond pas aux critères d'éligibilité énumérés pour cette "
 "étude. Vous pouvez tout de même essayer l'étude, mais nous ne pourrons pas "
 "utiliser les données collectées dans notre recherche. Veuillez contacter les "
 "chercheurs de l'étude"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Créer un exécuteur d'expérience pour prévisualiser"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Participez"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1561,34 +3405,266 @@ msgstr ""
 "protocole d'étude, ajoutez l'URL à laquelle le bouton ci-dessus vous renvoie "
 "dans vos favoris."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "S'inscrire"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Veuillez noter que vous aurez besoin d'un ordinateur portable ou de bureau "
+"(et non d'un appareil mobile) exécutant Chrome ou Firefox pour participer."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 #, fuzzy
 #| msgid "Participant account"
 msgid "Participant created."
 msgstr "Compte du participant"
 
-#: web/views.py:88
+#: web/views.py:157
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Demographic data saved."
 msgstr "Questionnaire démographique"
 
-#: web/views.py:156
+#: web/views.py:223
 #, fuzzy
 #| msgid "Children"
 msgid "Child added."
 msgstr "Enfants"
 
-#: web/views.py:217
+#: web/views.py:264
+#, fuzzy
+#| msgid "Children"
+msgid "Child deleted."
+msgstr "Enfants"
+
+#: web/views.py:266
+#, fuzzy
+#| msgid "Children"
+msgid "Child updated."
+msgstr "Enfants"
+
+#: web/views.py:294
 #, fuzzy
 #| msgid "Email Preferences"
 msgid "Email preferences saved."
 msgstr "Préférences de messagerie"
 
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "À quel(s) groupe(s) votre famille s’identifie-t-elle?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr ""
+#~ "Réponses numériques uniquement - une estimation approximative est correct!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Quelle (s) langue (s) votre famille parle-t-elle à la maison?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "Quel est le niveau de scolarité le plus élevé de votre conjoint(e)?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Environ combien de livres pour enfants y a-t-il dans votre maison?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Si la réponse varie en raison d'arrangements de garde partagée ou de "
+#~ "voyages, veuillez entrer le nombre de parents / tuteurs avec lesquels vos "
+#~ "enfants vivent habituellement ou fournir une explication."
+
+#~ msgid "other"
+#~ msgstr "autre"
+
+#~ msgid "3 or more"
+#~ msgstr "3 ou plus"
+
+#~ msgid "varies"
+#~ msgstr "varie"
+
+#~ msgid "My Account"
+#~ msgstr "Mon compte"
+
+#~ msgid "Last Active:"
+#~ msgstr "Dernière activité:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "ID global du participant"
+
+#~ msgid "Dashboard"
+#~ msgstr "Tableau de bord"
+
 #, fuzzy
-#~| msgid "instead?"
-#~ msgid "instead"
-#~ msgstr "au lieu?"
+#~| msgid "Yes"
+#~ msgid "Yue"
+#~ msgstr "Oui"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Connectez-vous pour participer"
+
+#, fuzzy
+#~| msgid "Your username and password didn't match. Please try again."
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr ""
+#~ "Votre nom d\"utilisateur et votre mot de passe ne correspondent pas. "
+#~ "Veuillez réessayer."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Nouveau à Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nouveau mot de passe:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Confirmez le mot de passe:"
+
+#, fuzzy, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "L'équipe %(site_name)s"
+
+#~ msgid "Email address:"
+#~ msgstr "Adresse courriel:"
+
+#~ msgid "FAQ"
+#~ msgstr "FAQ"
+
+#~ msgid "Hi"
+#~ msgstr "Bonjour"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Date de naissance non indiquée"
+
+#~ msgid " day"
+#~ msgstr "jour"
+
+#~ msgid " days"
+#~ msgstr "jours"
+
+#~ msgid " month"
+#~ msgstr "mois"
+
+#~ msgid " months"
+#~ msgstr "mois"
+
+#~ msgid " year"
+#~ msgstr "an"
+
+#~ msgid " years"
+#~ msgstr "ans"
+
+#~ msgid "Hide Form"
+#~ msgstr "Masquer le formulaire"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Votre compte n'a pas accès à cette page. Pour continuer, veuillez vous "
+#~ "connecter avec un compte qui y a accès."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Veuillez vous connecter pour voir cette page."
+
+#~ msgid "Compensation: "
+#~ msgstr "Compensation:"
+
+#~ msgid "Current Studies"
+#~ msgstr "Études actuelles"
+
+#~ msgid "See details"
+#~ msgstr "Voir les détails"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Nous ne menons aucune étude pour le moment!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Vous cherchez d'autres moyens de contribuer à la recherche depuis chez "
+#~ "vous? Consultez  <a href=\"https://childrenhelpingscience.com/\" "
+#~ "target=\"_blank\" rel=\"noreferrer noopener\">Children Helping Science</"
+#~ "a>  pour encore plus d'études!"
+
+#, fuzzy
+#~| msgid " days"
+#~ msgid "days"
+#~ msgstr "jours"
+
+#~ msgid "Study overview"
+#~ msgstr "Aperçu de l'étude"
+
+#~ msgid "Back to list"
+#~ msgstr "Retour à la liste"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Critère d'éligibilité"
 
 #~ msgid "Login Unsuccessful"
 #~ msgstr "Échec de la connexion"
@@ -1660,6 +3736,3 @@ msgstr "Préférences de messagerie"
 
 #~ msgid "Signup"
 #~ msgstr "S'inscrire"
-
-#~ msgid "Update account information"
-#~ msgstr "Mettre à jour les informations du compte"

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -3298,10 +3298,8 @@ msgstr "מֶשֶׁך"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "מחקר זה נערך על ידי"
+msgstr "מחקר זה נערך על ידי %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -2,39 +2,54 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "כתובת מייל"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "כינוי"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "הגיע הזמן למפגש נוסף של המחקר שאנחנו משתתפים בו כרגע"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "מחקר חדש זמין לאחד מילדי"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
 msgstr "יש עדכון לגבי מחקר שהשתתפנו בו (למשל, התפרסמו תוצאות)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -42,99 +57,92 @@ msgstr ""
 "יש לחוקרים שאלה לגבי אחת התגובות שלי (למשל, אם דיווחתי על תקלה טכנית במהלך "
 "המחקר)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "איזה קטגוריה (או קטגוריות) מתאימה למשפחה שלך?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "ארץ"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "יש להכניס כרשימה המופרדת על ידי פסיקים: YYYY-MM-DD, YYYY-MM-DD..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "תשובות מספריות בלבד - זה בסדר לתת הערכה גסה!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "באיזו ארץ אתם חיים?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "באיזו מדינה אתם חיים?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "איך הייתם מתארים את האיזור בו אתם חיים?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "איזה שפה (או שפות) המשפחה שלכם מדברת בבית?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "כמה ילדים יש לך?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "לגבי כל ילד או ילדה, אנא הקלידו את יום ההולדת שלו או שלה:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "עם כמה הורים/אפוטרופסים חיים ילדכם?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "מה גילך?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "מה מגדרך?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "מה מגדרך?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "מהי רמת ההשכלה הגבוהה ביותר שהשלמת?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "מהי רמת ההשכלה הגבוהה ביותר שהשלימ/ה בן/בת זוגך?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "מהי בערך רמת ההכנסה השנתית של משפחתך?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "בערך כמה ספרי ילדים יש בבית?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "עוד משהו שתרצו שנדע?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "איך שמעתם על לוקיט?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"אם התשובה משתנה עקב הסדרי משמורת משותפים או נסיעות, אנא הכניסו את מספר "
-"ההורים / האפוטרופוסים שילדיכם מתגוררים איתם בדרך כלל או הסבירו."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "יום הולדת"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "גזע אחר, מוצא אתני או מוצא"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -143,39 +151,42 @@ msgstr ""
 "זה מאפשר לנו להבין בדיוק בן כמה ילדך כשהוא משתתף במחקר. אנו אף פעם לא "
 "מפרסמים תאריכי לידה של ילדים או מידע שיאפשר לקורא לחשב את תאריך הלידה."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "ימי הולדת לא יכולים להיות בעתיד."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "שם פרטי"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "יום הולדת"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "מגדר"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "גיל הריון בלידה"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "כל מידע נוסף שתרצו שנדע"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "מאפיינים ותנאים"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
 msgstr "שפות שילד זה נחשף אליהן בבית, בבית הספר או אצל מטפל אחר."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -186,501 +197,609 @@ msgstr ""
 "הם בסדר! אנו עשויים לכלול את שמו של ילדך במייל אליכם (למשל, \"יש מחקר חדש "
 "זמין עבור יונתן!\") אך לעולם לא נפרסם שמות ולא נשתמש בהם במחקר שלנו."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr "למשל, הפרעות התפתחות מאובחנות או בעיות ראייה או שמיעה"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "אנא עגלו מטה לשבוע המלא של הריון שהושלם"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "מחקרים"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "מחקרים נוכחיים"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "מחקרים קודמים שלכם"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "מחקרים נוכחיים"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "לא בטוח/ה או מעדיפ/ה לא לענות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "מתחת ל-24 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 שבועות"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 שבועות ויותר"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "יכול/ה להציג ארגון"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "יכול/ה לערוך ארגון"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "יכול/ה ליצור ארגון"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "יכול/ה להסיר ארגון"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "יכול/ה לראות את הנסיין"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "יכול להציג נתונים"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "יכול/ה ליצור משתמש"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "יכול/ה להציג משתמש"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "יכול/ה לערוך משתמש"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "יכול/ה להסיר משתמש"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "יכול/ה להציג הרשאות משתמש"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "יכול/ה לערוך הרשאות משתמש"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "יכול/ה לקרוא את כל נתוני המשתמשים"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "יכול/ה לקרוא שמות משתמש של משתמשים"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "זָכָר"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "נְקֵבָה"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "אַחֵר"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "מעדיפ/ה שלא לענות"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "יכול/ה להציג ארגון"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "יכול/ה לערוך ארגון"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "יכול/ה ליצור ארגון"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "יכול/ה להסיר ארגון"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "יכול/ה לראות את הנסיין"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "יכול להציג נתונים"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "יכול/ה ליצור משתמש"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "יכול/ה להציג משתמש"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "יכול/ה לערוך משתמש"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "יכול/ה להסיר משתמש"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "יכול/ה להציג הרשאות משתמש"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "יכול/ה לערוך הרשאות משתמש"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "יכול/ה לקרוא את כל נתוני המשתמשים"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "יכול/ה לקרוא שמות משתמש של משתמשים"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "לבן"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "מוצא היספני, לטיני או ספרדי"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "שחור או אפרו אמריקאי"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "אסייתי"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "אינדיאני אמריקאים או יליד אלסקה"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "מזרח תיכוני או צפון אפריקאי"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "יליד הוואי או איים פסיפיים אחרים"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "גזע אחר, מוצא אתני או מוצא"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "לומדים בתיכון כעת סיימתם תיכון חלקית"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "תעודת בגרות או מקבילה"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "לומדים באוניברסיטה/מכללה כעת או סיימתם חלק מהתואר הראשון"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "לימודי תעודה"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "תואר ראשון"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "לומדים לתואר שני או מקצועי כעת או סיימת חלק ממנו"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "תואר שני או מקצועי"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "לא רלוונטי - אין בן או בת זוג"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "יותר מ 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "מתחת לגיל 18"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 ומעלה"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 או יותר"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "משתנה"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "מעל 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "עִירוֹנִי"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "פַּרבַרִי"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "כַּפרִי"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "בחרו מדינה"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "פרטי חשבון"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "סקר דמוגרפי"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "ספרו לנו עוד על עצמכם."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "מידע על ילדים"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "הוסיפו או ערכו מידע על משתתף."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "העדפות דוא\"ל"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "ערכו מתי אפשר ליצור איתכם קשר."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "החשבון שלי"
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr "עדכון פרטי החשבון"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "לשמור"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "שנו את סיסמתכם"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "כל המשתתפים"
 
@@ -688,76 +807,83 @@ msgstr "כל המשתתפים"
 msgid "Participant ID"
 msgstr "מספר משתתף"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "פעיל לאחרונה:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "מספר מזהה גלובלי של המשתתף:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "יְלָדִים"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "גיל"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "מידע נוסף"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "לא נמצאו פרופילי ילדים!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "הנתונים הדמוגרפיים האחרונים"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "ארץ"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "מדינה"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "תיאור האזור"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "שפות המדוברות בבית"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "מספר הילדים"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "גיל הילדים כרגע"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "תגובות מחקר"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "מספר אפוטרופסים"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "הסבר לאפוטרופוסים:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "מגזר"
 
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "לוּחַ מַחווָנִים"
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
 
-#: project/settings.py:243 studies/fields.py:97
-#, fuzzy
-#| msgid "Asian"
-msgid "Russian"
-msgstr "אסייתי"
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
 
 #: studies/fields.py:45
 msgid "Twin"
@@ -787,35 +913,269 @@ msgstr "שביעיה"
 msgid "Octuplet"
 msgstr "שמיניה"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
 #: studies/fields.py:69
 #, fuzzy
 #| msgid "Duration"
 msgid "Gujarati"
 msgstr "מֶשֶׁך"
 
-#: studies/fields.py:115
-#, fuzzy
-#| msgid "Yes"
-msgid "Yue"
-msgstr "כן"
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+#, fuzzy
+#| msgid "Duration"
+msgid "Marathi"
+msgstr "מֶשֶׁך"
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+#, fuzzy
+#| msgid "Asian"
+msgid "Russian"
+msgstr "אסייתי"
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "לא נענתה"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "אַחֵר"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "זָכָר"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "נְקֵבָה"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -823,153 +1183,68 @@ msgstr ""
 "המשתמשים המשתייכים למעבדה זו. משתמשים במעבדה זו יוכלו ליצור מחקרים המשויכים "
 "למעבדה זו וניתן יהיה להוסיף אותם למחקרי מעבדה זו."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "המשתמשים שביקשו להצטרף למעבדה זו."
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-#, fuzzy
-#| msgid "researcher login"
-msgid "For researchers"
-msgstr "כניסת חוקרים"
-
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-#, fuzzy
-#| msgid "Contact:"
-msgid "Contact us"
-msgstr "איש קשר:"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "לְהִשְׂתַתֵף"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "התחברו כדי להשתתף"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "התחברו כדי להשתתף"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "מה מגדרך?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "מֶשֶׁך"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "כרגע אנחנו לא עורכים שום מחקרים!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "לְהִשְׂתַתֵף"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "הצהרת פרטיות"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "כל המשתתפים"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "מידע נוסף"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "התנתקת בהצלחה."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-#, fuzzy
-#| msgid "Your username and password didn't match. Please try again."
-msgid "Your login credentials didn't work. Please try again."
-msgstr "שם המשתמש והסיסמה שלכם לא תואמים. אנא נסו שוב."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "התחברות"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "שכחת סיסמה?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "חדש/ה ב- Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "סיסמא שונתה"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "הסיסמה שלך שונתה."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "תיעוד"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "לשנות סיסמה"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "להתנתק"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "בית"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "שינוי סיסמה"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "אנא תקנו את השגיאה למטה."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "אנא תקנו את הטעויות להלן."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -977,43 +1252,35 @@ msgstr ""
 "אנא הזינו את הסיסמה הישנה שלכם, למען האבטחה, ואז הזינו את הסיסמה החדשה שלכם "
 "פעמיים כדי שנוכל לאמת שהקלדתם אותה כהלכה."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "שנו את הסיסמה שלי"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "איפוס הסיסמה הושלם"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "הסיסמה שלכם הוגדרה. אתם יכולים להמשיך ולהיכנס עכשיו."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 msgid "Log in"
 msgstr "התחברות"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "איפוס הסיסמה הושלם"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "הסיסמה שלכם הוגדרה. אתם יכולים להמשיך ולהיכנס עכשיו."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "אישור איפוס סיסמה"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
 msgstr ""
 "אנא הזינו את הסיסמה החדשה שלכם פעמיים כדי שנוכל לאמת שהקלדתם אותה כהלכה."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "סיסמה חדשה:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "אשרו סיסמה:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1021,13 +1288,13 @@ msgstr ""
 "הקישור לאיפוס הסיסמה לא היה חוקי, אולי משום שכבר נעשה בו שימוש. אנא בקשו "
 "איפוס סיסמה חדש."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset link sent"
 msgstr "איפוס הסיסמה הושלם"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 #, fuzzy
 #| msgid ""
 #| "We've emailed you instructions for setting your password, if an account "
@@ -1039,7 +1306,7 @@ msgstr ""
 "שלחנו לכם בדוא\"ל הוראות להגדרת הסיסמה שלכם - אם קיים חשבון עם הדוא\"ל "
 "שהזנתם. אתם אמורים לקבל אותן בקרוב."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 #, fuzzy
 #| msgid ""
 #| "If you don't receive an email, please make sure you've entered the "
@@ -1052,14 +1319,14 @@ msgstr ""
 "אם אינכם מקבלים דוא\"ל, ודאו שהזנתם את הכתובת שאליה נרשמתם ובדקו את תיקיית "
 "הספאם שלכם."
 
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
 #| msgid ""
 #| "You're receiving this email because you requested a password reset for "
 #| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "אתם מקבלים דוא\"ל זה מכיוון שביקשתם לאפס סיסמה עבור חשבון המשתמש שלכם ב-% "
 "(site_name) s."
@@ -1072,23 +1339,25 @@ msgstr "עברו לדף הבא ובחרו סיסמה חדשה:"
 msgid "Your username, in case you've forgotten:"
 msgstr "שם המשתמש שלכם, למקרה ששכחתם:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "תודה על השימוש באתר שלנו!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "צוות% (site_name) s"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "אפסו את הסיסמה שלי"
+
+#: web/templates/registration/password_reset_form.html:8
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset"
 msgstr "איפוס הסיסמה הושלם"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1096,129 +1365,257 @@ msgstr ""
 "שכחתם את הסיסמה שלכם? הזינו את כתובת הדוא\"ל שלכם למטה ונשלח אליכם הוראות "
 "בדבר הגדרת כתובת חדשה."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "כתובת דוא\"ל:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset complete"
+msgid "Password reset on Children Helping Science"
+msgstr "איפוס הסיסמה הושלם"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "אפסו את הסיסמה שלי"
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "נסיינ/ית"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "מחקרים"
+#: web/templates/web/_footer.html:17
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact us"
+msgstr "איש קשר:"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "שאלות נפוצות"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "המדענים והמדעניות"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "משאבים"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "היי"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "להתנתק"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "להרשם"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "נסיינ/ית"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "יְלָדִים"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "לְבַטֵל"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "הוסף ילד"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "יֶלֶד"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 #| msgid "Back to list"
 msgid "Back to Children List"
 msgstr "בחזרה לרשימה"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "עדכון"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "לִמְחוֹק"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "לְבַטֵל"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "לשמור"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "יום הולדת ריק"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "עדכון"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " יְוֹם"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " ימים"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " חוֹדֶשׁ"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " חודשים"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " שָׁנָה"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " שנים"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "הוסף ילד"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "הסתירו טופס"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "שֵׁם"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "לעדכן ילד/ה"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "שֵׁם"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "לא נרשמו פרופילי ילדים!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+#, fuzzy
+#| msgid "researcher login"
+msgid "For researchers"
+msgstr "כניסת חוקרים"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "תיעוד"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "לעדכן דמוגרפיה"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1231,7 +1628,7 @@ msgstr ""
 "לאיזה קהל אנו מגיעים, כמו גם כיצד גורמים כמו רב-לשוניות או אחים גדולים "
 "משפיעים על למידתם של ילדים."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1240,121 +1637,1549 @@ msgstr ""
 "גם אם אתם מאפשרים לפרסם את סרטי המחקר שלכם למטרות מדעיות או פרסום, המידע "
 "הדמוגרפי שלכם לעולם אינו מתפרסם בשילוב עם הסרטון שלכם."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "לְהִשְׂתַתֵף"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "מחקרים קודמים שלכם"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "כרגע אנחנו לא עורכים שום מחקרים!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "התחברו כדי להשתתף"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "מה מגדרך?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "מֶשֶׁך"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "באיזו מדינה אתם חיים?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "researcher login"
+msgid "For Researchers"
+msgstr "כניסת חוקרים"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "מה גילך?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "התחברו כדי להשתתף"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "המדענים והמדעניות"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "לְהִשְׂתַתֵף"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "בית"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "אנו מבקשים ליצור איתנו קשר כאשר:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "התחברו כדי להשתתף"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "צרו חשבון"
+
+#: web/templates/web/participant-signup.html:13
 #, fuzzy
 #| msgid "Participant account"
 msgid "Create Participant Account"
 msgstr "חשבון המשתתפ/ת"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead?"
+msgid "instead."
+msgstr "במקום זאת?"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "בלחיצה על 'צרו חשבון' אני מסכימ/ה שקראתי וקיבלתי את ה "
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "הצהרת פרטיות"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "צרו חשבון"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "הצהרת פרטיות"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "כל המשתתפים"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "מידע נוסף"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "מחקרים קודמים"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
+msgstr ""
+
+#: web/templates/web/studies-history.html:31
 msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
-msgstr "לחשבון שלכם אין גישה לדף זה. כדי להמשיך, היכנסו עם חשבון שיש לו גישה."
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "אנא התחברו כדי לראות דף זה."
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "מחקרים נוכחיים"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "מחקרים קודמים שלכם"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr "כאן תוכלו לצפות במחקרים שלכם ולראות הערות שהשאירו חוקרים:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "תמונת מחקר ממוזערת"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "זכאות:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "איש קשר:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "עדיין אוספים נתונים?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "כן"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "לא"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "תמורה: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "תשלום"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "תגובות מחקר"
 
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "תַאֲרִיך"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "מצב הסכמה"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "אושר"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr "סרטון ההסכמה שלך נבדק על ידי חוקר והוא תקף."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "ממתין ל"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "סרטון ההסכמה שלך טרם נבדק על ידי חוקר."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "לא חוקי"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1364,155 +3189,180 @@ msgstr ""
 "ההסכמה. הנתונים האחרים שלך מהפגישה הזו לא ישמשו את חוקרי המחקר והם לא יצפו "
 "בהם."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr "אין מידע על סטטוס סקירת הסרטון."
 
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "עדיין לא השתתפת בשום מחקרים."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "מחקרים נוכחיים"
-
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
-msgstr ""
-"שימו לב שתצטרכו מחשב נייד או מחשב שולחני (לא טלפון נייד או טאבלט) בו פועל "
-"Chrome או Firefox כדי להשתתף."
-
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "ראו פרטים"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "כרגע אנחנו לא עורכים שום מחקרים!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
-msgstr ""
-"מחפשים דרכים נוספות לתרום למחקר מהבית? עיינו ב <a href=\"https://"
-"childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer noopener\"> "
-"ילדים העוזרים למדע </a> למחקרים נוספים!"
-
-#: web/templates/web/study-detail.html:53
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-#| msgid " days"
-msgid "days"
-msgstr " ימים"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "עדיין לא השתתפת בשום מחקרים."
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "סקירת המחקר"
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "מחקרים"
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "בחזרה לרשימה"
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "קריטריונים לזכאות"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
 
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "מֶשֶׁך"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "תשלום"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "מה קורה"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "משאבים"
 
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "מה אנחנו חוקרים"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "מחקר זה נערך על ידי"
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
 
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "האם תרצו להשתתף במחקר זה?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "התחברו כדי להשתתף"
-
-#: web/templates/web/study-detail.html:142
-#, fuzzy
-#| msgid "No child profiles registered!"
-msgid "Add child profile to "
-msgstr "לא נרשמו פרופילי ילדים!"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 #, fuzzy
 #| msgid "Participate"
 msgid "participate"
 msgstr "לְהִשְׂתַתֵף"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "בנו מריץ ניסויים לתצוגה מקדימה"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "התחברו כדי להשתתף"
+
+#: web/templates/web/study-detail.html:22
+#, fuzzy
+#| msgid "No child profiles registered!"
+msgid "Add child profile to "
+msgstr "לא נרשמו פרופילי ילדים!"
+
+#: web/templates/web/study-detail.html:23
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Complete demographic survey to "
 msgstr "סקר דמוגרפי"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "לְהִשְׂתַתֵף"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "מה קורה"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "מה אנחנו חוקרים"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "מֶשֶׁך"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "מחקר זה נערך על ידי"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "האם תרצו להשתתף במחקר זה?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "בחרו ילד:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "לא נבחר"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "ילדכם עדיין צעיר מטווח הגילאים המומלץ למחקר זה. אם תוכלו להמתין <span id = "
 "'wait-until'> עד ש- </span> הוא או היא יהיו מספיק גדולים, נוכל להשתמש "
 "בנתונים שנאספו במחקר שלנו!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "ילדכם מבוגר מטווח הגילאים המומלץ למחקר זה. אתם מוזמנים לנסות את המחקר בכל "
 "מקרה, אך לא נוכל להשתמש בנתונים שנאספו במחקר שלנו."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "ילדכם אינו עומד בקריטריוני הזכאות המפורטים למחקר זה. אתם מוזמנים לנסות את "
 "המחקר בכל מקרה, אך לא נוכל להשתמש בנתונים שנאספו במחקר שלנו. אנא צרו קשר עם "
 "חוקרי המחקר"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "בנו מריץ ניסויים לתצוגה מקדימה"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "לְהִשְׂתַתֵף"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1520,34 +3370,261 @@ msgstr ""
 "לקבלת דרך קלה לראות מה קורה בעת עדכון פרוטוקול הלימוד שלכם, סמנו את כתובת "
 "האתר שהכפתור שלמעלה שולח אתכם אליה."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "להרשם"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"שימו לב שתצטרכו מחשב נייד או מחשב שולחני (לא טלפון נייד או טאבלט) בו פועל "
+"Chrome או Firefox כדי להשתתף."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 #, fuzzy
 #| msgid "Participant account"
 msgid "Participant created."
 msgstr "חשבון המשתתפ/ת"
 
-#: web/views.py:88
+#: web/views.py:157
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Demographic data saved."
 msgstr "סקר דמוגרפי"
 
-#: web/views.py:156
+#: web/views.py:223
 #, fuzzy
 #| msgid "Children"
 msgid "Child added."
 msgstr "יְלָדִים"
 
-#: web/views.py:217
+#: web/views.py:264
+#, fuzzy
+#| msgid "Children"
+msgid "Child deleted."
+msgstr "יְלָדִים"
+
+#: web/views.py:266
+#, fuzzy
+#| msgid "Children"
+msgid "Child updated."
+msgstr "יְלָדִים"
+
+#: web/views.py:294
 #, fuzzy
 #| msgid "Email Preferences"
 msgid "Email preferences saved."
 msgstr "העדפות דוא\"ל"
 
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "איזה קטגוריה (או קטגוריות) מתאימה למשפחה שלך?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "תשובות מספריות בלבד - זה בסדר לתת הערכה גסה!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "איזה שפה (או שפות) המשפחה שלכם מדברת בבית?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "מהי רמת ההשכלה הגבוהה ביותר שהשלימ/ה בן/בת זוגך?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "בערך כמה ספרי ילדים יש בבית?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "אם התשובה משתנה עקב הסדרי משמורת משותפים או נסיעות, אנא הכניסו את מספר "
+#~ "ההורים / האפוטרופוסים שילדיכם מתגוררים איתם בדרך כלל או הסבירו."
+
+#~ msgid "other"
+#~ msgstr "אַחֵר"
+
+#~ msgid "3 or more"
+#~ msgstr "3 או יותר"
+
+#~ msgid "varies"
+#~ msgstr "משתנה"
+
+#~ msgid "My Account"
+#~ msgstr "החשבון שלי"
+
+#~ msgid "Last Active:"
+#~ msgstr "פעיל לאחרונה:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "מספר מזהה גלובלי של המשתתף:"
+
+#~ msgid "Dashboard"
+#~ msgstr "לוּחַ מַחווָנִים"
+
 #, fuzzy
-#~| msgid "instead?"
-#~ msgid "instead"
-#~ msgstr "במקום זאת?"
+#~| msgid "Yes"
+#~ msgid "Yue"
+#~ msgstr "כן"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "התחברו כדי להשתתף"
+
+#, fuzzy
+#~| msgid "Your username and password didn't match. Please try again."
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "שם המשתמש והסיסמה שלכם לא תואמים. אנא נסו שוב."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "חדש/ה ב- Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "סיסמה חדשה:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "אשרו סיסמה:"
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "צוות% (site_name) s"
+
+#~ msgid "Email address:"
+#~ msgstr "כתובת דוא\"ל:"
+
+#~ msgid "FAQ"
+#~ msgstr "שאלות נפוצות"
+
+#~ msgid "Hi"
+#~ msgstr "היי"
+
+#~ msgid "Empty birthday"
+#~ msgstr "יום הולדת ריק"
+
+#~ msgid " day"
+#~ msgstr " יְוֹם"
+
+#~ msgid " days"
+#~ msgstr " ימים"
+
+#~ msgid " month"
+#~ msgstr " חוֹדֶשׁ"
+
+#~ msgid " months"
+#~ msgstr " חודשים"
+
+#~ msgid " year"
+#~ msgstr " שָׁנָה"
+
+#~ msgid " years"
+#~ msgstr " שנים"
+
+#~ msgid "Hide Form"
+#~ msgstr "הסתירו טופס"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "לחשבון שלכם אין גישה לדף זה. כדי להמשיך, היכנסו עם חשבון שיש לו גישה."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "אנא התחברו כדי לראות דף זה."
+
+#~ msgid "Compensation: "
+#~ msgstr "תמורה: "
+
+#~ msgid "Current Studies"
+#~ msgstr "מחקרים נוכחיים"
+
+#~ msgid "See details"
+#~ msgstr "ראו פרטים"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "כרגע אנחנו לא עורכים שום מחקרים!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "מחפשים דרכים נוספות לתרום למחקר מהבית? עיינו ב <a href=\"https://"
+#~ "childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
+#~ "noopener\"> ילדים העוזרים למדע </a> למחקרים נוספים!"
+
+#, fuzzy
+#~| msgid " days"
+#~ msgid "days"
+#~ msgstr " ימים"
+
+#~ msgid "Study overview"
+#~ msgstr "סקירת המחקר"
+
+#~ msgid "Back to list"
+#~ msgstr "בחזרה לרשימה"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "קריטריונים לזכאות"
 
 #, fuzzy
 #~| msgid "Birthday"
@@ -1626,6 +3703,3 @@ msgstr "העדפות דוא\"ל"
 
 #~ msgid "Signup"
 #~ msgstr "הירשמו"
-
-#~ msgid "Update account information"
-#~ msgstr "עדכון פרטי החשבון"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -1,0 +1,3300 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
+msgid "Email address"
+msgstr ""
+
+#: accounts/forms.py:223
+msgid "Nickname"
+msgstr ""
+
+#: accounts/forms.py:286
+msgid ""
+"It's time for another session of a study we are currently participating in"
+msgstr ""
+
+#: accounts/forms.py:288
+msgid "A new study is available for one of my children"
+msgstr ""
+
+#: accounts/forms.py:290
+msgid ""
+"There's an update about a study we participated in (for example, results are "
+"published)"
+msgstr ""
+
+#: accounts/forms.py:293
+msgid ""
+"A researcher has questions about my individual responses (for example, if I "
+"report a technical problem during the study)"
+msgstr ""
+
+#: accounts/forms.py:323
+msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
+msgstr ""
+
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
+
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
+msgid "What country do you live in?"
+msgstr ""
+
+#: accounts/forms.py:335
+msgid "What state do you live in?"
+msgstr ""
+
+#: accounts/forms.py:336
+msgid "How would you describe the area where you live?"
+msgstr ""
+
+#: accounts/forms.py:337
+msgid "How many children do you have?"
+msgstr ""
+
+#: accounts/forms.py:338
+msgid "For each child, please enter his or her birthdate:"
+msgstr ""
+
+#: accounts/forms.py:340
+msgid "How many parents/guardians do your children live with?"
+msgstr ""
+
+#: accounts/forms.py:342
+msgid "What is your age?"
+msgstr ""
+
+#: accounts/forms.py:343
+msgid "What is your gender?"
+msgstr ""
+
+#: accounts/forms.py:344
+msgid "Describe your gender"
+msgstr ""
+
+#: accounts/forms.py:346
+msgid "What is the highest level of education you've completed?"
+msgstr ""
+
+#: accounts/forms.py:349
+msgid "What is your approximate family yearly income (in US dollars)?"
+msgstr ""
+
+#: accounts/forms.py:351
+msgid "Anything else you'd like us to know?"
+msgstr ""
+
+#: accounts/forms.py:352
+msgid "How did you hear about Lookit?"
+msgstr ""
+
+#: accounts/forms.py:354
+msgid ""
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
+msgstr ""
+
+#: accounts/forms.py:357
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr ""
+
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
+msgid ""
+"This lets us figure out exactly how old your child is when they participate "
+"in a study. We never publish children's birthdates or information that would "
+"allow a reader to calculate the birthdate."
+msgstr ""
+
+#: accounts/forms.py:386
+msgid "Birthdays cannot be in the future."
+msgstr ""
+
+#: accounts/forms.py:403
+msgid "First Name"
+msgstr ""
+
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr ""
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
+msgid "Gender"
+msgstr ""
+
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
+msgid "Gestational Age at Birth"
+msgstr ""
+
+#: accounts/forms.py:408
+msgid "Any additional information you'd like us to know"
+msgstr ""
+
+#: accounts/forms.py:410
+msgid "Characteristics and conditions"
+msgstr ""
+
+#: accounts/forms.py:412
+msgid ""
+"Languages this child is exposed to at home, school, or with another "
+"caregiver."
+msgstr ""
+
+#: accounts/forms.py:418
+msgid ""
+"This lets you select the correct child to participate in a particular study. "
+"A nickname or initials are fine! We may include your child's name in email "
+"to you (for instance, \"There's a new study available for Molly!\") but will "
+"never publish names or use them in our research."
+msgstr ""
+
+#: accounts/forms.py:421
+msgid ""
+"For instance, diagnosed developmental disorders or vision or hearing problems"
+msgstr ""
+
+#: accounts/forms.py:424
+msgid "Please round down to the nearest full week of pregnancy completed"
+msgstr ""
+
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+msgid "All studies"
+msgstr ""
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+msgid "Scheduled studies"
+msgstr ""
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+msgid "Lookit studies"
+msgstr ""
+
+#: accounts/forms.py:517
+msgid "External studies"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:12
+#: accounts/models.py:339 studies/fields.py:136
+msgid "Not sure or prefer not to answer"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:13
+#: accounts/models.py:340 studies/fields.py:137
+msgid "Under 24 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:14
+#: accounts/models.py:341 studies/fields.py:138
+msgid "24 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:15
+#: accounts/models.py:342 studies/fields.py:139
+msgid "25 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:16
+#: accounts/models.py:343 studies/fields.py:140
+msgid "26 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:17
+#: accounts/models.py:344 studies/fields.py:141
+msgid "27 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:18
+#: accounts/models.py:345 studies/fields.py:142
+msgid "28 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:19
+#: accounts/models.py:346 studies/fields.py:143
+msgid "29 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:20
+#: accounts/models.py:347 studies/fields.py:144
+msgid "30 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:21
+#: accounts/models.py:348 studies/fields.py:145
+msgid "31 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:22
+#: accounts/models.py:349 studies/fields.py:146
+msgid "32 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:23
+#: accounts/models.py:350 studies/fields.py:147
+msgid "33 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:24
+#: accounts/models.py:351 studies/fields.py:148
+msgid "34 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:25
+#: accounts/models.py:352 studies/fields.py:149
+msgid "35 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:26
+#: accounts/models.py:353 studies/fields.py:150
+msgid "36 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:27
+#: accounts/models.py:354 studies/fields.py:151
+msgid "37 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:28
+#: accounts/models.py:355 studies/fields.py:152
+msgid "38 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:29
+#: accounts/models.py:356 studies/fields.py:153
+msgid "39 weeks"
+msgstr ""
+
+#: accounts/migrations/0041_add_existing_conditions.py:30
+#: accounts/models.py:357 studies/fields.py:154
+msgid "40 or more weeks"
+msgstr ""
+
+#: accounts/models.py:45
+msgid "male"
+msgstr ""
+
+#: accounts/models.py:46
+msgid "female"
+msgstr ""
+
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
+
+#: accounts/models.py:48 accounts/models.py:510
+msgid "prefer not to answer"
+msgstr ""
+
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr ""
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr ""
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr ""
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr ""
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr ""
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr ""
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr ""
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr ""
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr ""
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr ""
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr ""
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr ""
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr ""
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr ""
+
+#: accounts/models.py:425
+msgid "White"
+msgstr ""
+
+#: accounts/models.py:426
+msgid "Hispanic, Latino, or Spanish origin"
+msgstr ""
+
+#: accounts/models.py:427
+msgid "Black or African American"
+msgstr ""
+
+#: accounts/models.py:428
+msgid "Asian"
+msgstr ""
+
+#: accounts/models.py:429
+msgid "American Indian or Alaska Native"
+msgstr ""
+
+#: accounts/models.py:430
+msgid "Middle Eastern or North African"
+msgstr ""
+
+#: accounts/models.py:431
+msgid "Native Hawaiian or Other Pacific Islander"
+msgstr ""
+
+#: accounts/models.py:432
+msgid "Another race, ethnicity, or origin"
+msgstr ""
+
+#: accounts/models.py:435 accounts/models.py:444
+msgid "some or attending high school"
+msgstr ""
+
+#: accounts/models.py:436 accounts/models.py:445
+msgid "high school diploma or GED"
+msgstr ""
+
+#: accounts/models.py:437 accounts/models.py:446
+msgid "some or attending college"
+msgstr ""
+
+#: accounts/models.py:438 accounts/models.py:447
+msgid "2-year college degree"
+msgstr ""
+
+#: accounts/models.py:439 accounts/models.py:448
+msgid "4-year college degree"
+msgstr ""
+
+#: accounts/models.py:440 accounts/models.py:449
+msgid "some or attending graduate or professional school"
+msgstr ""
+
+#: accounts/models.py:441 accounts/models.py:450
+msgid "graduate or professional degree"
+msgstr ""
+
+#: accounts/models.py:451
+msgid "not applicable - no spouse or partner"
+msgstr ""
+
+#: accounts/models.py:454 accounts/models.py:487
+msgid "0"
+msgstr ""
+
+#: accounts/models.py:455 accounts/models.py:481
+msgid "1"
+msgstr ""
+
+#: accounts/models.py:456 accounts/models.py:482
+msgid "2"
+msgstr ""
+
+#: accounts/models.py:457 accounts/models.py:483
+msgid "3"
+msgstr ""
+
+#: accounts/models.py:458
+msgid "4"
+msgstr ""
+
+#: accounts/models.py:459
+msgid "5"
+msgstr ""
+
+#: accounts/models.py:460
+msgid "6"
+msgstr ""
+
+#: accounts/models.py:461
+msgid "7"
+msgstr ""
+
+#: accounts/models.py:462
+msgid "8"
+msgstr ""
+
+#: accounts/models.py:463
+msgid "9"
+msgstr ""
+
+#: accounts/models.py:464
+msgid "10"
+msgstr ""
+
+#: accounts/models.py:465
+msgid "More than 10"
+msgstr ""
+
+#: accounts/models.py:468
+msgid "under 18"
+msgstr ""
+
+#: accounts/models.py:469
+msgid "18-21"
+msgstr ""
+
+#: accounts/models.py:470
+msgid "22-24"
+msgstr ""
+
+#: accounts/models.py:471
+msgid "25-29"
+msgstr ""
+
+#: accounts/models.py:472
+msgid "30-34"
+msgstr ""
+
+#: accounts/models.py:473
+msgid "35-39"
+msgstr ""
+
+#: accounts/models.py:474
+msgid "40-44"
+msgstr ""
+
+#: accounts/models.py:475
+msgid "45-49"
+msgstr ""
+
+#: accounts/models.py:476
+msgid "50-59"
+msgstr ""
+
+#: accounts/models.py:477
+msgid "60-69"
+msgstr ""
+
+#: accounts/models.py:478
+msgid "70 or over"
+msgstr ""
+
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
+
+#: accounts/models.py:488
+msgid "5000"
+msgstr ""
+
+#: accounts/models.py:489
+msgid "10000"
+msgstr ""
+
+#: accounts/models.py:490
+msgid "15000"
+msgstr ""
+
+#: accounts/models.py:491
+msgid "20000"
+msgstr ""
+
+#: accounts/models.py:492
+msgid "30000"
+msgstr ""
+
+#: accounts/models.py:493
+msgid "40000"
+msgstr ""
+
+#: accounts/models.py:494
+msgid "50000"
+msgstr ""
+
+#: accounts/models.py:495
+msgid "60000"
+msgstr ""
+
+#: accounts/models.py:496
+msgid "70000"
+msgstr ""
+
+#: accounts/models.py:497
+msgid "80000"
+msgstr ""
+
+#: accounts/models.py:498
+msgid "90000"
+msgstr ""
+
+#: accounts/models.py:499
+msgid "100000"
+msgstr ""
+
+#: accounts/models.py:500
+msgid "110000"
+msgstr ""
+
+#: accounts/models.py:501
+msgid "120000"
+msgstr ""
+
+#: accounts/models.py:502
+msgid "130000"
+msgstr ""
+
+#: accounts/models.py:503
+msgid "140000"
+msgstr ""
+
+#: accounts/models.py:504
+msgid "150000"
+msgstr ""
+
+#: accounts/models.py:505
+msgid "160000"
+msgstr ""
+
+#: accounts/models.py:506
+msgid "170000"
+msgstr ""
+
+#: accounts/models.py:507
+msgid "180000"
+msgstr ""
+
+#: accounts/models.py:508
+msgid "190000"
+msgstr ""
+
+#: accounts/models.py:509
+msgid "over 200000"
+msgstr ""
+
+#: accounts/models.py:513
+msgid "urban"
+msgstr ""
+
+#: accounts/models.py:513
+msgid "suburban"
+msgstr ""
+
+#: accounts/models.py:513
+msgid "rural"
+msgstr ""
+
+#: accounts/models.py:567
+msgid "Select a State"
+msgstr ""
+
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
+msgid "Account Information"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
+msgid "Demographic Survey"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:12
+msgid "Tell us more about yourself."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:15
+msgid "Children Information"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:17
+msgid "Add or edit participant information."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
+msgid "Email Preferences"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:40
+msgid "Edit when you can be contacted."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:28
+msgid "Change Your Password"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
+msgid "All Participants"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:23
+msgid "Participant ID"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:40
+msgid "Age"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:52
+msgid "Additional Info"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:57
+msgid "No children profiles registered!"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:62
+msgid "Latest Demographic Data"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:68
+msgid "State"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:72
+msgid "Area description"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:76
+msgid "Languages Spoken at Home"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:80
+msgid "Number of Children"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:84
+msgid "Children current ages"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:90
+msgid "No Response"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:95
+msgid "Number of Guardians"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:99
+msgid "Explanation for Guardians:"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:103
+msgid "Race"
+msgstr ""
+
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
+
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
+
+#: studies/fields.py:45
+msgid "Twin"
+msgstr ""
+
+#: studies/fields.py:46
+msgid "Triplet"
+msgstr ""
+
+#: studies/fields.py:47
+msgid "Quadruplet"
+msgstr ""
+
+#: studies/fields.py:48
+msgid "Quintuplet"
+msgstr ""
+
+#: studies/fields.py:49
+msgid "Sextuplet"
+msgstr ""
+
+#: studies/fields.py:50
+msgid "Septuplet"
+msgstr ""
+
+#: studies/fields.py:51
+msgid "Octuplet"
+msgstr ""
+
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
+#: studies/fields.py:69
+msgid "Gujarati"
+msgstr ""
+
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
+
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+msgid "Marathi"
+msgstr ""
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+msgid "Russian"
+msgstr ""
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
+msgid "Not answered"
+msgstr ""
+
+#: studies/fields.py:125
+msgid "Other"
+msgstr ""
+
+#: studies/fields.py:126
+msgid "Male"
+msgstr ""
+
+#: studies/fields.py:127
+msgid "Female"
+msgstr ""
+
+#: studies/models.py:143
+msgid ""
+"The Users who belong to this Lab. A user in this lab will be able to create "
+"studies associated with this Lab and can be added to this Lab's studies."
+msgstr ""
+
+#: studies/models.py:152
+msgid "The Users who have requested to join this Lab."
+msgstr ""
+
+#: web/templates/registration/logged_out.html:5
+msgid "You've successfully logged out."
+msgstr ""
+
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
+msgid "Login"
+msgstr ""
+
+#: web/templates/registration/login.html:25
+msgid "Forgot password?"
+msgstr ""
+
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
+
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
+msgid "Password changed"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:12
+msgid "Your password was changed."
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:12
+msgid "Documentation"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Change password"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Log out"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:18
+msgid "Home"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:19
+msgid "Password change"
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:36
+msgid "Please correct the error below."
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:38
+msgid "Please correct the errors below."
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:43
+msgid ""
+"Please enter your old password, for security's sake, and then enter your new "
+"password twice so we can verify you typed it in correctly."
+msgstr ""
+
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
+msgid "Change my password"
+msgstr ""
+
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr ""
+
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr ""
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr ""
+
+#: web/templates/registration/password_reset_confirm.html:8
+msgid "Password reset confirmation"
+msgstr ""
+
+#: web/templates/registration/password_reset_confirm.html:11
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly."
+msgstr ""
+
+#: web/templates/registration/password_reset_confirm.html:21
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+
+#: web/templates/registration/password_reset_done.html:6
+msgid "Password reset link sent"
+msgstr ""
+
+#: web/templates/registration/password_reset_done.html:9
+msgid ""
+"If an account exists with the email you entered, we've emailed instructions "
+"for resetting your password and you should receive them shortly."
+msgstr ""
+
+#: web/templates/registration/password_reset_done.html:12
+msgid ""
+"If you don't receive an email, please check your spam folder and make sure "
+"you've entered the address you registered with. (You won't get an email "
+"unless there's already an account for that email address!)"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:3
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at Children Helping Science."
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:4
+msgid "Please go to the following page and choose a new password:"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:8
+msgid "Your username, in case you've forgotten:"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:9
+msgid "Thanks for using our site!"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:8
+msgid "Password reset"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:11
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll email "
+"instructions for setting a new one."
+msgstr ""
+
+#: web/templates/registration/password_reset_subject_1.txt:2
+msgid "Password reset on Children Helping Science"
+msgstr ""
+
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
+
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
+
+#: web/templates/web/_footer.html:17
+msgid "Contact us"
+msgstr ""
+
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
+
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr ""
+
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr ""
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr ""
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr ""
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr ""
+
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr ""
+
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr ""
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr ""
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr ""
+
+#: web/templates/web/children-list.html:9
+msgid "Update child"
+msgstr ""
+
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr ""
+
+#: web/templates/web/children-list.html:64
+msgid "No child profiles registered!"
+msgstr ""
+
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr ""
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+msgid "documentation"
+msgstr ""
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
+msgid "Update demographics"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
+msgid ""
+"One reason we are developing Internet-based experiments is to represent a "
+"more diverse group of families in our research. Your answers to these "
+"questions will help us understand what audience we reach, as well as how "
+"factors like speaking multiple languages or having older siblings affect "
+"children's learning."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:47
+msgid ""
+"Even if you allow your study videos to be published for scientific or "
+"publicity purposes, your demographic information is never published in "
+"conjunction with your video."
+msgstr ""
+
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+msgid "Participation"
+msgstr ""
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+msgid "Who creates the studies?"
+msgstr ""
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+msgid "Why are you running studies online instead of in person?"
+msgstr ""
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+msgid "How do we provide consent to participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+msgid "Who will see our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+msgid "Habituation"
+msgstr ""
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+msgid "What security measures do you implement?"
+msgstr ""
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+msgid "For Researchers"
+msgstr ""
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+msgid "What is Project Garden?"
+msgstr ""
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+msgid "How to Participate"
+msgstr ""
+
+#: web/templates/web/garden/scientists.html:13
+msgid "Meet the GARDEN Scientists"
+msgstr ""
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+msgid "Participate in a Study"
+msgstr ""
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+msgid "From Home"
+msgstr ""
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
+msgid "I would like to be contacted when:"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:7
+msgid "Sign up to participate"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:13
+msgid "Create Participant Account"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+msgid "instead."
+msgstr ""
+
+#: web/templates/web/participant-signup.html:28
+msgid ""
+"By clicking 'Create Account', I agree that I have read and accepted the "
+msgstr ""
+
+#: web/templates/web/participant-signup.html:28
+msgid "Privacy Statement"
+msgstr ""
+
+#: web/templates/web/privacy.html:9
+msgid "Privacy statement"
+msgstr ""
+
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+msgid "For participants"
+msgstr ""
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+msgid "Additional Information"
+msgstr ""
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
+msgid "Past Studies"
+msgstr ""
+
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
+msgstr ""
+
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
+
+#: web/templates/web/studies-history.html:33
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
+msgid "Study Thumbnail"
+msgstr ""
+
+#: web/templates/web/studies-history.html:55
+msgid "Eligibility"
+msgstr ""
+
+#: web/templates/web/studies-history.html:59
+msgid "Contact"
+msgstr ""
+
+#: web/templates/web/studies-history.html:63
+msgid "Still collecting data?"
+msgstr ""
+
+#: web/templates/web/studies-history.html:65
+msgid "Yes"
+msgstr ""
+
+#: web/templates/web/studies-history.html:67
+msgid "No"
+msgstr ""
+
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr ""
+
+#: web/templates/web/studies-history.html:78
+msgid "Study Responses"
+msgstr ""
+
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
+msgid "Date"
+msgstr ""
+
+#: web/templates/web/studies-history.html:114
+msgid "Consent status"
+msgstr ""
+
+#: web/templates/web/studies-history.html:116
+msgid "Approved"
+msgstr ""
+
+#: web/templates/web/studies-history.html:117
+msgid "Your consent video was reviewed by a researcher and is valid."
+msgstr ""
+
+#: web/templates/web/studies-history.html:119
+msgid "Pending"
+msgstr ""
+
+#: web/templates/web/studies-history.html:120
+msgid "Your consent video has not yet been reviewed by a researcher."
+msgstr ""
+
+#: web/templates/web/studies-history.html:122
+msgid "Invalid"
+msgstr ""
+
+#: web/templates/web/studies-history.html:123
+msgid ""
+"There was a technical problem with your consent video, or it did not show "
+"you reading the consent statement out loud. Your other data from this "
+"session will not be viewed or used by the study researchers."
+msgstr ""
+
+#: web/templates/web/studies-history.html:125
+msgid "No information about consent video review status."
+msgstr ""
+
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+msgid "You have not yet participated in any Lookit studies."
+msgstr ""
+
+#: web/templates/web/studies-history.html:147
+msgid "You have not yet participated in any external studies."
+msgstr ""
+
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr ""
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
+
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
+
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
+
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
+
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr ""
+
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
+
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
+
+#: web/templates/web/study-detail.html:18
+msgid "participate"
+msgstr ""
+
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr ""
+
+#: web/templates/web/study-detail.html:21
+msgid "Schedule a time to participate"
+msgstr ""
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr ""
+
+#: web/templates/web/study-detail.html:23
+msgid "Complete demographic survey to "
+msgstr ""
+
+#: web/templates/web/study-detail.html:54
+msgid "Who Can Participate"
+msgstr ""
+
+#: web/templates/web/study-detail.html:60
+msgid "What Happens"
+msgstr ""
+
+#: web/templates/web/study-detail.html:66
+msgid "What We're Studying"
+msgstr ""
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr ""
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, python-format
+msgid "This study is conducted by %(contact)s."
+msgstr ""
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr ""
+
+#: web/templates/web/study-detail.html:108
+msgid "Select a child:"
+msgstr ""
+
+#: web/templates/web/study-detail.html:119
+msgid "None Selected"
+msgstr ""
+
+#: web/templates/web/study-detail.html:132
+msgid ""
+"Your child is still younger than the recommended age range for this study. "
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
+msgstr ""
+
+#: web/templates/web/study-detail.html:135
+msgid ""
+"Your child is older than the recommended age range for this study. You're "
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
+msgstr ""
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, python-format
+msgid ""
+"Your child does not meet the eligibility criteria listed for this study. "
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
+msgstr ""
+
+#: web/templates/web/study-detail.html:153
+msgid ""
+"For an easy way to see what happens as you update your study protocol, "
+"bookmark the URL the button above sends you to."
+msgstr ""
+
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr ""
+
+#: web/templatetags/web_extras.py:191
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
+msgid "Participant created."
+msgstr ""
+
+#: web/views.py:157
+msgid "Demographic data saved."
+msgstr ""
+
+#: web/views.py:223
+msgid "Child added."
+msgstr ""
+
+#: web/views.py:264
+msgid "Child deleted."
+msgstr ""
+
+#: web/views.py:266
+msgid "Child updated."
+msgstr ""
+
+#: web/views.py:294
+msgid "Email preferences saved."
+msgstr ""
+
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-15 17:00+0200\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr ""
 "Inserisci una password monouso di 6 cifre valida da Google Authenticator"
@@ -36,45 +36,26 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "Questo account non è attivo."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr ""
-"La tua password non può essere troppo simile alle tue informazioni personali."
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "La tua password deve contenere almeno 16 caratteri."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "La tua password non può essere una password comunemente utilizzata."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "La tua password non può essere interamente numerica."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Indirizzo email"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Nickname"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr ""
 "È il momento per un'altra sessione di uno studio a cui stiamo attualmente "
 "partecipando"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "È disponibile un nuovo studio per uno dei miei figli"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -82,7 +63,7 @@ msgstr ""
 "C'è un aggiornamento su uno studio a cui abbiamo partecipato (ad esempio: i "
 "risultati vengono pubblicati)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -90,100 +71,92 @@ msgstr ""
 "Un ricercatore ha domande sulle mie risposte individuali (ad esempio: se "
 "segnalo un problema tecnico durante lo studio)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "In quale categoria(e) si identifica la tua famiglia?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Nazione"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Inserisci come elenco separato da virgole: AAAA-MM-GG, AAAA-MM-GG, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Solo risposte numeriche: un'ipotesi approssimativa va bene!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "In quale stato vivi?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "In quale regione vivi?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Come descriveresti la zona in cui vivi?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Che lingua (e) parla la tua famiglia a casa?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Quanti figli hai?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Per ogni bambino, inserisci la sua data di nascita:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Con quanti genitori / tutori convivono i tuoi figli?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Quanti anni hai?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Qual è il tuo genere?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Qual è il tuo genere?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Qual è il livello di istruzione più alto che hai completato?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Qual è il livello di istruzione più alto completato dal tuo coniuge?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Qual è il tuo reddito annuo familiare approssimativo (in Euro)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Quanti libri per bambini ci sono in casa tua?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "C'è qualcos'altro che vorresti farci sapere?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Come hai saputo di Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Se la risposta varia a causa di accordi di affidamento condiviso o di "
-"viaggio, inserisci il numero di genitori / tutori con cui vivono "
-"abitualmente i tuoi figli o spiega."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Data di nascita"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Un'altra etnia o origine"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -194,33 +167,36 @@ msgstr ""
 "o informazioni che consentirebbero a un lettore di calcolare la data di "
 "nascita."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "I compleanni non possono essere in futuro."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Nome di battesimo"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Data di nascita"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Genere"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Età gestazionale alla nascita"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Qualsiasi informazione aggiuntiva che desideri farci sapere"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Caratteristiche e condizioni"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -228,7 +204,7 @@ msgstr ""
 "Lingue a cui questo bambino è esposto a casa, a scuola o con un altro "
 "caregiver."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -241,513 +217,602 @@ msgstr ""
 "nuovo studio disponibile per Maria!\") Ma non pubblicheremo mai nomi né li "
 "utilizzeremo nella nostra ricerca."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Ad esempio, disturbi dello sviluppo diagnosticati o problemi alla vista o "
 "all'udito"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr ""
 "Si prega di arrotondare per difetto alla settimana intera di gravidanza "
 "completata più vicina"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Studi"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Studi disponibili"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+#, fuzzy
+#| msgid "Meet the Lookit team"
+msgid "here on the Lookit platform"
+msgstr "Incontra il team di Lookit"
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "I tuoi studi passati"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Studi disponibili"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Non sono sicuro o preferisco non rispondere"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Meno di 24 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 settimane"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 o più settimane"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Può visualizzare l'organizzazione"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Può modificare l'organizzazione"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Può creare organizzazione"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Può rimuovere l'organizzazione"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Può visualizzare lo sperimentatore"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Può visualizzare Analytics"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Può creare utente"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Può visualizzare l'utente"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Può modificare l'utente"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Può rimuovere l'utente"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Può visualizzare le autorizzazioni degli utenti"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Può modificare le autorizzazioni degli utenti"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Può leggere tutti i dati utente"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Può leggere i nomi utente degli utenti"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "maschio"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "femmina"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "altro"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "Preferisco non rispondere"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Può visualizzare l'organizzazione"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Può modificare l'organizzazione"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Può creare organizzazione"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Può rimuovere l'organizzazione"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Può visualizzare lo sperimentatore"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Può visualizzare Analytics"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Può creare utente"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Può visualizzare l'utente"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Può modificare l'utente"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Può rimuovere l'utente"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Può visualizzare le autorizzazioni degli utenti"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Può modificare le autorizzazioni degli utenti"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Può leggere tutti i dati utente"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Può leggere i nomi utente degli utenti"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Bianco"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Origine ispanica, latina o spagnola"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Nero o afroamericano"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asiatico"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Indiano americano o nativo dell'Alaska"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Mediorientale o nordafricano"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Nativo hawaiano o altro isolano del Pacifico"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Un'altra etnia o origine"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "alcuni o frequentando il liceo"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "diploma di scuola superiore o GED"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "alcuni o frequentando il college"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "Laurea di 2 anni"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "Laurea di 4 anni"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "alcuni o frequentando una scuola di specializzazione o professionale"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "laureato o laurea professionale"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "non applicabile - nessun coniuge o partner"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Più di 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "sotto i 18"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 o più"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 o più"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "varia"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "oltre 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "Urbana"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "Suburbana"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "Rurale"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Seleziona uno stato"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "Gan"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Informazioni account"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "Modifica le tue credenziali di accesso e/o il nickname."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Indagine demografica"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Dicci di più su di te."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informazioni sui bambini"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Aggiungi o modifica le informazioni sui partecipanti."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Preferenze email"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Modifica quando puoi essere contattato."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:38 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Il mio account"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Informazioni account"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Salva"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Cambia la tua password"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "Gestisci l'autenticazione a due fattori"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -755,11 +820,18 @@ msgstr ""
 "Se lo desideri, puoi disattivare l'autenticazione a due fattori qui. "
 "Inserisci la tua password monouso, premi Invia e verrà eliminata per te!"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "Imposta l'autenticazione a due fattori"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Tutti i partecipanti"
 
@@ -767,146 +839,63 @@ msgstr "Tutti i partecipanti"
 msgid "Participant ID"
 msgstr "ID partecipante"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Ultimo attivo:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "ID globale partecipante:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Bambini"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Età"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Informazioni addizionali"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Nessun profilo bambini registrato!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Ultimi dati demografici"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Nazione"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Stato"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Descrizione dell'area"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Lingue parlate a casa"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Numero di bambini"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Età attuale dei bambini"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Risposte dello studio"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Numero di tutori"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Spiegazione per i tutori:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Etnia"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Pannello di controllo"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "Tedesco"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "Inglese"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "Spagnolo"
-
-#: project/settings.py:231
-msgid "Argentinian Spanish"
-msgstr "Spagnolo argentino"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "Francese"
-
-#: project/settings.py:233
-msgid "Canadian French"
-msgstr "Francese canadese"
-
-#: project/settings.py:234
-msgid "Hebrew"
-msgstr "Ebreo"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "Italiano"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "Giapponese"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "Coreano"
-
-#: project/settings.py:238
-msgid "Norwegian Bokmål"
-msgstr "Norvegese Bokmål"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "Polacco"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "Portoghese"
-
-#: project/settings.py:241
-msgid "Brazilian Portuguese"
-msgstr "Portoghese brasiliano"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "Rumeno"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "Russo"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "Turco"
-
-#: project/settings.py:245
-msgid "Simplified Chinese"
-msgstr "Cinese semplificato"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "Olandese"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -956,6 +945,10 @@ msgstr "Plurigemellare di 7 gemelli"
 msgid "Octuplet"
 msgstr "Plurigemellare di 8 gemelli"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "Inglese"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "Amarico"
@@ -980,13 +973,25 @@ msgstr "Cebuano"
 msgid "Chhattisgarhi"
 msgstr "Chhattisgarhi"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "Olandese"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "Arabo Egiziano"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "Francese"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "Gan"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "Tedesco"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -1001,162 +1006,204 @@ msgid "Hausa"
 msgstr "Hausa"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr "Ebreo"
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "Hindi"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "Igbo"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "Indonesiano"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "Persiano iraniano"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "Italiano"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "Giapponese"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "Giavanese"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "Jinyu"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "Kannada"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "Khmer"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "Coreano"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "Magahi"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "Maithili"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "Malese"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "Mandarino"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "Marathi"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "Min Nan"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "Arabo Marocchino"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "Pashto settentrionale"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "Uzbeko settentrionale"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "Odia"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "Polacco"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "Portoghese"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "Rumeno"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "Russo"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "Saraiki"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "Somalo"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "Spagnolo"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "Sundanese"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "Tamil"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "Telugu"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "Thailandese"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "Turco"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "Urdu"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "Vietnamita"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "Punjabi occidentale"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "Wu"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "Cinese Xiāng"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "Cantonese"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Non risposto"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Altro"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Maschio"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Femmina"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -1164,35 +1211,202 @@ msgstr ""
 "Gli utenti che appartengono a questo laboratorio. Un utente in questo "
 "laboratorio potrà creare studi associati e potrà essere aggiunto agli studi."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Gli utenti che hanno richiesto di partecipare a questo laboratorio."
 
-#: web/templates/frontpages/contact.html:15
-msgid "Technical difficulties"
-msgstr "Difficoltà tecniche"
+#: web/templates/registration/logged_out.html:5
+msgid "You've successfully logged out."
+msgstr "Ti sei disconnesso con successo."
 
-#: web/templates/frontpages/contact.html:17
-msgid "Questions about the studies"
-msgstr "Domande sugli studi"
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
+msgid "Login"
+msgstr "Accesso"
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-msgid "For researchers"
-msgstr "Per i ricercatori"
+#: web/templates/registration/login.html:25
+msgid "Forgot password?"
+msgstr "Hai dimenticato la password?"
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:16 web/templates/web/_navigation.html:21
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/frontpages/default.html:53
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr "Registra la tua famiglia!"
+
+#: web/templates/registration/password_change_done.html:9
+msgid "Password changed"
+msgstr "Password cambiata"
+
+#: web/templates/registration/password_change_done.html:12
+msgid "Your password was changed."
+msgstr "La tua password é stata cambiata."
+
+#: web/templates/registration/password_change_form.html:12
+msgid "Documentation"
+msgstr "Documentazione"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Change password"
+msgstr "Cambia la password"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Log out"
+msgstr "Disconnettiti"
+
+#: web/templates/registration/password_change_form.html:18
+msgid "Home"
+msgstr "Home"
+
+#: web/templates/registration/password_change_form.html:19
+msgid "Password change"
+msgstr "Modifica della password"
+
+#: web/templates/registration/password_change_form.html:36
+msgid "Please correct the error below."
+msgstr "Correggi l'errore di seguito."
+
+#: web/templates/registration/password_change_form.html:38
+msgid "Please correct the errors below."
+msgstr "Si prega di correggere gli errori di seguito."
+
+#: web/templates/registration/password_change_form.html:43
+msgid ""
+"Please enter your old password, for security's sake, and then enter your new "
+"password twice so we can verify you typed it in correctly."
+msgstr ""
+"Inserisci la tua vecchia password, per motivi di sicurezza, quindi inserisci "
+"la nuova password due volte in modo da verificare di averla digitata "
+"correttamente."
+
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
+msgid "Change my password"
+msgstr "Cambia la mia password"
+
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "Accesso"
+
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Reimpostazione della password completata"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "La tua password è stata impostata. Puoi andare avanti e accedere ora."
+
+#: web/templates/registration/password_reset_confirm.html:8
+msgid "Password reset confirmation"
+msgstr "Conferma della reimpostazione della password"
+
+#: web/templates/registration/password_reset_confirm.html:11
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly."
+msgstr ""
+"Inserisci la tua nuova password due volte in modo da verificare di averla "
+"digitata correttamente."
+
+#: web/templates/registration/password_reset_confirm.html:21
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+"Il link per la reimpostazione della password non era valido, probabilmente "
+"perché è già stato utilizzato. Richiedi una nuova reimpostazione della "
+"password."
+
+#: web/templates/registration/password_reset_done.html:6
+msgid "Password reset link sent"
+msgstr "Ti abbiamo inviato il link per reimpostare la password"
+
+#: web/templates/registration/password_reset_done.html:9
+msgid ""
+"If an account exists with the email you entered, we've emailed instructions "
+"for resetting your password and you should receive them shortly."
+msgstr ""
+"Se esiste un account con l'email che hai inserito, ti abbiamo inviato per "
+"email le istruzioni per reimpostare la tua password e dovresti riceverle a "
+"breve."
+
+#: web/templates/registration/password_reset_done.html:12
+msgid ""
+"If you don't receive an email, please check your spam folder and make sure "
+"you've entered the address you registered with. (You won't get an email "
+"unless there's already an account for that email address!)"
+msgstr ""
+"Se non ricevi un'email, controlla la tua cartella spam e assicurati di aver "
+"inserito l'indirizzo con cui ti sei registrato. (Non riceverai un'email se "
+"non c'è già un account per quell'indirizzo email!)"
+
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at Children Helping Science."
+msgstr ""
+"Hai ricevuto questa email perché hai richiesto una reimpostazione della "
+"password per il tuo account utente su %(site_name)s."
+
+#: web/templates/registration/password_reset_email.html:4
+msgid "Please go to the following page and choose a new password:"
+msgstr "Vai alla pagina seguente e scegli una nuova password:"
+
+#: web/templates/registration/password_reset_email.html:8
+msgid "Your username, in case you've forgotten:"
+msgstr "Il tuo nome utente, nel caso l'avessi dimenticato:"
+
+#: web/templates/registration/password_reset_email.html:9
+msgid "Thanks for using our site!"
+msgstr "Grazie per aver utilizzato il nostro sito!"
+
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Reimposta la mia password"
+
+#: web/templates/registration/password_reset_form.html:8
+msgid "Password reset"
+msgstr "Ripristino della password"
+
+#: web/templates/registration/password_reset_form.html:11
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll email "
+"instructions for setting a new one."
+msgstr ""
+"Hai dimenticato la tua password? Inserisci il tuo indirizzo email di seguito "
+"e ti invieremo un'email con le istruzioni per impostarne una nuova."
+
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "Ti abbiamo inviato il link per reimpostare la password"
+
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
 msgid ""
 "This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
 "findings, and conclusions or recommendations expressed in this material are "
 "those of the authors(s) and do not necessarily reflect the views of the "
 "National Science Foundation."
@@ -1205,48 +1419,304 @@ msgstr ""
 "questo materiale sono quelli degli autori e non riflettono necessariamente "
 "le opinioni della National Science Foundation."
 
-#: web/templates/frontpages/default.html:58 web/templates/frontpages/home.html:48
+#: web/templates/web/_footer.html:14
 msgid "Privacy"
 msgstr "Privacy"
 
-#: web/templates/frontpages/default.html:59 web/templates/frontpages/home.html:49
+#: web/templates/web/_footer.html:17
 msgid "Contact us"
 msgstr "Contattaci"
 
-#: web/templates/frontpages/default.html:60
+#: web/templates/web/_footer.html:20
 msgid "Connect"
 msgstr "Connettiti"
 
-#: web/templates/frontpages/faq.html:11
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr "Disconnettiti"
+
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Sperimentatore"
+
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Bambini"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Annulla"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Aggiungi figlio"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr "Bambino"
+
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr "Torna alla lista dei bambini"
+
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr "Elimina"
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Salva"
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Aggiorna"
+
+#: web/templates/web/children-list.html:9
+msgid "Update child"
+msgstr "Aggiorna bambino"
+
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nome"
+
+#: web/templates/web/children-list.html:64
+msgid "No child profiles registered!"
+msgstr "Nessun profilo bambino registrato!"
+
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr "Difficoltà tecniche"
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr "Domande sugli studi"
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr "Per i ricercatori"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Documentazione"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
+msgid "Update demographics"
+msgstr "Aggiorna i dati demografici"
+
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
+msgid ""
+"One reason we are developing Internet-based experiments is to represent a "
+"more diverse group of families in our research. Your answers to these "
+"questions will help us understand what audience we reach, as well as how "
+"factors like speaking multiple languages or having older siblings affect "
+"children's learning."
+msgstr ""
+"Uno dei motivi per cui stiamo sviluppando esperimenti on-line è "
+"rappresentare un gruppo più diversificato di famiglie nella nostra ricerca. "
+"Le tue risposte a queste domande ci aiuteranno a capire quale pubblico "
+"raggiungiamo e in che modo fattori come parlare più lingue o avere fratelli "
+"maggiori influenzano l'apprendimento dei bambini."
+
+#: web/templates/web/demographic-data-update.html:47
+msgid ""
+"Even if you allow your study videos to be published for scientific or "
+"publicity purposes, your demographic information is never published in "
+"conjunction with your video."
+msgstr ""
+"Anche se acconsenti alla pubblicazione dei tuoi video per scopi scientifici "
+"o pubblicitari, le tue informazioni demografiche non verranno mai pubblicate "
+"insieme al tuo video."
+
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
 msgid "Frequently Asked Questions"
 msgstr "Domande frequenti"
 
-#: web/templates/frontpages/faq.html:16
+#: web/templates/web/faq.html:12
 msgid "Participation"
 msgstr "Partecipazione"
 
-#: web/templates/frontpages/faq.html:20
+#: web/templates/web/faq.html:22
 msgid "What is a 'study' about cognitive development?"
 msgstr "Che cos'è uno 'studio' sullo sviluppo cognitivo?"
 
-#: web/templates/frontpages/faq.html:25
+#: web/templates/web/faq.html:30
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Cognitive development is the science "
+#| "of what kids understand and how they learn. Researchers in cognitive "
+#| "development are interested in questions like...</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li>what knowledge and abilities "
+#| "infants are born with, and what they have to learn from experience</li>\n"
+#| "                                    <li>how abilities like mathematical "
+#| "reasoning are organized and how they develop over time</li>\n"
+#| "                                    <li>what strategies children use to "
+#| "learn from the wide variety of data they observe</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>A study is meant to answer a very "
+#| "specific question about how children learn or what they know: for "
+#| "instance, 'Do three-month-olds recognize their parents' faces?'</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Cognitive development is the science of "
-"what kids understand and how they learn. Researchers in cognitive "
-"development are interested in questions like...</p>\n"
-"                                <ul>\n"
-"                                    <li>what knowledge and abilities infants "
-"are born with, and what they have to learn from experience</li>\n"
-"                                    <li>how abilities like mathematical "
-"reasoning are organized and how they develop over time</li>\n"
-"                                    <li>what strategies children use to "
-"learn from the wide variety of data they observe</li>\n"
-"                                </ul>\n"
-"                                <p>A study is meant to answer a very "
-"specific question about how children learn or what they know: for instance, "
-"'Do three-month-olds recognize their parents' faces?'</p>\n"
-"                                "
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
 msgstr ""
 "\n"
 "                                <p>Lo sviluppo cognitivo è la scienza di ciò "
@@ -1264,91 +1734,263 @@ msgstr ""
 "una domanda molto specifica su come i bambini imparano o cosa sanno: ad "
 "esempio, 'I bambini di tre mesi riconoscono i volti dei loro genitori?'</p>"
 
-#: web/templates/frontpages/faq.html:40
-msgid "How can we participate online?"
-msgstr "Come possiamo partecipare online?"
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
 
-#: web/templates/frontpages/faq.html:45
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
 msgid ""
 "\n"
 "                            <p>If you have a child and would like to "
-"participate, create an account and take a look at what we have available for "
-"your child's age range. You'll need a working webcam to participate.</p>\n"
-"                                <p>When you select a study, you'll be asked "
-"to read a consent form and record yourself stating that you and your child "
-"agree to participate. Then we'll guide you through what will happen during "
-"the study. Depending on your child's age, your child may answer questions "
-"directly or we may be looking for indirect signs of what she thinks is going "
-"on--like how long she looks at a surprising outcome.</p>\n"
-"                                <p>Some portions of the study will be "
-"automatically recorded using your webcam and sent securely to the Lookit "
-"platform. Trained researchers will watch the video and record your child's "
-"responses--for instance, which way he pointed, or how long she looked at "
-"each image. We'll put these together with responses from lots of other "
-"children to learn more about how kids think!</p>\n"
-"                            "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
 msgstr ""
-"\n"
-"                            <p>Se hai un figlio e desideri partecipare, crea "
-"un account e dai un'occhiata a ciò che è disponibile per la fascia di età di "
-"tuo figlio. Avrai bisogno di una webcam funzionante per partecipare.</p>\n"
-"                                <p>Quando selezioni uno studio, ti verrà "
-"chiesto di leggere un modulo di consenso e registrarti affermando che tu e "
-"tuo figlio acconsentite a partecipare. Quindi ti guideremo attraverso ciò "
-"che accadrà durante lo studio. A seconda della sua età, tuo figlio potrebbe "
-"rispondere direttamente alle domande o potremmo cercare segni indiretti di "
-"ciò che pensa stia succedendo--ad esempio per quanto tempo osserva un "
-"risultato sorprendente.</p>\n"
-"                                <p>Alcune parti dello studio verranno "
-"registrate automaticamente utilizzando la tua webcam e inviate in modo "
-"sicuro alla piattaforma Lookit. Ricercatori qualificati guarderanno il video "
-"e registreranno le risposte di tuo figlio--ad esempio, da che parte ha "
-"indicato o per quanto tempo ha guardato ogni immagine. Li metteremo insieme "
-"alle risposte di molti altri partecipati per saperne di più su come pensano "
-"i bambini!</p>"
 
-#: web/templates/frontpages/faq.html:56
-msgid "Who can create studies on Lookit?"
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Who can create studies on Lookit?"
+msgid "Who creates the studies?"
 msgstr "Chi può creare studi su Lookit?"
 
-#: web/templates/frontpages/faq.html:61
+#: web/templates/web/faq.html:114
+#, python-format
 msgid ""
-"Any researcher with questions about how kids learn and grow can propose a "
-"Lookit study! Each institution using Lookit has to sign a contract with MIT "
-"where they agree to the <a href='/termsofuse'>Terms of Use</a> and certify "
-"that their studies will be reviewed and approved by an institutional review "
-"board. Studies are also subject to approval by Lookit. As of June 2020 we "
-"have agreements with 20 universities!"
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
 msgstr ""
-"Qualsiasi ricercatore con domande su come i bambini imparano e crescono può "
-"proporre uno studio Lookit! Ogni istituzione che utilizza LookIt deve "
-"firmare un contratto con il MIT in cui accetta i <a \n"
-"href='/termsofuse'>Terms of Use</a> e certifica che i suoi studi saranno "
-"esaminati e approvati da un comitato di revisione istituzionale. Inoltre, "
-"gli studi sono soggetti all'approvazione di Lookit. Da giugno 2020 abbiamo "
-"accordi con 20 università!"
 
-#: web/templates/frontpages/faq.html:69
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+msgid "Why are you running studies online instead of in person?"
+msgstr "Perché state conducendo studi online invece che di persona?"
+
+#: web/templates/web/faq.html:159
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <ul>\n"
+#| "                                    <li>Make it easier for you to take "
+#| "part in research, especially for families without a stay-at-home parent</"
+#| "li>\n"
+#| "                                    <li>Work with more kids when needed--"
+#| "right now a limiting factor in designing studies is the time it takes to "
+#| "recruit participants</li>\n"
+#| "                                    <li>Draw conclusions from a more "
+#| "representative population of families--not just those who live near a "
+#| "university and are able to visit the lab during the day.\n"
+#| "                                    </li>\n"
+#| "                                    <li>Make it easier for families to "
+#| "continue participating in longitudinal studies, which may involve "
+#| "multiple testing sessions separated by months or years</li>\n"
+#| "                                    <li>Observe more natural behavior "
+#| "because children are at home rather than in an unfamiliar place</li>\n"
+#| "                                    <li>Create a system for learning "
+#| "about special populations--for instance, children with specific "
+#| "developmental disorders</li>\n"
+#| "                                    <li>Make the procedures we use in "
+#| "doing research more transparent, and make it easier to replicate our "
+#| "findings</li>\n"
+#| "                                    <li>Communicate with families about "
+#| "the research we're doing and what we can learn from it</li>\n"
+#| "                                </ul>\n"
+#| "                                "
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+"\n"
+"                                <ul>\n"
+"                                    <li>Semplificare la tua partecipazione "
+"alla ricerca, soprattutto per le famiglie senza un genitore casalingo</li>\n"
+"                                    <li>Lavorare con più bambini quando "
+"necessario--in questo momento un fattore limitante nella progettazione degli "
+"studi è il tempo necessario per reclutare i partecipanti</li>\n"
+"                                    <li>Trarre conclusioni da una "
+"popolazione di famiglie più rappresentativa--non solo da quelle che vivono "
+"vicino a un'università e possono visitare il laboratorio durante il giorno.\n"
+"                                    </li>\n"
+"                                    <li>Rendere più facile per le famiglie "
+"continuare a partecipare a studi longitudinali, che possono comportare più "
+"sessioni di test separate da mesi o anni</li>\n"
+"                                    <li>Osservare un comportamento più "
+"naturale perché i bambini sono a casa piuttosto che in un luogo sconosciuto</"
+"li>\n"
+"                                    <li>Creare un sistema per conoscere "
+"popolazioni speciali--ad esempio, bambini con disturbi dello sviluppo "
+"specifici</li>\n"
+"                                    <li>Rendere le procedure che utilizziamo "
+"per svolgere la ricerca più trasparenti e semplificare la replicazione dei "
+"nostri risultati</li>\n"
+"                                    <li>Comunicare alle famiglie circa la "
+"ricerca che stiamo facendo e su ciò che possiamo imparare da essa</li>\n"
+"                                </ul>"
+
+#: web/templates/web/faq.html:184
 msgid "How do we provide consent to participate?"
 msgstr "Come forniamo il consenso alla partecipazione?"
 
-#: web/templates/frontpages/faq.html:74
+#: web/templates/web/faq.html:191
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Rather than having the parent or legal "
+#| "guardian sign a form, we ask that you read aloud (or sign in ASL) a "
+#| "statement of consent which is recorded using your webcam. This statement "
+#| "holds the same weight as a signed form, but should be less hassle for "
+#| "you. It also lets us verify that you understand written English and that "
+#| "you understand you're being videotaped.</p>\n"
+#| "                                <p>Researchers watch these consent videos "
+#| "on a special page of the researcher interface, and record for each one "
+#| "whether the video shows informed consent. They cannot view other video or "
+#| "download data from a session unless they have confirmed that you "
+#| "consented to participate! If they see a consent video that does NOT "
+#| "clearly demonstrate informed consent--for instance, there was a technical "
+#| "problem and there's no audio--they may contact you to check, depending on "
+#| "your email settings.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Rather than having the parent or legal "
-"guardian sign a form, we ask that you read aloud (or sign in ASL) a "
-"statement of consent which is recorded using your webcam. This statement "
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
 "holds the same weight as a signed form, but should be less hassle for you. "
 "It also lets us verify that you understand written English and that you "
 "understand you're being videotaped.</p>\n"
-"                                <p>Researchers watch these consent videos on "
-"a special page of the researcher interface, and record for each one whether "
-"the video shows informed consent. They cannot view other video or download "
-"data from a session unless they have confirmed that you consented to "
-"participate! If they see a consent video that does NOT clearly demonstrate "
-"informed consent--for instance, there was a technical problem and there's no "
-"audio--they may contact you to check, depending on your email settings.</p>\n"
-"                                "
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
 msgstr ""
 "\n"
 "                               <p> Anziché chiedere al genitore o al tutore "
@@ -1368,40 +2010,59 @@ msgstr ""
 "contattarti per verificarlo, a seconda delle tue impostazioni email. </p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:80
-msgid "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-msgstr ""
-"https://storage.googleapis.com/lookit-\n"
-"staging/static/videos/consent.mp4"
-
-#: web/templates/frontpages/faq.html:89
+#: web/templates/web/faq.html:215
 msgid "How is our information kept secure and confidential?"
 msgstr "Come vengono mantenute sicure e confidenziali le nostre informazioni?"
 
-#: web/templates/frontpages/faq.html:94
+#: web/templates/web/faq.html:223
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>\n"
+#| "                                Researchers using Lookit agree to uphold "
+#| "a common set of standards about how data is protected and shared. For "
+#| "instance, they never publish children's names or birthdates, or "
+#| "information that could be used to calculate a birthdate.</p>\n"
+#| "                                <p>The Lookit researcher interface is "
+#| "designed with participant data protection as the top priority. For "
+#| "instance, a special interface lets researchers confirm consent videos "
+#| "before they are able to download any other data from your session. "
+#| "Research groups can control who has access to what data in a very fine-"
+#| "grained way, for instance allowing an assistant to confirm consent and "
+#| "send gift cards, but not download study data.</p>\n"
+#| "                                <p>All of your data, including video, is "
+#| "transmitted over a secure HTTPS connection to Lookit storage, and is "
+#| "encrypted at rest. We take security very seriously; in addition to making "
+#| "sure any software we use is up-to-date, cloud servers are configured "
+#| "securely, and unit tests cover checking that accessing data requires "
+#| "correct permissions, we conducted a risk assessment and detailed manual "
+#| "penetration testing with a security contractor prior to our 2020 launch.</"
+#| "p>\n"
+#| "                                <p>See also 'Who will see our video?'</"
+#| "p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>\n"
-"                                Researchers using Lookit agree to uphold a "
-"common set of standards about how data is protected and shared. For "
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
 "instance, they never publish children's names or birthdates, or information "
 "that could be used to calculate a birthdate.</p>\n"
-"                                <p>The Lookit researcher interface is "
-"designed with participant data protection as the top priority. For instance, "
-"a special interface lets researchers confirm consent videos before they are "
-"able to download any other data from your session. Research groups can "
-"control who has access to what data in a very fine-grained way, for instance "
-"allowing an assistant to confirm consent and send gift cards, but not "
-"download study data.</p>\n"
-"                                <p>All of your data, including video, is "
-"transmitted over a secure HTTPS connection to Lookit storage, and is "
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
 "encrypted at rest. We take security very seriously; in addition to making "
 "sure any software we use is up-to-date, cloud servers are configured "
 "securely, and unit tests cover checking that accessing data requires correct "
-"permissions, we conducted a risk assessment and detailed manual penetration "
-"testing with a security contractor prior to our 2020 launch.</p>\n"
-"                                <p>See also 'Who will see our video?'</p>\n"
-"                                "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>\n"
@@ -1431,35 +2092,106 @@ msgstr ""
 "p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:107
+#: web/templates/web/faq.html:239
 msgid "Who will see our video?"
 msgstr "Chi vedrà il nostro video?"
 
-#: web/templates/frontpages/faq.html:112
+#: web/templates/web/faq.html:246
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Lookit staff at MIT will have access "
+#| "to your video and other data in order to improve and promote the platform "
+#| "and help with troubleshooting. The researchers running the study you "
+#| "participated in will also have access to your video and other data (like "
+#| "responses to questions during the study, and information you fill out "
+#| "when registering a child) for research purposes. They will watch the "
+#| "video segments you send to mark down information specific to the study--"
+#| "for instance, what your child said, or how long he/she looked to the left "
+#| "versus the right of the screen. This research group may be at MIT or at "
+#| "another institution. All studies run on Lookit must be approved by an "
+#| "Institutional Review Board (IRB) that ensures participants' rights and "
+#| "welfare are protected. All researchers using Lookit also agree to Terms "
+#| "of Use that govern what data they can share and what sorts of studies are "
+#| "okay to run on Lookit; these rules are sometimes stricter than their own "
+#| "institution might be.  </p>\n"
+#| "                                <p>Whether anyone else may view the video "
+#| "depends on the privacy settings you select at the end of the study. There "
+#| "are two decisions to make: whether to share your data with Databrary, and "
+#| "how to allow your video clips to be used by the researchers you have "
+#| "selected.</p>\n"
+#| "                                <p>First, we ask if you would like to "
+#| "share your data (including video) with authorized users fo the secure "
+#| "data library Databrary. Data sharing will lead to faster progress in "
+#| "research on human development and behavior. Researchers who are granted "
+#| "access to the Databrary library must agree to treat the data with the "
+#| "same high standard of care they would use in their own laboratories. "
+#| "Learn more about Databrary's <a href=\"https://databrary.org/about."
+#| "html\">mission</a> or the <a href=\"https://databrary.org/about/agreement."
+#| "html\">requirements for authorized users</a>.</p>\n"
+#| "                                <p>Next, we ask what types of uses of "
+#| "your video are okay with you.</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li><strong>Private</strong> This "
+#| "privacy level ensures that your video clips will be viewed only by "
+#| "authorized scientists (Lookit staff, the research group running the study "
+#| "and, if you have opted to share your data with Databrary, authorized "
+#| "Databrary users.) They will view the videos to record information about "
+#| "what your child did during the study--for instance, looking for 9 seconds "
+#| "at one image and 7 seconds at another image.</li>\n"
+#| "                                    <li><strong>Scientific and "
+#| "educational</strong> This privacy level gives permission to share your "
+#| "video clips with other researchers or students for scientific or "
+#| "educational purposes. For example, researchers might show a video clip in "
+#| "a talk at a scientific conference or an undergraduate class about "
+#| "cognitive development, or include an image or video in a scientific "
+#| "paper. In some circumstances, video or images may be available online, "
+#| "for instance as supplemental material in a scientific paper. Sharing "
+#| "videos with other researchers helps other groups trust and build on our "
+#| "work.</li>\n"
+#| "                                    <li><strong>Publicity</strong> This "
+#| "privacy level is for families who would be excited to see their child "
+#| "featured on the Lookit website or in the news! Selecting this privacy "
+#| "level gives permission to use your video clips to communicate about "
+#| "developmental studies and the Lookit platform with the public. For "
+#| "instance, we might post a short video clip on the Lookit website, on our "
+#| "Facebook page, or in a press release. Your video will never be used for "
+#| "commercial purposes.</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>If for some reason you do not select a "
+#| "privacy level, we treat the data as 'Private' and do not share with "
+#| "Databrary. Participants also have the option to withdraw all video "
+#| "besides consent at the end of the study if necessary (for instance, "
+#| "because someone was discussing state secrets in the background), and in "
+#| "this case it is automatically deleted. Privacy settings for completed "
+#| "sessions cannot automatically be changed retroactively. If you have any "
+#| "questions or concerns about privacy, please contact our team at <a "
+#| "href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Lookit staff at MIT will have access to "
-"your video and other data in order to improve and promote the platform and "
-"help with troubleshooting. The researchers running the study you "
-"participated in will also have access to your video and other data (like "
-"responses to questions during the study, and information you fill out when "
-"registering a child) for research purposes. They will watch the video "
-"segments you send to mark down information specific to the study--for "
-"instance, what your child said, or how long he/she looked to the left versus "
-"the right of the screen. This research group may be at MIT or at another "
-"institution. All studies run on Lookit must be approved by an Institutional "
-"Review Board (IRB) that ensures participants' rights and welfare are "
-"protected. All researchers using Lookit also agree to Terms of Use that "
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
 "govern what data they can share and what sorts of studies are okay to run on "
-"Lookit; these rules are sometimes stricter than their own institution might "
-"be.  </p>\n"
-"                                <p>Whether anyone else may view the video "
-"depends on the privacy settings you select at the end of the study. There "
-"are two decisions to make: whether to share your data with Databrary, and "
-"how to allow your video clips to be used by the researchers you have "
-"selected.</p>\n"
-"                                <p>First, we ask if you would like to share "
-"your data (including video) with authorized users fo the secure data library "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
 "Databrary. Data sharing will lead to faster progress in research on human "
 "development and behavior. Researchers who are granted access to the "
 "Databrary library must agree to treat the data with the same high standard "
@@ -1467,43 +2199,44 @@ msgid ""
 "Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
 "<a href=\"https://databrary.org/about/agreement.html\">requirements for "
 "authorized users</a>.</p>\n"
-"                                <p>Next, we ask what types of uses of your "
-"video are okay with you.</p>\n"
-"                                <ul>\n"
-"                                    <li><strong>Private</strong> This "
-"privacy level ensures that your video clips will be viewed only by "
-"authorized scientists (Lookit staff, the research group running the study "
-"and, if you have opted to share your data with Databrary, authorized "
-"Databrary users.) They will view the videos to record information about what "
-"your child did during the study--for instance, looking for 9 seconds at one "
-"image and 7 seconds at another image.</li>\n"
-"                                    <li><strong>Scientific and educational</"
-"strong> This privacy level gives permission to share your video clips with "
-"other researchers or students for scientific or educational purposes. For "
-"example, researchers might show a video clip in a talk at a scientific "
-"conference or an undergraduate class about cognitive development, or include "
-"an image or video in a scientific paper. In some circumstances, video or "
-"images may be available online, for instance as supplemental material in a "
-"scientific paper. Sharing videos with other researchers helps other groups "
-"trust and build on our work.</li>\n"
-"                                    <li><strong>Publicity</strong> This "
-"privacy level is for families who would be excited to see their child "
-"featured on the Lookit website or in the news! Selecting this privacy level "
-"gives permission to use your video clips to communicate about developmental "
-"studies and the Lookit platform with the public. For instance, we might post "
-"a short video clip on the Lookit website, on our Facebook page, or in a "
-"press release. Your video will never be used for commercial purposes.</li>\n"
-"                                </ul>\n"
-"                                <p>If for some reason you do not select a "
-"privacy level, we treat the data as 'Private' and do not share with "
-"Databrary. Participants also have the option to withdraw all video besides "
-"consent at the end of the study if necessary (for instance, because someone "
-"was discussing state secrets in the background), and in this case it is "
-"automatically deleted. Privacy settings for completed sessions cannot "
-"automatically be changed retroactively. If you have any questions or "
-"concerns about privacy, please contact our team at <a href=\"mailto:"
-"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
-"                                "
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p> Il personale di Lookit al MIT avrà "
@@ -1535,9 +2268,9 @@ msgstr ""
 "accettare di trattare i dati con lo stesso elevato standard di cura che "
 "utilizzerebbero nei propri laboratori. Ulteriori informazioni su Databrary  "
 "<a\n"
-"href=\"https://databrary.org/about.html\">mission</a> or the <a href="
-"\"https://databrary.org/about/agreement.html\">requirements for authorized "
-"users</a>.</p>\n"
+"href=\"https://databrary.org/about.html\">mission</a> or the <a "
+"href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
 "                                <p> Successivamente, ti chiediamo quali tipi "
 "di utilizzi del tuo video ti vanno bene. </p> \n"
 "                                 <ul>\n"
@@ -1578,11 +2311,11 @@ msgstr ""
 "sulla privacy, puoi contattare il nostro team all'indirizzo <a href=\"mailto:"
 "lookit@mit.edu\">lookit@mit.edu</a>.</p>"
 
-#: web/templates/frontpages/faq.html:130
+#: web/templates/web/faq.html:269
 msgid "What information do researchers use from our video?"
 msgstr "Quali informazioni usano i ricercatori dal nostro video?"
 
-#: web/templates/frontpages/faq.html:136
+#: web/templates/web/faq.html:278
 msgid ""
 "For children under about two years old, we usually design our studies to let "
 "their eyes do the talking! We're interested in where on the screen your "
@@ -1599,7 +2332,7 @@ msgstr ""
 "bambino guarda a destra o a sinistra, in modo da poter codificare il resto "
 "del video."
 
-#: web/templates/frontpages/faq.html:143
+#: web/templates/web/faq.html:290
 msgid ""
 "Here's an example of a few children watching our calibration video--it's "
 "easy to see that they look to one side and then the other."
@@ -1608,7 +2341,7 @@ msgstr ""
 "calibrazione-\n"
 "- è facile vedere che guardano da una parte e poi dall'altra."
 
-#: web/templates/frontpages/faq.html:149
+#: web/templates/web/faq.html:302
 msgid ""
 "Your child's decisions about where to look can give us lots of information "
 "about what he or she understands. Here are some of the techniques labs use "
@@ -1618,36 +2351,62 @@ msgstr ""
 "su ciò che lui o lei comprende. Ecco alcune delle tecniche che i laboratori "
 "usano per comprendere di più su come i bambini imparano"
 
-#: web/templates/frontpages/faq.html:150
+#: web/templates/web/faq.html:304
 msgid "Habituation"
 msgstr "Abituazione"
 
-#: web/templates/frontpages/faq.html:151
+#: web/templates/web/faq.html:305
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>In a habituation study, we first show "
+#| "infants many examples of one type of object or event, and they lose "
+#| "interest over time. Infants typically look for a long time at the first "
+#| "pictures, but then they start to look away more quickly. Once their "
+#| "looking times are much less than they were initially, we show either a "
+#| "picture from a new category or a new picture from the familiar category. "
+#| "If infants now look longer to the novel example, we can tell that they "
+#| "understood--and got bored of--the category we showed initially.</p>\n"
+#| "                                <p>Habituation requires waiting for each "
+#| "individual infant to achieve some threshold of \"boredness\"--for "
+#| "instance, looking half as long at a picture as he or she did initially. "
+#| "Sometimes this is impractical, and we use familiarization instead. In a "
+#| "familiarization study, we show all babies the same number of examples, "
+#| "and then see how interested they are in the familiar versus a new "
+#| "category. Younger infants and those who have seen few examples tend to "
+#| "show a familiarity preference--they look longer at images similar to what "
+#| "they have seen before. Older infants and those who have seen many "
+#| "examples tend to show a novelty preference--they look longer at images "
+#| "that are different from the ones they saw before. You probably notice the "
+#| "same phenomenon when you hear a new song on the radio: initially you "
+#| "don't recognize it; after it's played several times you may like it and "
+#| "sing along; after it's played hundreds of times you would choose to "
+#| "listen to anything else.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>In a habituation study, we first show "
-"infants many examples of one type of object or event, and they lose interest "
-"over time. Infants typically look for a long time at the first pictures, but "
-"then they start to look away more quickly. Once their looking times are much "
-"less than they were initially, we show either a picture from a new category "
-"or a new picture from the familiar category. If infants now look longer to "
-"the novel example, we can tell that they understood--and got bored of--the "
-"category we showed initially.</p>\n"
-"                                <p>Habituation requires waiting for each "
-"individual infant to achieve some threshold of \"boredness\"--for instance, "
-"looking half as long at a picture as he or she did initially. Sometimes this "
-"is impractical, and we use familiarization instead. In a familiarization "
-"study, we show all babies the same number of examples, and then see how "
-"interested they are in the familiar versus a new category. Younger infants "
-"and those who have seen few examples tend to show a familiarity preference--"
-"they look longer at images similar to what they have seen before. Older "
-"infants and those who have seen many examples tend to show a novelty "
-"preference--they look longer at images that are different from the ones they "
-"saw before. You probably notice the same phenomenon when you hear a new song "
-"on the radio: initially you don't recognize it; after it's played several "
-"times you may like it and sing along; after it's played hundreds of times "
-"you would choose to listen to anything else.</p>\n"
-"                                "
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                 <p> In uno studio di abituazione, per prima "
@@ -1676,11 +2435,11 @@ msgstr ""
 "piacerti e potresti cantarla; invece dopo che è stato riprodotta centinaia "
 "di volte, sceglierai di ascoltare qualsiasi altra cosa.</p>"
 
-#: web/templates/frontpages/faq.html:156
+#: web/templates/web/faq.html:308
 msgid "Violation of expectation"
 msgstr "Violazione delle aspettative"
 
-#: web/templates/frontpages/faq.html:157
+#: web/templates/web/faq.html:310
 msgid ""
 "Infants and children already have rich expectations about how events work. "
 "Children (and adults for that matter) tend to look longer at things they "
@@ -1692,11 +2451,11 @@ msgstr ""
 "lungo le cose che trovano sorprendenti, quindi in alcuni casi, possiamo "
 "prendere i loro tempi di osservazione come misura di quanto siano sorpresi."
 
-#: web/templates/frontpages/faq.html:158
+#: web/templates/web/faq.html:312
 msgid "Preferential looking"
 msgstr "Sguardo preferenziale"
 
-#: web/templates/frontpages/faq.html:159
+#: web/templates/web/faq.html:314
 msgid ""
 "Even when they seem to be passive observers, children are making lots of "
 "decisions about where to look and what to pay attention to. In this "
@@ -1715,11 +2474,11 @@ msgstr ""
 "le viene chiesto di 'trovare gli applausi'; il display che sta guardando è "
 "mostrato in alto."
 
-#: web/templates/frontpages/faq.html:165
+#: web/templates/web/faq.html:325
 msgid "Predictive looking"
 msgstr "Ricerca predittiva"
 
-#: web/templates/frontpages/faq.html:166
+#: web/templates/web/faq.html:327
 msgid ""
 "Children can often make sophisticated predictions about what they expect to "
 "see or hear next. One way we can see those predictions in young children is "
@@ -1742,7 +2501,7 @@ msgstr ""
 "imparano queste relazioni e come le generalizzano, analizzando dove dirigono "
 "il loro sguardo quando sentono una o l'altra sillaba."
 
-#: web/templates/frontpages/faq.html:168
+#: web/templates/web/faq.html:330
 msgid ""
 "Older children may simply be able to answer spoken questions about what they "
 "think is happening. For instance, in a recent study, two women called an "
@@ -1755,7 +2514,7 @@ msgstr ""
 "diversi e ai bambini è stato chiesto quale fosse il nome corretto "
 "dell'oggetto."
 
-#: web/templates/frontpages/faq.html:174
+#: web/templates/web/faq.html:342
 msgid ""
 "Another way we can learn about how older children (and adults) think is to "
 "measure their reaction times. For instance, we might ask you to help your "
@@ -1769,99 +2528,7 @@ msgstr ""
 "un cerchio e un altro tasto quando appare un quadrato, e quindi esaminare i "
 "fattori che influenzano la velocità con cui preme un tasto."
 
-#: web/templates/frontpages/faq.html:181
-msgid "Why are you running studies online instead of in person?"
-msgstr "Perché state conducendo studi online invece che di persona?"
-
-#: web/templates/frontpages/faq.html:186
-msgid ""
-"Traditionally, developmental studies happen in a quiet room in a university "
-"lab. Researchers call or email local parents to see if they'd like to take "
-"part and schedule an appointment for them to come visit the lab. Why "
-"complement these in-lab studies with online ones? We're hoping to..."
-msgstr ""
-"Tradizionalmente, gli studi sullo sviluppo avvengono in una stanza "
-"tranquilla in un laboratorio universitario. I ricercatori chiamano o inviano "
-"un'e-mail ai genitori locali per vedere se desiderano partecipare e fissare "
-"un appuntamento per andare in laboratorio. Perché integrare questi studi in "
-"laboratorio con quelli online? Speriamo di..."
-
-#: web/templates/frontpages/faq.html:187
-msgid ""
-"\n"
-"                                <ul>\n"
-"                                    <li>Make it easier for you to take part "
-"in research, especially for families without a stay-at-home parent</li>\n"
-"                                    <li>Work with more kids when needed--"
-"right now a limiting factor in designing studies is the time it takes to "
-"recruit participants</li>\n"
-"                                    <li>Draw conclusions from a more "
-"representative population of families--not just those who live near a "
-"university and are able to visit the lab during the day.\n"
-"                                    </li>\n"
-"                                    <li>Make it easier for families to "
-"continue participating in longitudinal studies, which may involve multiple "
-"testing sessions separated by months or years</li>\n"
-"                                    <li>Observe more natural behavior "
-"because children are at home rather than in an unfamiliar place</li>\n"
-"                                    <li>Create a system for learning about "
-"special populations--for instance, children with specific developmental "
-"disorders</li>\n"
-"                                    <li>Make the procedures we use in doing "
-"research more transparent, and make it easier to replicate our findings</"
-"li>\n"
-"                                    <li>Communicate with families about the "
-"research we're doing and what we can learn from it</li>\n"
-"                                </ul>\n"
-"                                "
-msgstr ""
-"\n"
-"                                <ul>\n"
-"                                    <li>Semplificare la tua partecipazione "
-"alla ricerca, soprattutto per le famiglie senza un genitore casalingo</li>\n"
-"                                    <li>Lavorare con più bambini quando "
-"necessario--in questo momento un fattore limitante nella progettazione degli "
-"studi è il tempo necessario per reclutare i partecipanti</li>\n"
-"                                    <li>Trarre conclusioni da una "
-"popolazione di famiglie più rappresentativa--non solo da quelle che vivono "
-"vicino a un'università e possono visitare il laboratorio durante il giorno.\n"
-"                                    </li>\n"
-"                                    <li>Rendere più facile per le famiglie "
-"continuare a partecipare a studi longitudinali, che possono comportare più "
-"sessioni di test separate da mesi o anni</li>\n"
-"                                    <li>Osservare un comportamento più "
-"naturale perché i bambini sono a casa piuttosto che in un luogo sconosciuto</"
-"li>\n"
-"                                    <li>Creare un sistema per conoscere "
-"popolazioni speciali--ad esempio, bambini con disturbi dello sviluppo "
-"specifici</li>\n"
-"                                    <li>Rendere le procedure che utilizziamo "
-"per svolgere la ricerca più trasparenti e semplificare la replicazione dei "
-"nostri risultati</li>\n"
-"                                    <li>Comunicare alle famiglie circa la "
-"ricerca che stiamo facendo e su ciò che possiamo imparare da essa</li>\n"
-"                                </ul>"
-
-#: web/templates/frontpages/faq.html:206
-msgid "When will we see the results of the study?"
-msgstr "Quando vedremo i risultati dello studio?"
-
-#: web/templates/frontpages/faq.html:211
-msgid ""
-"The process of publishing a scientific study, from starting data collection "
-"to seeing the paper in a journal, can take several years. You can check the "
-"Lookit home page for updates on papers, or set your communication "
-"preferences to be notified when we have results from studies you "
-"participated in."
-msgstr ""
-"Il processo di pubblicazione di uno studio scientifico, dall'avvio della "
-"raccolta dei dati alla visualizzazione dell'articolo su una rivista, può "
-"richiedere diversi anni. Puoi controllare la home page di Lookit per gli "
-"aggiornamenti sui documenti o impostare le tue preferenze di comunicazione "
-"per essere avvisato quando avremo i risultati degli studi a cui hai "
-"partecipato."
-
-#: web/templates/frontpages/faq.html:218
+#: web/templates/web/faq.html:355
 msgid ""
 "My child wasn't paying attention, or we were interrupted. Can we try the "
 "study again?"
@@ -1869,7 +2536,7 @@ msgstr ""
 "Mio figlio non stava prestando attenzione o siamo stati interrotti. Possiamo "
 "provare di nuovo lo studio?"
 
-#: web/templates/frontpages/faq.html:223
+#: web/templates/web/faq.html:364
 msgid ""
 "Certainly--thanks for your dedication! You may see a warning that you have "
 "already participated in the study when you go to try it again, but you can "
@@ -1881,14 +2548,14 @@ msgstr ""
 "ignorarlo. Non hai bisogno di dirci che hai già provato lo studio in "
 "precedenza; avremo una registrazione della tua precedente partecipazione."
 
-#: web/templates/frontpages/faq.html:230
+#: web/templates/web/faq.html:377
 msgid ""
 "My child is outside the age range. Can he/she still participate in this "
 "study?"
 msgstr ""
 "Mio figlio non ha l'età prevista. Può comunque partecipare a questo studio?"
 
-#: web/templates/frontpages/faq.html:235
+#: web/templates/web/faq.html:386
 msgid ""
 "Sure! We may not be able to use his or her data in our research directly, "
 "but if you're curious you're welcome to try the study anyway. (Sometimes big "
@@ -1901,11 +2568,11 @@ msgstr ""
 "figlio è appena al di sotto dell'età minima per uno studio, tuttavia, ti "
 "invitiamo ad aspettare in modo da poter utilizzare i dati."
 
-#: web/templates/frontpages/faq.html:242
+#: web/templates/web/faq.html:399
 msgid "My child was born prematurely. Should we use his/her adjusted age?"
 msgstr "Mio figlio è nato prematuro. Dobbiamo usare la sua età corretta?"
 
-#: web/templates/frontpages/faq.html:247
+#: web/templates/web/faq.html:408
 msgid ""
 "For study eligibility, we usually use the child's chronological age (time "
 "since birth), even for premature babies. If adjusted age is important for a "
@@ -1916,7 +2583,7 @@ msgstr ""
 "corretta è importante per uno studio particolare, lo renderemo chiaro nei "
 "criteri di ammissibilità dello studio."
 
-#: web/templates/frontpages/faq.html:254
+#: web/templates/web/faq.html:421
 msgid ""
 "Our family speaks a language other than English at home. Can my child "
 "participate?"
@@ -1924,7 +2591,7 @@ msgstr ""
 "La nostra famiglia parla una lingua diversa dall'italiano a casa. Mio figlio "
 "può partecipare?"
 
-#: web/templates/frontpages/faq.html:259
+#: web/templates/web/faq.html:430
 msgid ""
 "Sure! Right now, instructions for children and parents are written only in "
 "English, so some of them may be confusing to a child who does not hear "
@@ -1942,7 +2609,7 @@ msgstr ""
 "lo chiederemo specificamente. Puoi anche indicare le lingue che tuo figlio "
 "parla o sta imparando a parlare nella tua indagine demografica."
 
-#: web/templates/frontpages/faq.html:266
+#: web/templates/web/faq.html:443
 msgid ""
 "My child has been diagnosed with a developmental disorder or has special "
 "needs. Can he/she still participate?"
@@ -1950,20 +2617,32 @@ msgstr ""
 "A mio figlio è stato diagnosticato un disturbo dello sviluppo o ha bisogni "
 "speciali. Può ancora partecipare?"
 
-#: web/templates/frontpages/faq.html:271
+#: web/templates/web/faq.html:451
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Of course! We're interested in how all "
+#| "children learn and grow. If you'd like, you can make a note of any "
+#| "developmental disorders in the comments section at the end of the study. "
+#| "We are excited that in the future, online studies may help more families "
+#| "participate in research to better understand their own children's "
+#| "diagnoses.</p>\n"
+#| "                                <p>One note: most of our studies include "
+#| "both images and sound, and may be hard to understand if your child is "
+#| "blind or deaf. If you can, please feel free to help out by describing "
+#| "images or signing.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Of course! We're interested in how all "
-"children learn and grow. If you'd like, you can make a note of any "
-"developmental disorders in the comments section at the end of the study. We "
-"are excited that in the future, online studies may help more families "
-"participate in research to better understand their own children's diagnoses."
-"</p>\n"
-"                                <p>One note: most of our studies include "
-"both images and sound, and may be hard to understand if your child is blind "
-"or deaf. If you can, please feel free to help out by describing images or "
-"signing.</p>\n"
-"                                "
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                           <p>Certo! Siamo interessati a "
@@ -1977,7 +2656,7 @@ msgstr ""
 "capire se vostro figlio ha una disabilità visiva o uditiva. Se potete, "
 "sentitevi liberi di aiutare descrivendo le immagini o segnando.</p> </p>"
 
-#: web/templates/frontpages/faq.html:281
+#: web/templates/web/faq.html:466
 msgid ""
 "I have multiple children in the age range for a study. Can they participate "
 "together?"
@@ -1985,7 +2664,7 @@ msgstr ""
 "Ho più bambini nella fascia d'età per uno studio. Possono partecipare "
 "insieme?"
 
-#: web/templates/frontpages/faq.html:286
+#: web/templates/web/faq.html:475
 msgid ""
 "If possible, we ask that each child participate separately. When children "
 "participate together they generally influence each other. That's a "
@@ -1997,26 +2676,40 @@ msgstr ""
 "un argomento affascinante di per sé, ma di solito non è al centro della "
 "nostra ricerca."
 
-#: web/templates/frontpages/faq.html:293
+#: web/templates/web/faq.html:488
 msgid "But I've heard that young children should avoid 'screen time.'"
 msgstr ""
 "Ma ho sentito dire che i bambini piccoli dovrebbero evitare di passare del "
 "tempo davanti allo schermo."
 
-#: web/templates/frontpages/faq.html:298
+#: web/templates/web/faq.html:496
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>We agree with the American Academy of "
+#| "Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
+#| "e20162591\" target=\"_blank\">advice</a> that children learn best from "
+#| "people, not screens! However, our studies are not intended to educate "
+#| "children, but to learn from them.</p>\n"
+#| "                                <p>As part of a child's limited screen "
+#| "time, we hope that our studies will foster family conversation and "
+#| "engagement with science that offsets the few minutes spent watching a "
+#| "video instead of playing. And we do \"walk the walk\"--our own young "
+#| "children provide lots of feedback on our studies!</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>We agree with the American Academy of "
-"Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
-"e20162591\" target=\"_blank\">advice</a> that children learn best from "
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
 "people, not screens! However, our studies are not intended to educate "
 "children, but to learn from them.</p>\n"
-"                                <p>As part of a child's limited screen time, "
-"we hope that our studies will foster family conversation and engagement with "
-"science that offsets the few minutes spent watching a video instead of "
-"playing. And we do \"walk the walk\"--our own young children provide lots of "
-"feedback on our studies!</p>\n"
-"                                "
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>Siamo d'accordo con l'American Academy of "
@@ -2031,11 +2724,11 @@ msgstr ""
 "fatti valgono più delle parole\"-- i nostri bambini ci forniscono un sacco "
 "di feedback per i nostri studi!</p>"
 
-#: web/templates/frontpages/faq.html:308
+#: web/templates/web/faq.html:510
 msgid "Will we be paid for our participation?"
 msgstr "Saremo pagati per la nostra partecipazione?"
 
-#: web/templates/frontpages/faq.html:313
+#: web/templates/web/faq.html:518
 msgid ""
 "Some research groups provide gift cards or other compensation for completing "
 "their studies, and others rely on volunteers. (This often depends on the "
@@ -2048,77 +2741,185 @@ msgstr ""
 "Queste informazioni saranno elencate nella pagina di descrizione dello "
 "studio."
 
-#: web/templates/frontpages/faq.html:320
-msgid "Can I get my child's results?"
-msgstr "Posso avere i risultati di mio figlio?"
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
 
-#: web/templates/frontpages/faq.html:325
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
 #, python-format
 msgid ""
 "\n"
-"                                <p>For some studies, yes! Usually, "
-"developmental researchers only interpret children's abilities and "
-"developmental trends at a group level, and the individual data collected "
-"just isn't very interpretable. But for \"Your baby, the physicist\" and "
-"other longitudinal studies (where you come back for more than one session), "
-"we can sometimes collect enough data to give you a report of your child's "
-"responses after you complete all the sessions.</p>\n"
-"                                <p>Please note that none of the measures we "
-"collect are diagnostic! For instance, while we hope you'll be interested to "
-"learn that your child looked 70%% of the time at videos where things fell up "
-"versus falling down, we won't be able to tell you whether this means your "
-"child is going to be especially good at physics.</p>\n"
-"                                <p>If you're interested in getting "
-"individual results right away, please see our <a href='resources'>Resources</"
-"a> section for fun at-home activities you can try with your child.</p>\n"
-"                                "
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
 msgstr ""
-"\n"
-"                                <p>Per alcuni studi, sì! Di solito, i "
-"ricercatori dello sviluppo interpretano le capacità e le tendenze evolutive "
-"dei bambini solo a livello di gruppo, e i dati individuali raccolti "
-"semplicemente non sono molto interpretabili. Ma per \"Il tuo bambino, il "
-"fisico\" e altri studi longitudinali (in cui torni per più di una sessione), "
-"a volte, possiamo raccogliere dati sufficienti per darti un resoconto delle "
-"risposte di tuo figlio dopo aver completato tutte le sessioni.</p>\n"
-"                                <p>Tieni presente che nessuna delle misure "
-"che raccogliamo è diagnostica! Ad esempio, anche se speriamo che ti "
-"interesserà sapere che tuo figlio ha guardato il 70 %% delle volte un video "
-"in cui le cose cadevano verso l'alto invece che cadere in basso, non saremo "
-"in grado di dirti se questo significa che tuo figlio sarà particolarmente "
-"bravo in fisica.</p>\n"
-"                                <p>Se sei interessato a ottenere subito "
-"risultati individuali, consulta la nostra sezione <a \n"
-"href='resources'>Resources</a> per divertenti attività  che puoi provare a "
-"casa con tuo figlio.</p>"
 
-#: web/templates/frontpages/faq.html:335
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
 msgid "Technical"
 msgstr "Tecnico"
 
-#: web/templates/frontpages/faq.html:339
+#: web/templates/web/faq.html:652
 msgid "What browsers are supported?"
 msgstr "Quali browser sono supportati?"
 
-#: web/templates/frontpages/faq.html:344
+#: web/templates/web/faq.html:660
+#, fuzzy
+#| msgid ""
+#| "Lookit supports recent versions of Chrome and Firefox. We are not "
+#| "currently able to support Internet Explorer or Safari."
 msgid ""
-"Lookit supports recent versions of Chrome and Firefox. We are not currently "
-"able to support Internet Explorer or Safari."
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
 msgstr ""
 "Lookit supporta le versioni recenti di Chrome e Firefox. Attualmente non "
 "siamo in grado di supportare Internet Explorer o Safari."
 
-#: web/templates/frontpages/faq.html:351
+#: web/templates/web/faq.html:672
 msgid "Can we do a study on my phone or tablet?"
 msgstr "Possiamo fare uno studio sul mio telefono o tablet?"
 
-#: web/templates/frontpages/faq.html:357
+#: web/templates/web/faq.html:679
+#, fuzzy
+#| msgid ""
+#| "Not yet! Because we're measuring kids' looking patterns, we need a "
+#| "reasonably stable view of their eyes and a big enough screen that we can "
+#| "tell whether they're looking at the left or the right side of it. We're "
+#| "excited about the potential for touchscreen studies that allow us to "
+#| "observe infants and toddlers exploring, though!"
 msgid ""
-"Not yet! Because we're measuring kids' looking patterns, we need a "
-"reasonably stable view of their eyes and a big enough screen that we can "
-"tell whether they're looking at the left or the right side of it. We're "
-"excited about the potential for touchscreen studies that allow us to observe "
-"infants and toddlers exploring, though!"
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
 msgstr ""
 "Non ancora! Poiché stiamo misurando i pattern di osservazione dei bambini, "
 "abbiamo bisogno di una visione ragionevolmente stabile dei loro occhi e di "
@@ -2127,66 +2928,296 @@ msgstr ""
 "studi con il touchscreen che ci consentono di osservare neonati e bambini "
 "che esplorano!"
 
-#: web/templates/frontpages/home.html:11
-msgid "the online child lab"
-msgstr "Il laboratorio online per bambini"
-
-#: web/templates/frontpages/home.html:12
-msgid "A project of the MIT Early Childhood Cognition Lab"
-msgstr "Un progetto del MIT Early Childhood Cognition Lab "
-
-#: web/templates/frontpages/home.html:22
-msgid "Bringing science home"
-msgstr "Portare la scienza a casa"
-
-#: web/templates/frontpages/home.html:23
-msgid ""
-"Here at MIT's Early Childhood Cognition Lab, we're trying a new approach in "
-"developmental psychology: bringing the experiments to you."
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
 msgstr ""
-"Qui al MIT Early Childhood Cognition Lab, stiamo provando un nuovo approccio "
-"alla psicologia dello sviluppo: portare gli esperimenti nelle vostre case."
 
-#: web/templates/frontpages/home.html:29
-msgid "Help us understand how your child thinks"
-msgstr "Aiutaci a capire come pensa tuo figlio"
-
-#: web/templates/frontpages/home.html:30
+#: web/templates/web/faq.html:700
 msgid ""
-"Your family can contribute to research about how children learn by doing fun "
-"activities together, right in your web browser."
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
 msgstr ""
-"La tua famiglia può contribuire alla ricerca su come i bambini imparano "
-"svolgendo attività divertenti insieme, direttamente nel tuo browser web."
 
-#: web/templates/frontpages/home.html:36
-msgid "Participate whenever and wherever"
-msgstr "Partecipa sempre e ovunque"
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "In quale regione vivi?"
 
-#: web/templates/frontpages/home.html:37
+#: web/templates/web/faq.html:721
 msgid ""
-"Log in or create an account at the top right to get started! You can "
-"participate with your child from any computer with a webcam."
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
 msgstr ""
-"Accedi o crea un account in alto a destra per iniziare! Puoi partecipare con "
-"tuo figlio da qualsiasi computer dotato di webcam."
 
-#: web/templates/frontpages/privacy.html:11
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "For researchers"
+msgid "For Researchers"
+msgstr "Per i ricercatori"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Quanti anni hai?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Accedi per partecipare"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Gli scienziati"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participation"
+msgid "Participate in a Study"
+msgstr "Partecipazione"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Home"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
+msgid "I would like to be contacted when:"
+msgstr "Vorrei essere contattato quando:"
+
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Accedi per partecipare"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Creare un profilo"
+
+#: web/templates/web/participant-signup.html:13
+msgid "Create Participant Account"
+msgstr "Creare un'account per partecipare"
+
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "Per registrarsi come ricercatore, si prega di utilizzare"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead"
+msgid "instead."
+msgstr "invece"
+
+#: web/templates/web/participant-signup.html:28
+msgid ""
+"By clicking 'Create Account', I agree that I have read and accepted the "
+msgstr ""
+"Facendo clic su \"Crea account\", accetto di aver letto e accettato il "
+
+#: web/templates/web/participant-signup.html:28
+msgid "Privacy Statement"
+msgstr "Informativa sulla Privacy"
+
+#: web/templates/web/privacy.html:9
 msgid "Privacy statement"
 msgstr "Informativa sulla Privacy"
 
-#: web/templates/frontpages/privacy.html:17
+#: web/templates/web/privacy.html:11
 msgid "Introduction"
 msgstr "Introduzione"
 
-#: web/templates/frontpages/privacy.html:18
+#: web/templates/web/privacy.html:14
+#, fuzzy
+#| msgid ""
+#| "Lookit is committed to supporting the privacy of individuals who enroll "
+#| "on our Platform to conduct\n"
+#| "                research or serve as research subjects. This Privacy "
+#| "Statement explains how we handle and use the\n"
+#| "                personal information we collect about our researchers and "
+#| "research participant community."
 msgid ""
 "Lookit is committed to supporting the privacy of individuals who enroll on "
 "our Platform to conduct\n"
-"                research or serve as research subjects. This Privacy "
-"Statement explains how we handle and use the\n"
-"                personal information we collect about our researchers and "
-"research participant community."
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
 msgstr ""
 "Lookit si impegna a sostenere la privacy degli individui che si iscrivono "
 "alla nostra Piattaforma per condurre\n"
@@ -2195,19 +3226,28 @@ msgstr ""
 "                informazioni personali che raccogliamo sui nostri "
 "ricercatori e sui partecipanti alla ricerca."
 
-#: web/templates/frontpages/privacy.html:22
+#: web/templates/web/privacy.html:19
 msgid "For participants"
 msgstr "Per i partecipanti"
 
-#: web/templates/frontpages/privacy.html:24
+#: web/templates/web/privacy.html:22
+#, fuzzy
+#| msgid ""
+#| "Lookit is a platform that many different researchers use to conduct "
+#| "studies about how children learn and\n"
+#| "                develop. It is run by the MIT Early Childhood Cognition "
+#| "Lab, which has access to all of the data\n"
+#| "                collected on Lookit. Researchers using Lookit to conduct "
+#| "studies only access your personal information\n"
+#| "                if you choose to participate in their study."
 msgid ""
 "Lookit is a platform that many different researchers use to conduct studies "
 "about how children learn and\n"
-"                develop. It is run by the MIT Early Childhood Cognition Lab, "
-"which has access to all of the data\n"
-"                collected on Lookit. Researchers using Lookit to conduct "
-"studies only access your personal information\n"
-"                if you choose to participate in their study."
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
 msgstr ""
 "Lookit è una piattaforma che molti ricercatori diversi usano per condurre "
 "studi su come i bambini imparano e si\n"
@@ -2217,35 +3257,54 @@ msgstr ""
 "condurre studi accedono alle tue informazioni personali solo\n"
 "                solo se scegli di partecipare al loro studio."
 
-#: web/templates/frontpages/privacy.html:29
-#: web/templates/frontpages/privacy.html:142
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
 msgid "What personal information we collect"
 msgstr "Quali informazioni personali raccogliamo"
 
-#: web/templates/frontpages/privacy.html:31
+#: web/templates/web/privacy.html:30
 msgid "We collect the following kinds of personal information:"
 msgstr "Raccogliamo i seguenti tipi di informazioni personali:"
 
-#: web/templates/frontpages/privacy.html:32
+#: web/templates/web/privacy.html:33
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Account data: basic contact information that may "
+#| "include your email address, nickname, mailing\n"
+#| "                    address, and contact preferences.</li>\n"
+#| "                <li>Child data: basic biographical information about your "
+#| "child(ren), including nickname, date of birth,\n"
+#| "                    and gestational age at birth.</li>\n"
+#| "                <li>Demographic data: background and biographical "
+#| "information such as your native language, race, age,\n"
+#| "                    educational background, and family history of "
+#| "particular medical conditions.</li>\n"
+#| "                <li>Study data: responses collected during particular "
+#| "studies conducted on Lookit, including webcam\n"
+#| "                    video of your family participating in the study, text "
+#| "entered in forms, the particular images that\n"
+#| "                    were shown, the timing of progression through the "
+#| "study, etc.</li>\n"
+#| "            </ul>"
 msgid ""
 "<ul>\n"
-"                <li>Account data: basic contact information that may include "
-"your email address, nickname, mailing\n"
-"                    address, and contact preferences.</li>\n"
-"                <li>Child data: basic biographical information about your "
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
 "child(ren), including nickname, date of birth,\n"
-"                    and gestational age at birth.</li>\n"
-"                <li>Demographic data: background and biographical "
-"information such as your native language, race, age,\n"
-"                    educational background, and family history of particular "
-"medical conditions.</li>\n"
-"                <li>Study data: responses collected during particular "
-"studies conducted on Lookit, including webcam\n"
-"                    video of your family participating in the study, text "
-"entered in forms, the particular images that\n"
-"                    were shown, the timing of progression through the study, "
-"etc.</li>\n"
-"            </ul>"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
 msgstr ""
 "<ul>\n"
 "                <li>Dati dell'account: informazioni di contatto di base che "
@@ -2266,19 +3325,26 @@ msgstr ""
 "attraverso lo studio, ecc.</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:44
-#: web/templates/frontpages/privacy.html:147
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
 msgid "How we collect personal information about you"
 msgstr "Come raccogliamo informazioni personali su di te"
 
-#: web/templates/frontpages/privacy.html:46
+#: web/templates/web/privacy.html:48
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is the information you "
+#| "provide to us when registering\n"
+#| "                for a Lookit account, registering your children, updating "
+#| "your account or your children’s profiles,\n"
+#| "                completing or updating surveys, or participating in "
+#| "individual Lookit studies."
 msgid ""
 "The information we collect and maintain about you is the information you "
 "provide to us when registering\n"
-"                for a Lookit account, registering your children, updating "
-"your account or your children’s profiles,\n"
-"                completing or updating surveys, or participating in "
-"individual Lookit studies."
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
 msgstr ""
 "Le informazioni che raccogliamo e conserviamo su di te sono le informazioni "
 "che ci fornisci al momento della registrazione\n"
@@ -2287,12 +3353,11 @@ msgstr ""
 "                per completare o aggiornare sondaggi o partecipare a singoli "
 "studi Lookit."
 
-#: web/templates/frontpages/privacy.html:50
-#: web/templates/frontpages/privacy.html:167
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
 msgid "When we share your personal information"
 msgstr "Quando condividiamo le tue informazioni personali"
 
-#: web/templates/frontpages/privacy.html:52
+#: web/templates/web/privacy.html:56
 msgid ""
 "When you participate in a Lookit study, we share the following information "
 "with the research group conducting the study:"
@@ -2300,15 +3365,26 @@ msgstr ""
 "Quando partecipi a uno studio su Lookit, condividiamo le seguenti "
 "informazioni con il gruppo di ricerca che conduce lo studio:"
 
-#: web/templates/frontpages/privacy.html:54
+#: web/templates/web/privacy.html:60
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>Your account data </li>\n"
+#| "                <li>The child data for the child who is participating</"
+#| "li>\n"
+#| "                <li>Your demographic data</i>\n"
+#| "                <li>The study data for this particular study session</"
+#| "li>\n"
+#| "            </ul>"
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>Your account data </li>\n"
-"                <li>The child data for the child who is participating</li>\n"
-"                <li>Your demographic data</i>\n"
-"                <li>The study data for this particular study session</li>\n"
-"            </ul>"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
 msgstr ""
 "\n"
 "           <ul>\n"
@@ -2318,7 +3394,7 @@ msgstr ""
 "                <li>I dati di questa particolare sessione di studio</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:61
+#: web/templates/web/privacy.html:68
 msgid ""
 "Your email address is not shared directly with the research group, although "
 "they can contact you via Lookit in accordance with your contact preferences."
@@ -2327,13 +3403,20 @@ msgstr ""
 "ricerca, anche se potrai essere contattato tramite Lookit in base alle tue "
 "preferenze di contatto."
 
-#: web/templates/frontpages/privacy.html:63
+#: web/templates/web/privacy.html:71
+#, fuzzy
+#| msgid ""
+#| "Researchers may publish the results of a study, including individual "
+#| "responses. However, although they\n"
+#| "                may publish the ages of participants, they may not "
+#| "publish participant birthdates (or information that\n"
+#| "                could be used to calculate birthdates)."
 msgid ""
 "Researchers may publish the results of a study, including individual "
 "responses. However, although they\n"
-"                may publish the ages of participants, they may not publish "
+"        may publish the ages of participants, they may not publish "
 "participant birthdates (or information that\n"
-"                could be used to calculate birthdates)."
+"    could be used to calculate birthdates)."
 msgstr ""
 "I ricercatori possono pubblicare i risultati di uno studio, comprese le "
 "risposte individuali. Tuttavia, anche se\n"
@@ -2341,20 +3424,33 @@ msgstr ""
 "pubblicare le date di nascita (o informazioni che\n"
 "                potrebbero essere utilizzate per calcolarle)."
 
-#: web/templates/frontpages/privacy.html:67
+#: web/templates/web/privacy.html:76
+#, fuzzy
+#| msgid ""
+#| "We and/or the researchers responsible for a study may share video of your "
+#| "family’s participation for\n"
+#| "                scientific, educational, and/or publicity purposes, but "
+#| "only if you choose at the conclusion of a study\n"
+#| "                to allow such usage. Researchers may also share your "
+#| "video and other data with Databrary if you choose\n"
+#| "                at the conclusion of a study to allow that. We don’t "
+#| "publish video of participants such that it can be\n"
+#| "                linked to individual demographic data (e.g., household "
+#| "income or number of parents/guardians), and\n"
+#| "                researchers must also agree not to do so in order to use "
+#| "Lookit."
 msgid ""
 "We and/or the researchers responsible for a study may share video of your "
 "family’s participation for\n"
-"                scientific, educational, and/or publicity purposes, but only "
-"if you choose at the conclusion of a study\n"
-"                to allow such usage. Researchers may also share your video "
-"and other data with Databrary if you choose\n"
-"                at the conclusion of a study to allow that. We don’t publish "
-"video of participants such that it can be\n"
-"                linked to individual demographic data (e.g., household "
-"income or number of parents/guardians), and\n"
-"                researchers must also agree not to do so in order to use "
-"Lookit."
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
 msgstr ""
 "Noi e/o i ricercatori responsabili di uno studio potremmo condividere il "
 "video della partecipazione della tua famiglia a\n"
@@ -2370,13 +3466,20 @@ msgstr ""
 "                i ricercatori devono accettare di non farlo per utilizzare "
 "Lookit."
 
-#: web/templates/frontpages/privacy.html:74
+#: web/templates/web/privacy.html:84
+#, fuzzy
+#| msgid ""
+#| "We don’t share, sell, publish, or otherwise disclose your contact "
+#| "information (email and/or mailing\n"
+#| "                address) to anyone but the researchers involved in a "
+#| "study. Researchers must also agree not to disclose\n"
+#| "                your contact information in order to use Lookit."
 msgid ""
 "We don’t share, sell, publish, or otherwise disclose your contact "
 "information (email and/or mailing\n"
-"                address) to anyone but the researchers involved in a study. "
+"        address) to anyone but the researchers involved in a study. "
 "Researchers must also agree not to disclose\n"
-"                your contact information in order to use Lookit."
+"        your contact information in order to use Lookit."
 msgstr ""
 "Non condividiamo, vendiamo, pubblichiamo o divulghiamo in altro modo le tue "
 "informazioni di contatto (email e/o\n"
@@ -2385,12 +3488,11 @@ msgstr ""
 "non divulgare\n"
 "                le tue informazioni di contatto per utilizzare Lookit."
 
-#: web/templates/frontpages/privacy.html:78
-#: web/templates/frontpages/privacy.html:152
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
 msgid "How we use your personal information"
 msgstr "Come utilizziamo le tue informazioni personali"
 
-#: web/templates/frontpages/privacy.html:80
+#: web/templates/web/privacy.html:92
 msgid ""
 "We may use your personal information (account, child, demographic, and study "
 "data) for a variety of purposes, including to:"
@@ -2398,35 +3500,63 @@ msgstr ""
 "Potremmo utilizzare le tue informazioni personali (account, figli, dati "
 "demografici e di studio) per una varietà di scopi, tra cui:"
 
-#: web/templates/frontpages/privacy.html:81
+#: web/templates/web/privacy.html:94
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Provide you with the research studies you have "
+#| "enrolled in, and information about which studies your\n"
+#| "                    children are eligible for</li>\n"
+#| "                <li>Send you information about studies you may be "
+#| "interested in, reminders to participate in multi-part\n"
+#| "                    studies, and/or results of studies you have "
+#| "participated in, subject to your contact preferences\n"
+#| "                </li>\n"
+#| "                <li>Improve the Lookit platform: e.g., detect and fix "
+#| "technical problems or identify new features that\n"
+#| "                    would be helpful</li>\n"
+#| "                <li>Develop data analysis tools for Lookit researchers </"
+#| "li>\n"
+#| "                <li>Provide technical support to study researchers</li>\n"
+#| "                <li>Assess the quality of data collected on the platform "
+#| "(e.g., how well an observer can tell which\n"
+#| "                    direction children are looking)</li>\n"
+#| "                <li>Evaluate recruitment and family engagement efforts (e."
+#| "g., see how many participants come from rural\n"
+#| "                    vs. urban areas)</li>\n"
+#| "                <li>Recruit participants or researchers to use Lookit (e."
+#| "g., sharing a short video clip of your child\n"
+#| "                    having fun – ONLY if you have chosen to allow use of "
+#| "the video for publicity)</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research studies you have enrolled "
-"in, and information about which studies your\n"
-"                    children are eligible for</li>\n"
-"                <li>Send you information about studies you may be interested "
-"in, reminders to participate in multi-part\n"
-"                    studies, and/or results of studies you have participated "
-"in, subject to your contact preferences\n"
-"                </li>\n"
-"                <li>Improve the Lookit platform: e.g., detect and fix "
-"technical problems or identify new features that\n"
-"                    would be helpful</li>\n"
-"                <li>Develop data analysis tools for Lookit researchers </"
-"li>\n"
-"                <li>Provide technical support to study researchers</li>\n"
-"                <li>Assess the quality of data collected on the platform (e."
-"g., how well an observer can tell which\n"
-"                    direction children are looking)</li>\n"
-"                <li>Evaluate recruitment and family engagement efforts (e."
-"g., see how many participants come from rural\n"
-"                    vs. urban areas)</li>\n"
-"                <li>Recruit participants or researchers to use Lookit (e.g., "
-"sharing a short video clip of your child\n"
-"                    having fun – ONLY if you have chosen to allow use of the "
-"video for publicity)</li>\n"
-"            </ul>\n"
-"            "
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "                <li>Fornirti gli studi di ricerca a cui ti sei iscritto e "
@@ -2456,17 +3586,28 @@ msgstr ""
 "del video per scopi pubblicitari)</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:100
+#: web/templates/web/privacy.html:113
+#, fuzzy
+#| msgid ""
+#| "Researchers use the data collected in their studies to address particular "
+#| "scientific questions. It may\n"
+#| "                also turn out that data collected for one study can help "
+#| "to answer a related question later on. If\n"
+#| "                researchers are using any additional information about "
+#| "you in their study, beyond what is collected on\n"
+#| "                Lookit – for instance, if you are participating in a "
+#| "follow-up online session for an in-person study –\n"
+#| "                they must tell you that in the study consent form."
 msgid ""
 "Researchers use the data collected in their studies to address particular "
 "scientific questions. It may\n"
-"                also turn out that data collected for one study can help to "
+"            also turn out that data collected for one study can help to "
 "answer a related question later on. If\n"
-"                researchers are using any additional information about you "
-"in their study, beyond what is collected on\n"
-"                Lookit – for instance, if you are participating in a follow-"
-"up online session for an in-person study –\n"
-"                they must tell you that in the study consent form."
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
 msgstr ""
 "I ricercatori utilizzano i dati raccolti nei loro studi per affrontare "
 "particolari domande di ricerca. Potrebbe anche\n"
@@ -2479,7 +3620,7 @@ msgstr ""
 "                sono tenuti a comunicartelo nel modulo di consenso allo "
 "studio."
 
-#: web/templates/frontpages/privacy.html:106
+#: web/templates/web/privacy.html:120
 msgid ""
 "There are some basic rules about how personal information may be used that "
 "all Lookit researchers agree to, including:"
@@ -2487,17 +3628,28 @@ msgstr ""
 "Ci sono alcune regole di base su come possono essere utilizzate le "
 "informazioni personali che tutti i ricercatori di Lookit accettano, tra cui:"
 
-#: web/templates/frontpages/privacy.html:107
+#: web/templates/web/privacy.html:122
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>They may not use usernames, child nicknames, or "
+#| "contact information as a subject of research.</li>\n"
+#| "                <li>They may contact families by postal mail only in "
+#| "order to send compensation for study participation\n"
+#| "                    or materials needed for participation.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>They may not use usernames, child nicknames, or contact "
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
 "information as a subject of research.</li>\n"
-"                <li>They may contact families by postal mail only in order "
-"to send compensation for study participation\n"
-"                    or materials needed for participation.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "\n"
 "          <ul>\n"
@@ -2508,14 +3660,20 @@ msgstr ""
 "                    o materiali necessari per la partecipazione.</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:114
-#: web/templates/frontpages/privacy.html:163
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+#, fuzzy
+#| msgid ""
+#| "If you have concerns about any of these purposes, or how we communicate "
+#| "with you, please contact us at\n"
+#| "                dataprotection@mit.edu. We will always respect a request "
+#| "by you to stop processing your personal\n"
+#| "                information (subject to our legal obligations)."
 msgid ""
 "If you have concerns about any of these purposes, or how we communicate with "
 "you, please contact us at\n"
-"                dataprotection@mit.edu. We will always respect a request by "
-"you to stop processing your personal\n"
-"                information (subject to our legal obligations)."
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
 msgstr ""
 "In caso di dubbi su uno qualsiasi di questi scopi o su come comunichiamo con "
 "te, contattaci all'indirizzo\n"
@@ -2523,12 +3681,11 @@ msgstr ""
 "di interrompere l'elaborazione dei tuoi dati personali\n"
 "                (soggetti ai nostri obblighi legali)."
 
-#: web/templates/frontpages/privacy.html:118
-#: web/templates/frontpages/privacy.html:171
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
 msgid "How your information is stored and secured"
 msgstr "Come vengono archiviate e protette le tue informazioni"
 
-#: web/templates/frontpages/privacy.html:120
+#: web/templates/web/privacy.html:138
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2553,23 +3710,23 @@ msgstr "Come vengono archiviate e protette le tue informazioni"
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection, "
-"and all video data is encrypted at rest on\n"
-"                the storage systems used by Lookit to provide data to "
-"researchers. Researchers are responsible for their\n"
-"                own secure storage of data once they obtain it from Lookit. "
-"You should be aware, however, that since the\n"
-"                internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be accessed,\n"
-"                disclosed, altered, or destroyed by breach of any of our "
-"physical, technical, or managerial safeguards.\n"
-"                It's your responsibility to protect the security of your "
-"account details, including your username and\n"
-"                password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
 msgstr ""
 "Abbiamo implementato misure di sicurezza standard del settore progettate per "
 "proteggere le informazioni personali\n"
@@ -2591,25 +3748,37 @@ msgstr ""
 "del tuo account, inclusi nome utente e\n"
 "                password."
 
-#: web/templates/frontpages/privacy.html:131
-#: web/templates/frontpages/privacy.html:182
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
 msgid "How long we keep your personal information"
 msgstr "Per quanto tempo conserviamo le tue informazioni personali"
 
-#: web/templates/frontpages/privacy.html:133
+#: web/templates/web/privacy.html:153
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you wish\n"
+#| "                to remove your account, we will retain a core set of "
+#| "information about you to fulfill administrative\n"
+#| "                tasks and legal obligations. If you have participated in "
+#| "Lookit studies, the personal information\n"
+#| "                already shared with those researchers may not generally "
+#| "be ‘taken back,’ as it is part of a scientific\n"
+#| "                dataset and removing your data could affect already "
+#| "published findings."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you wish\n"
-"                to remove your account, we will retain a core set of "
-"information about you to fulfill administrative\n"
-"                tasks and legal obligations. If you have participated in "
-"Lookit studies, the personal information\n"
-"                already shared with those researchers may not generally be "
-"‘taken back,’ as it is part of a scientific\n"
-"                dataset and removing your data could affect already "
-"published findings."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
 msgstr ""
 "Riteniamo che il nostro rapporto con la nostra comunità di ricerca duri "
 "tutta la vita. Ciò significa che manterremo\n"
@@ -2625,31 +3794,42 @@ msgstr ""
 "                 e la rimozione dei dati potrebbe influire sui risultati già "
 "pubblicati."
 
-#: web/templates/frontpages/privacy.html:144
+#: web/templates/web/privacy.html:165
+#, fuzzy
+#| msgid ""
+#| "We may collect basic biographic/contact information about you and your "
+#| "representative organization,\n"
+#| "                including name, title, business addresses, phone numbers, "
+#| "and email addresses."
 msgid ""
 "We may collect basic biographic/contact information about you and your "
 "representative organization,\n"
-"                including name, title, business addresses, phone numbers, "
-"and email addresses."
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
 msgstr ""
 "Potremmo raccogliere informazioni biografiche/di contatto di base su di te e "
 "sulla tua organizzazione rappresentativa,\n"
 "                inclusi nome, titolo, indirizzi aziendali, numeri di "
 "telefono e indirizzi e-mail."
 
-#: web/templates/frontpages/privacy.html:149
+#: web/templates/web/privacy.html:172
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is that which you have "
+#| "provided to us when registering\n"
+#| "                to use Lookit, updating your profile, or creating or "
+#| "editing a study."
 msgid ""
 "The information we collect and maintain about you is that which you have "
 "provided to us when registering\n"
-"                to use Lookit, updating your profile, or creating or editing "
-"a study."
+"        to use Lookit, updating your profile, or creating or editing a study."
 msgstr ""
 "Le informazioni che raccogliamo e conserviamo su di te sono quelle che ci "
 "hai fornito al momento della registrazione\n"
 "                per utilizzare Lookit, per aggiornare il tuo profilo, creare "
 "o modificare uno studio."
 
-#: web/templates/frontpages/privacy.html:154
+#: web/templates/web/privacy.html:179
 msgid ""
 "We use your personal information for a number of legitimate purposes, "
 "including the performance of contractual obligations. Specifically, we use "
@@ -2659,18 +3839,30 @@ msgstr ""
 "incluso l'adempimento degli obblighi contrattuali. In particolare, "
 "utilizziamo le tue informazioni personali per:"
 
-#: web/templates/frontpages/privacy.html:155
+#: web/templates/web/privacy.html:181
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Provide you with the research services for which you "
+#| "have enrolled. </li>\n"
+#| "                <li>Perform administrative tasks and for internal record "
+#| "keeping purposes.</li>\n"
+#| "                <li>Create and analyze aggregated (fully anonymized) "
+#| "information about our users for statistical\n"
+#| "                    research purposes in support of our mission.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research services for which you "
-"have enrolled. </li>\n"
-"                <li>Perform administrative tasks and for internal record "
-"keeping purposes.</li>\n"
-"                <li>Create and analyze aggregated (fully anonymized) "
-"information about our users for statistical\n"
-"                    research purposes in support of our mission.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "                <li>Fornirti i servizi di ricerca per i quali ti sei "
@@ -2682,11 +3874,11 @@ msgstr ""
 "                    di ricerca a sostegno della nostra missione.</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:169
+#: web/templates/web/privacy.html:196
 msgid "We do not share your personal information with any third parties."
 msgstr "Non condividiamo le tue informazioni personali con terze parti."
 
-#: web/templates/frontpages/privacy.html:173
+#: web/templates/web/privacy.html:201
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2707,19 +3899,19 @@ msgstr "Non condividiamo le tue informazioni personali con terze parti."
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection. "
-"You should be aware, however, that since\n"
-"                the internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be\n"
-"                accessed, disclosed, altered, or destroyed by breach of any "
-"of our physical, technical, or managerial\n"
-"                safeguards. It's your responsibility to protect the security "
-"of your account details, including your\n"
-"                username and password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
 msgstr ""
 "Abbiamo implementato misure di sicurezza standard del settore progettate per "
 "proteggere le informazioni personali\n"
@@ -2737,15 +3929,24 @@ msgstr ""
 "del tuo account, inclusi nome utente e\n"
 "                password."
 
-#: web/templates/frontpages/privacy.html:184
+#: web/templates/web/privacy.html:214
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you no\n"
+#| "                longer wish to hear from Lookit, we will retain a core "
+#| "set of information about you to fulfill\n"
+#| "                administrative tasks and legal obligations."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you no\n"
-"                longer wish to hear from Lookit, we will retain a core set "
-"of information about you to fulfill\n"
-"                administrative tasks and legal obligations."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
 msgstr ""
 "Riteniamo che il nostro rapporto con la nostra comunità di ricerca duri "
 "tutta la vita. Ciò significa che manterremo un registro per te fino al "
@@ -2754,25 +3955,36 @@ msgstr ""
 "ristretta di informazioni fondamentali su di te per adempiere a compiti di "
 "livello amministrativo e obblighi legali."
 
-#: web/templates/frontpages/privacy.html:189
+#: web/templates/web/privacy.html:220
 msgid "For everyone"
 msgstr "Per tutti"
 
-#: web/templates/frontpages/privacy.html:191
+#: web/templates/web/privacy.html:221
 msgid "Rights for individuals in the European Economic Area"
 msgstr "Diritti degli individui nello Spazio economico europeo"
 
-#: web/templates/frontpages/privacy.html:192
+#: web/templates/web/privacy.html:224
+#, fuzzy
+#| msgid ""
+#| "You have the right in certain circumstances to (1) access your personal "
+#| "information; (2) to correct or\n"
+#| "                erase information; (3) restrict processing; and (4) "
+#| "object to communications, direct marketing, or\n"
+#| "                profiling. To the extent applicable, the EU’s General "
+#| "Data Protection Regulation provides further\n"
+#| "                information about your rights. You also have the right to "
+#| "lodge complaints with your national or\n"
+#| "                regional data protection authority."
 msgid ""
 "You have the right in certain circumstances to (1) access your personal "
 "information; (2) to correct or\n"
-"                erase information; (3) restrict processing; and (4) object "
-"to communications, direct marketing, or\n"
-"                profiling. To the extent applicable, the EU’s General Data "
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
 "Protection Regulation provides further\n"
-"                information about your rights. You also have the right to "
-"lodge complaints with your national or\n"
-"                regional data protection authority."
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
 msgstr ""
 "Hai il diritto in determinate circostanze di (1) accedere alle tue "
 "informazioni personali; (2) correggere o\n"
@@ -2784,23 +3996,40 @@ msgstr ""
 "alla tua\n"
 "                autorità nazionale o regionale per la protezione dei dati."
 
-#: web/templates/frontpages/privacy.html:198
+#: web/templates/web/privacy.html:231
+#, fuzzy
+#| msgid ""
+#| "If you are inclined to exercise these rights, we request an opportunity "
+#| "to discuss with you any concerns\n"
+#| "                you may have. To protect the personal information we "
+#| "hold, we may also request further information to\n"
+#| "                verify your identify when exercising these rights. Upon a "
+#| "request to erase information, we will maintain\n"
+#| "                a core set of personal data to ensure we do not contact "
+#| "you inadvertently in the future, as well as any\n"
+#| "                information necessary for archival purposes. We may also "
+#| "need to retain some financial information for\n"
+#| "                legal purposes, including US IRS compliance. In the event "
+#| "of an actual or threatened legal claim, we may\n"
+#| "                retain your information for purposes of establishing, "
+#| "defending against or exercising our rights with\n"
+#| "                respect to such claim."
 msgid ""
 "If you are inclined to exercise these rights, we request an opportunity to "
 "discuss with you any concerns\n"
-"                you may have. To protect the personal information we hold, "
-"we may also request further information to\n"
-"                verify your identify when exercising these rights. Upon a "
-"request to erase information, we will maintain\n"
-"                a core set of personal data to ensure we do not contact you "
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
 "inadvertently in the future, as well as any\n"
-"                information necessary for archival purposes. We may also "
-"need to retain some financial information for\n"
-"                legal purposes, including US IRS compliance. In the event of "
-"an actual or threatened legal claim, we may\n"
-"                retain your information for purposes of establishing, "
-"defending against or exercising our rights with\n"
-"                respect to such claim."
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
 msgstr ""
 "Se siete inclini ad esercitare questi diritti, vi chiediamo l'opportunità di "
 "discutere con voi qualsiasi preoccupazione\n"
@@ -2819,15 +4048,24 @@ msgstr ""
 "difendere o esercitare i nostri diritti\n"
 "                rispetto a tale rivendicazione."
 
-#: web/templates/frontpages/privacy.html:207
+#: web/templates/web/privacy.html:241
+#, fuzzy
+#| msgid ""
+#| "By providing information directly to Lookit, you consent to the transfer "
+#| "of your personal information\n"
+#| "                outside of the European Economic Area to the United "
+#| "States. You understand that the current laws and\n"
+#| "                regulations of the United States may not provide the same "
+#| "level of protection as the data and privacy\n"
+#| "                laws and regulations of the EEA."
 msgid ""
 "By providing information directly to Lookit, you consent to the transfer of "
 "your personal information\n"
-"                outside of the European Economic Area to the United States. "
-"You understand that the current laws and\n"
-"                regulations of the United States may not provide the same "
-"level of protection as the data and privacy\n"
-"                laws and regulations of the EEA."
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
 msgstr ""
 "Fornendo informazioni direttamente a Lookit, acconsenti al trasferimento dei "
 "tuoi dati personali\n"
@@ -2837,30 +4075,36 @@ msgstr ""
 "di protezione dei dati e della privacy\n"
 "               delle leggi e regolamenti del SEE."
 
-#: web/templates/frontpages/privacy.html:212
+#: web/templates/web/privacy.html:246
 msgid ""
 "You are under no statutory or contractual obligation to provide any personal "
 "data to us."
 msgstr ""
 "Non hai alcun obbligo legale o contrattuale di fornirci dati personali."
 
-#: web/templates/frontpages/privacy.html:214
+#: web/templates/web/privacy.html:248
 msgid "Additional Information"
 msgstr "Informazioni aggiuntive"
 
-#: web/templates/frontpages/privacy.html:216
+#: web/templates/web/privacy.html:251
+#, fuzzy
+#| msgid ""
+#| "We may change this Privacy Statement from time to time. If we make any "
+#| "significant changes in the way we\n"
+#| "                treat your personal information we will make this clear "
+#| "on our website or by contacting you directly."
 msgid ""
 "We may change this Privacy Statement from time to time. If we make any "
 "significant changes in the way we\n"
-"                treat your personal information we will make this clear on "
-"our website or by contacting you directly."
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
 msgstr ""
 "Possiamo modificare questa dichiarazione sulla privacy di tanto in tanto. Se "
 "apportiamo cambiamenti significativi nel modo in cui\n"
 "                trattiamo le tue informazioni personali lo renderemo chiaro "
 "sul nostro sito web o contattandoti direttamente."
 
-#: web/templates/frontpages/privacy.html:220
+#: web/templates/web/privacy.html:255
 msgid ""
 "The controller for your personal information is MIT. We can be contacted at "
 "dataprotection@mit.edu."
@@ -2868,508 +4112,131 @@ msgstr ""
 "Il responsabile del trattamento dei tuoi dati personali è il MIT. Possiamo "
 "essere contattati all'indirizzo dataprotection@mit.edu."
 
-#: web/templates/frontpages/privacy.html:222
+#: web/templates/web/privacy.html:257
 msgid "This policy was last updated in June 2018."
 msgstr "Questa policy è stata aggiornata l'ultima volta nel giugno 2018."
 
-#: web/templates/frontpages/scientists.html:27
-msgid "Meet the Lookit team"
-msgstr "Incontra il team di Lookit"
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
 
-#: web/templates/frontpages/scientists.html:33
-msgid "Core Team"
-msgstr "Squadra principale"
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
 
-#: web/templates/frontpages/scientists.html:38
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
 msgid ""
-"Rico is Lookit's lead software engineer, working on planning and adding "
-"features for both participants and researchers."
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
 msgstr ""
-"Rico è l'ingegnere capo del software di Lookit e lavora alla pianificazione "
-"e all'aggiunta di funzionalità sia per i partecipanti che per i ricercatori"
 
-#: web/templates/frontpages/scientists.html:43
-msgid ""
-"Laura is the PI of the Early Childhood Cognition Lab. She conducts research "
-"about how children arrive at a common-sense understanding of the physical "
-"and social world through exploration and instruction."
-msgstr ""
-"Laura è il PI dell' Early Childhood Cognition Lab. Conduce ricerche su come "
-"i bambini arrivano a una comprensione di senso comune del mondo fisico e "
-"sociale attraverso l'esplorazione e l'istruzione."
-
-#: web/templates/frontpages/scientists.html:49
-msgid ""
-"Kim started Lookit as a graduate student, and now runs the project as a "
-"research scientist in the Early Childhood Cognition Lab. Her three children "
-"frequently provide feedback on studies."
-msgstr ""
-"Kim ha iniziato a lavorare con Lookit da studentessa e ora gestisce il "
-"progetto come ricercatrice all'Early Childhood Cognition Lab. I suoi tre "
-"figli forniscono spesso un feedback sugli studi."
-
-#: web/templates/frontpages/scientists.html:54
-msgid ""
-"Mark organizes the Lookit Working Groups, which are groups of researchers "
-"working to improve Lookit in a variety of ways."
-msgstr ""
-"Mark organizza i gruppi di lavoro di Lookit che sono gruppi di ricercatori "
-"che lavorano per migliorare la piattaforma in diversi modi."
-
-#: web/templates/registration/logged_out.html:6
-msgid "You've successfully logged out."
-msgstr "Ti sei disconnesso con successo."
-
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr "Le tue credenziali di accesso non funzionano. Si prega di riprovare."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:45
-msgid "Login"
-msgstr "Accesso"
-
-#: web/templates/registration/login.html:34
-msgid "Forgot password?"
-msgstr "Hai dimenticato la password?"
-
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Nuovo su Lookit?"
-
-#: web/templates/registration/login.html:36
-msgid "Register your family!"
-msgstr "Registra la tua famiglia!"
-
-#: web/templates/registration/password_change_done.html:11
-msgid "Password changed"
-msgstr "Password cambiata"
-
-#: web/templates/registration/password_change_done.html:15
-msgid "Your password was changed."
-msgstr "La tua password é stata cambiata."
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Documentation"
-msgstr "Documentazione"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Change password"
-msgstr "Cambia la password"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Log out"
-msgstr "Disconnettiti"
-
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
-msgid "Home"
-msgstr "Home"
-
-#: web/templates/registration/password_change_form.html:8
-msgid "Password change"
-msgstr "Modifica della password"
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the error below."
-msgstr "Correggi l'errore di seguito."
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the errors below."
-msgstr "Si prega di correggere gli errori di seguito."
-
-#: web/templates/registration/password_change_form.html:26
-msgid ""
-"Please enter your old password, for security's sake, and then enter your new "
-"password twice so we can verify you typed it in correctly."
-msgstr ""
-"Inserisci la tua vecchia password, per motivi di sicurezza, quindi inserisci "
-"la nuova password due volte in modo da verificare di averla digitata "
-"correttamente."
-
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
-msgid "Change my password"
-msgstr "Cambia la mia password"
-
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Reimpostazione della password completata"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "La tua password è stata impostata. Puoi andare avanti e accedere ora."
-
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "Accesso"
-
-#: web/templates/registration/password_reset_confirm.html:11
-msgid "Password reset confirmation"
-msgstr "Conferma della reimpostazione della password"
-
-#: web/templates/registration/password_reset_confirm.html:17
-msgid ""
-"Please enter your new password twice so we can verify you typed it in "
-"correctly."
-msgstr ""
-"Inserisci la tua nuova password due volte in modo da verificare di averla "
-"digitata correttamente."
-
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nuova password:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Conferma password:"
-
-#: web/templates/registration/password_reset_confirm.html:37
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"Il link per la reimpostazione della password non era valido, probabilmente "
-"perché è già stato utilizzato. Richiedi una nuova reimpostazione della "
-"password."
-
-#: web/templates/registration/password_reset_done.html:11
-msgid "Password reset link sent"
-msgstr "Ti abbiamo inviato il link per reimpostare la password"
-
-#: web/templates/registration/password_reset_done.html:15
-msgid ""
-"If an account exists with the email you entered, we've emailed instructions "
-"for resetting your password and you should receive them shortly."
-msgstr ""
-"Se esiste un account con l'email che hai inserito, ti abbiamo inviato per "
-"email le istruzioni per reimpostare la tua password e dovresti riceverle a "
-"breve."
-
-#: web/templates/registration/password_reset_done.html:17
-msgid ""
-"If you don't receive an email, please check your spam folder and make sure "
-"you've entered the address you registered with. (You won't get an email "
-"unless there's already an account for that email address!)"
-msgstr ""
-"Se non ricevi un'email, controlla la tua cartella spam e assicurati di aver "
-"inserito l'indirizzo con cui ti sei registrato. (Non riceverai un'email se "
-"non c'è già un account per quell'indirizzo email!)"
-
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
-msgid ""
-"You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
-msgstr ""
-"Hai ricevuto questa email perché hai richiesto una reimpostazione della "
-"password per il tuo account utente su %(site_name)s."
-
-#: web/templates/registration/password_reset_email.html:4
-msgid "Please go to the following page and choose a new password:"
-msgstr "Vai alla pagina seguente e scegli una nuova password:"
-
-#: web/templates/registration/password_reset_email.html:8
-msgid "Your username, in case you've forgotten:"
-msgstr "Il tuo nome utente, nel caso l'avessi dimenticato:"
-
-#: web/templates/registration/password_reset_email.html:10
-msgid "Thanks for using our site!"
-msgstr "Grazie per aver utilizzato il nostro sito!"
-
-#: web/templates/registration/password_reset_email.html:12
-#, python-format
-msgid "The %(site_name)s team"
-msgstr "Il team di %(site_name)s"
-
-#: web/templates/registration/password_reset_form.html:11
-msgid "Password reset"
-msgstr "Ripristino della password"
-
-#: web/templates/registration/password_reset_form.html:15
-msgid ""
-"Forgotten your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Hai dimenticato la tua password? Inserisci il tuo indirizzo email di seguito "
-"e ti invieremo un'email con le istruzioni per impostarne una nuova."
-
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Indirizzo email:"
-
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Reimposta la mia password"
-
-#: web/templates/web/_navigation.html:17
-msgid "Experimenter"
-msgstr "Sperimentatore"
-
-#: web/templates/web/_navigation.html:28 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Studi"
-
-#: web/templates/web/_navigation.html:29
-msgid "FAQ"
-msgstr "FAQ"
-
-#: web/templates/web/_navigation.html:30
-msgid "The Scientists"
-msgstr "Gli scienziati"
-
-#: web/templates/web/_navigation.html:31
-msgid "Resources"
-msgstr "Risorse"
-
-#: web/templates/web/_navigation.html:40
-msgid "Hi"
-msgstr "Ciao"
-
-#: web/templates/web/_navigation.html:42
-msgid "Logout"
-msgstr "Disconnettiti"
-
-#: web/templates/web/_navigation.html:44
-msgid "Sign up"
-msgstr "Iscriviti"
-
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
-msgid "Child"
-msgstr "Bambino"
-
-#: web/templates/web/child-update.html:26
-msgid "Back to Children List"
-msgstr "Torna alla lista dei bambini"
-
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Aggiorna"
-
-#: web/templates/web/child-update.html:41
-msgid "Delete"
-msgstr "Elimina"
-
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Annulla"
-
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Compleanno vuoto"
-
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " giorno"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " giorni"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " mese"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " mesi"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " anno"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " anni"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Aggiungi figlio"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Nascondi modulo"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nome"
-
-#: web/templates/web/children-list.html:121
-msgid "Update child"
-msgstr "Aggiorna bambino"
-
-#: web/templates/web/children-list.html:128
-msgid "No child profiles registered!"
-msgstr "Nessun profilo bambino registrato!"
-
-#: web/templates/web/demographic-data-update.html:4
-msgid "Update demographics"
-msgstr "Aggiorna i dati demografici"
-
-#: web/templates/web/demographic-data-update.html:89
-msgid ""
-"One reason we are developing Internet-based experiments is to represent a "
-"more diverse group of families in our research. Your answers to these "
-"questions will help us understand what audience we reach, as well as how "
-"factors like speaking multiple languages or having older siblings affect "
-"children's learning."
-msgstr ""
-"Uno dei motivi per cui stiamo sviluppando esperimenti on-line è "
-"rappresentare un gruppo più diversificato di famiglie nella nostra ricerca. "
-"Le tue risposte a queste domande ci aiuteranno a capire quale pubblico "
-"raggiungiamo e in che modo fattori come parlare più lingue o avere fratelli "
-"maggiori influenzano l'apprendimento dei bambini."
-
-#: web/templates/web/demographic-data-update.html:90
-msgid ""
-"Even if you allow your study videos to be published for scientific or "
-"publicity purposes, your demographic information is never published in "
-"conjunction with your video."
-msgstr ""
-"Anche se acconsenti alla pubblicazione dei tuoi video per scopi scientifici "
-"o pubblicitari, le tue informazioni demografiche non verranno mai pubblicate "
-"insieme al tuo video."
-
-#: web/templates/web/participant-email-preferences.html:27
-msgid "I would like to be contacted when:"
-msgstr "Vorrei essere contattato quando:"
-
-#: web/templates/web/participant-signup.html:18
-msgid "Create Participant Account"
-msgstr "Creare un'account per partecipare"
-
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
-msgstr ""
-"Crea un account familiare per iniziare a partecipare agli studi di Lookit!"
-
-#: web/templates/web/participant-signup.html:31
-msgid ""
-"By clicking 'Create Account', I agree that I have read and accepted the "
-msgstr ""
-"Facendo clic su \"Crea account\", accetto di aver letto e accettato il "
-
-#: web/templates/web/participant-signup.html:31
-msgid "Privacy Statement"
-msgstr "Informativa sulla Privacy"
-
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Creare un profilo"
-
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Studi passati"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
+#: web/templates/web/studies-history.html:15
+#, fuzzy
+#| msgid "Video"
+msgid "Next Video"
+msgstr "Video"
+
+#: web/templates/web/studies-history.html:31
 msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
 msgstr ""
-"Il tuo account non ha accesso a questa pagina. Per procedere, effettua il "
-"login con un account autorizzato."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Effettua il login per vedere questa pagina."
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Studi disponibili"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "I tuoi studi passati"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Qui puoi visualizzare i tuoi studi e vedere i commenti lasciati dai "
 "ricercatori:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Anteprima dello studio"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Idoneaità:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contatta:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Stai ancora raccogliendo dati?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Sì"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "No"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Compenso: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Compenso"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Risposte dello studio"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "Video"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Data"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Stato del consenso"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Approvato"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Il tuo video per il consenso è stato esaminato da un ricercatore ed è valido."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "In sospeso"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr ""
 "Il tuo video per il consenso non è stato ancora esaminato da un ricercatore."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Non valido"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -3380,175 +4247,177 @@ msgstr ""
 "dati di questa sessione non verranno visualizzati o utilizzati dai "
 "ricercatori dello studio."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr ""
 "Nessuna informazione sullo stato della revisione del video per il consenso."
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "Feedback"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "Nessuno"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Non hai ancora partecipato a nessuno studio."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Studi disponibili"
+#: web/templates/web/studies-history.html:147
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Non hai ancora partecipato a nessuno studio."
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studi"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Tieni presente che per partecipare è necessario un laptop o un computer "
-"desktop (non un dispositivo mobile) con Chrome o Firefox."
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Vedi i dettagli"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "Non stiamo conducendo alcuno studio in questo momento!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"Cerchi altri modi per contribuire alla ricerca da casa? Dai un'occhiata a <a "
-"href=\"https://childrenhelpingscience.com/\" target=\"_blank\" rel="
-"\"noreferrer noopener\">Children Helping Science</a> per ulteriori studi!"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "giorni"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " fino a "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " quando "
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Risorse"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Panoramica dello studio"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Torna alla lista"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Criteri di ammissione"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Durata"
-
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Compenso"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Che succede"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Cosa stiamo studiando"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Questo studio è condotto da"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Vorresti partecipare a questo studio?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Accedi per partecipare"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "Aggiungi il profilo del bambino a "
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "anteprima"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "partecipa"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "adesso"
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Crea un runner dell'esperimento per l'anteprima"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Accedi per partecipare"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "Aggiungi il profilo del bambino a "
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "Completa il sondaggio demografico a "
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Partecipare"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Che succede"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Cosa stiamo studiando"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Durata"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Questo studio è condotto da"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Vorresti partecipare a questo studio?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Seleziona un bambino:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Nessuno selezionato"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Suo figlio è più giovane della fascia di età raccomandata per questo studio. "
 "Se puoi aspettare <span id='wait-until'>until</span> sarà abbastanza grande "
 "e saremo in grado di utilizzare i dati raccolti nella nostra ricerca!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Suo figlio ha un'età superiore alla fascia di età raccomandata per questo "
 "studio. Puoi comunque provare lo studio, ma non saremo in grado di "
 "utilizzare i dati raccolti nella nostra ricerca."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Suo figlio non soddisfa i criteri di ammissione elencati per questo studio. "
 "Puoi comunque provare lo studio, ma non saremo in grado di utilizzare i dati "
 "raccolti nella nostra ricerca. Si prega di contattare i ricercatori dello "
 "studio"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Crea un runner dell'esperimento per l'anteprima"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Partecipare"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "adesso"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -3556,31 +4425,89 @@ msgstr ""
 "Per visualizzare facilmente cosa succede mentre aggiorni il protocollo di "
 "studio, aggiungi ai segnalibri l'URL a cui ti invia il pulsante sopra."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Iscriviti"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Tieni presente che per partecipare è necessario un laptop o un computer "
+"desktop (non un dispositivo mobile) con Chrome o Firefox."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "Partecipante creato."
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "Dati demografici salvati."
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "Bambino aggiunto."
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "Bambino eliminato."
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "Bambino aggiornato."
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "Preferenze email salvate."
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -3591,14 +4518,412 @@ msgstr ""
 "potrebbe essere completato o attualmente in pausa. Se pensi che si tratti di "
 "un errore, contatta {study.contact_info}"
 
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr ""
+#~ "La tua password non può essere troppo simile alle tue informazioni "
+#~ "personali."
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "La tua password deve contenere almeno 16 caratteri."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "La tua password non può essere una password comunemente utilizzata."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "La tua password non può essere interamente numerica."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "In quale categoria(e) si identifica la tua famiglia?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Solo risposte numeriche: un'ipotesi approssimativa va bene!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Che lingua (e) parla la tua famiglia a casa?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr ""
+#~ "Qual è il livello di istruzione più alto completato dal tuo coniuge?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Quanti libri per bambini ci sono in casa tua?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Se la risposta varia a causa di accordi di affidamento condiviso o di "
+#~ "viaggio, inserisci il numero di genitori / tutori con cui vivono "
+#~ "abitualmente i tuoi figli o spiega."
+
+#~ msgid "other"
+#~ msgstr "altro"
+
+#~ msgid "3 or more"
+#~ msgstr "3 o più"
+
+#~ msgid "varies"
+#~ msgstr "varia"
+
+#~ msgid "My Account"
+#~ msgstr "Il mio account"
+
+#~ msgid "Last Active:"
+#~ msgstr "Ultimo attivo:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "ID globale partecipante:"
+
+#~ msgid "Dashboard"
+#~ msgstr "Pannello di controllo"
+
+#~ msgid "Argentinian Spanish"
+#~ msgstr "Spagnolo argentino"
+
+#~ msgid "Canadian French"
+#~ msgstr "Francese canadese"
+
+#~ msgid "Norwegian Bokmål"
+#~ msgstr "Norvegese Bokmål"
+
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "Portoghese brasiliano"
+
+#~ msgid "Simplified Chinese"
+#~ msgstr "Cinese semplificato"
+
+#~ msgid "Yue"
+#~ msgstr "Cantonese"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#~ msgid "How can we participate online?"
+#~ msgstr "Come possiamo partecipare online?"
+
+#~ msgid ""
+#~ "\n"
+#~ "                            <p>If you have a child and would like to "
+#~ "participate, create an account and take a look at what we have available "
+#~ "for your child's age range. You'll need a working webcam to participate.</"
+#~ "p>\n"
+#~ "                                <p>When you select a study, you'll be "
+#~ "asked to read a consent form and record yourself stating that you and "
+#~ "your child agree to participate. Then we'll guide you through what will "
+#~ "happen during the study. Depending on your child's age, your child may "
+#~ "answer questions directly or we may be looking for indirect signs of what "
+#~ "she thinks is going on--like how long she looks at a surprising outcome.</"
+#~ "p>\n"
+#~ "                                <p>Some portions of the study will be "
+#~ "automatically recorded using your webcam and sent securely to the Lookit "
+#~ "platform. Trained researchers will watch the video and record your "
+#~ "child's responses--for instance, which way he pointed, or how long she "
+#~ "looked at each image. We'll put these together with responses from lots "
+#~ "of other children to learn more about how kids think!</p>\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ "                            <p>Se hai un figlio e desideri partecipare, "
+#~ "crea un account e dai un'occhiata a ciò che è disponibile per la fascia "
+#~ "di età di tuo figlio. Avrai bisogno di una webcam funzionante per "
+#~ "partecipare.</p>\n"
+#~ "                                <p>Quando selezioni uno studio, ti verrà "
+#~ "chiesto di leggere un modulo di consenso e registrarti affermando che tu "
+#~ "e tuo figlio acconsentite a partecipare. Quindi ti guideremo attraverso "
+#~ "ciò che accadrà durante lo studio. A seconda della sua età, tuo figlio "
+#~ "potrebbe rispondere direttamente alle domande o potremmo cercare segni "
+#~ "indiretti di ciò che pensa stia succedendo--ad esempio per quanto tempo "
+#~ "osserva un risultato sorprendente.</p>\n"
+#~ "                                <p>Alcune parti dello studio verranno "
+#~ "registrate automaticamente utilizzando la tua webcam e inviate in modo "
+#~ "sicuro alla piattaforma Lookit. Ricercatori qualificati guarderanno il "
+#~ "video e registreranno le risposte di tuo figlio--ad esempio, da che parte "
+#~ "ha indicato o per quanto tempo ha guardato ogni immagine. Li metteremo "
+#~ "insieme alle risposte di molti altri partecipati per saperne di più su "
+#~ "come pensano i bambini!</p>"
+
+#~ msgid ""
+#~ "Any researcher with questions about how kids learn and grow can propose a "
+#~ "Lookit study! Each institution using Lookit has to sign a contract with "
+#~ "MIT where they agree to the <a href='/termsofuse'>Terms of Use</a> and "
+#~ "certify that their studies will be reviewed and approved by an "
+#~ "institutional review board. Studies are also subject to approval by "
+#~ "Lookit. As of June 2020 we have agreements with 20 universities!"
+#~ msgstr ""
+#~ "Qualsiasi ricercatore con domande su come i bambini imparano e crescono "
+#~ "può proporre uno studio Lookit! Ogni istituzione che utilizza LookIt deve "
+#~ "firmare un contratto con il MIT in cui accetta i <a \n"
+#~ "href='/termsofuse'>Terms of Use</a> e certifica che i suoi studi saranno "
+#~ "esaminati e approvati da un comitato di revisione istituzionale. Inoltre, "
+#~ "gli studi sono soggetti all'approvazione di Lookit. Da giugno 2020 "
+#~ "abbiamo accordi con 20 università!"
+
+#~ msgid ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+#~ msgstr ""
+#~ "https://storage.googleapis.com/lookit-\n"
+#~ "staging/static/videos/consent.mp4"
+
+#~ msgid ""
+#~ "Traditionally, developmental studies happen in a quiet room in a "
+#~ "university lab. Researchers call or email local parents to see if they'd "
+#~ "like to take part and schedule an appointment for them to come visit the "
+#~ "lab. Why complement these in-lab studies with online ones? We're hoping "
+#~ "to..."
+#~ msgstr ""
+#~ "Tradizionalmente, gli studi sullo sviluppo avvengono in una stanza "
+#~ "tranquilla in un laboratorio universitario. I ricercatori chiamano o "
+#~ "inviano un'e-mail ai genitori locali per vedere se desiderano partecipare "
+#~ "e fissare un appuntamento per andare in laboratorio. Perché integrare "
+#~ "questi studi in laboratorio con quelli online? Speriamo di..."
+
+#~ msgid "When will we see the results of the study?"
+#~ msgstr "Quando vedremo i risultati dello studio?"
+
+#~ msgid ""
+#~ "The process of publishing a scientific study, from starting data "
+#~ "collection to seeing the paper in a journal, can take several years. You "
+#~ "can check the Lookit home page for updates on papers, or set your "
+#~ "communication preferences to be notified when we have results from "
+#~ "studies you participated in."
+#~ msgstr ""
+#~ "Il processo di pubblicazione di uno studio scientifico, dall'avvio della "
+#~ "raccolta dei dati alla visualizzazione dell'articolo su una rivista, può "
+#~ "richiedere diversi anni. Puoi controllare la home page di Lookit per gli "
+#~ "aggiornamenti sui documenti o impostare le tue preferenze di "
+#~ "comunicazione per essere avvisato quando avremo i risultati degli studi a "
+#~ "cui hai partecipato."
+
+#~ msgid "Can I get my child's results?"
+#~ msgstr "Posso avere i risultati di mio figlio?"
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                                <p>For some studies, yes! Usually, "
+#~ "developmental researchers only interpret children's abilities and "
+#~ "developmental trends at a group level, and the individual data collected "
+#~ "just isn't very interpretable. But for \"Your baby, the physicist\" and "
+#~ "other longitudinal studies (where you come back for more than one "
+#~ "session), we can sometimes collect enough data to give you a report of "
+#~ "your child's responses after you complete all the sessions.</p>\n"
+#~ "                                <p>Please note that none of the measures "
+#~ "we collect are diagnostic! For instance, while we hope you'll be "
+#~ "interested to learn that your child looked 70%% of the time at videos "
+#~ "where things fell up versus falling down, we won't be able to tell you "
+#~ "whether this means your child is going to be especially good at physics.</"
+#~ "p>\n"
+#~ "                                <p>If you're interested in getting "
+#~ "individual results right away, please see our <a "
+#~ "href='resources'>Resources</a> section for fun at-home activities you can "
+#~ "try with your child.</p>\n"
+#~ "                                "
+#~ msgstr ""
+#~ "\n"
+#~ "                                <p>Per alcuni studi, sì! Di solito, i "
+#~ "ricercatori dello sviluppo interpretano le capacità e le tendenze "
+#~ "evolutive dei bambini solo a livello di gruppo, e i dati individuali "
+#~ "raccolti semplicemente non sono molto interpretabili. Ma per \"Il tuo "
+#~ "bambino, il fisico\" e altri studi longitudinali (in cui torni per più di "
+#~ "una sessione), a volte, possiamo raccogliere dati sufficienti per darti "
+#~ "un resoconto delle risposte di tuo figlio dopo aver completato tutte le "
+#~ "sessioni.</p>\n"
+#~ "                                <p>Tieni presente che nessuna delle "
+#~ "misure che raccogliamo è diagnostica! Ad esempio, anche se speriamo che "
+#~ "ti interesserà sapere che tuo figlio ha guardato il 70 %% delle volte un "
+#~ "video in cui le cose cadevano verso l'alto invece che cadere in basso, "
+#~ "non saremo in grado di dirti se questo significa che tuo figlio sarà "
+#~ "particolarmente bravo in fisica.</p>\n"
+#~ "                                <p>Se sei interessato a ottenere subito "
+#~ "risultati individuali, consulta la nostra sezione <a \n"
+#~ "href='resources'>Resources</a> per divertenti attività  che puoi provare "
+#~ "a casa con tuo figlio.</p>"
+
+#~ msgid "the online child lab"
+#~ msgstr "Il laboratorio online per bambini"
+
+#~ msgid "A project of the MIT Early Childhood Cognition Lab"
+#~ msgstr "Un progetto del MIT Early Childhood Cognition Lab "
+
+#~ msgid "Bringing science home"
+#~ msgstr "Portare la scienza a casa"
+
+#~ msgid ""
+#~ "Here at MIT's Early Childhood Cognition Lab, we're trying a new approach "
+#~ "in developmental psychology: bringing the experiments to you."
+#~ msgstr ""
+#~ "Qui al MIT Early Childhood Cognition Lab, stiamo provando un nuovo "
+#~ "approccio alla psicologia dello sviluppo: portare gli esperimenti nelle "
+#~ "vostre case."
+
+#~ msgid "Help us understand how your child thinks"
+#~ msgstr "Aiutaci a capire come pensa tuo figlio"
+
+#~ msgid ""
+#~ "Your family can contribute to research about how children learn by doing "
+#~ "fun activities together, right in your web browser."
+#~ msgstr ""
+#~ "La tua famiglia può contribuire alla ricerca su come i bambini imparano "
+#~ "svolgendo attività divertenti insieme, direttamente nel tuo browser web."
+
+#~ msgid "Participate whenever and wherever"
+#~ msgstr "Partecipa sempre e ovunque"
+
+#~ msgid ""
+#~ "Log in or create an account at the top right to get started! You can "
+#~ "participate with your child from any computer with a webcam."
+#~ msgstr ""
+#~ "Accedi o crea un account in alto a destra per iniziare! Puoi partecipare "
+#~ "con tuo figlio da qualsiasi computer dotato di webcam."
+
+#~ msgid "Core Team"
+#~ msgstr "Squadra principale"
+
+#~ msgid ""
+#~ "Rico is Lookit's lead software engineer, working on planning and adding "
+#~ "features for both participants and researchers."
+#~ msgstr ""
+#~ "Rico è l'ingegnere capo del software di Lookit e lavora alla "
+#~ "pianificazione e all'aggiunta di funzionalità sia per i partecipanti che "
+#~ "per i ricercatori"
+
+#~ msgid ""
+#~ "Laura is the PI of the Early Childhood Cognition Lab. She conducts "
+#~ "research about how children arrive at a common-sense understanding of the "
+#~ "physical and social world through exploration and instruction."
+#~ msgstr ""
+#~ "Laura è il PI dell' Early Childhood Cognition Lab. Conduce ricerche su "
+#~ "come i bambini arrivano a una comprensione di senso comune del mondo "
+#~ "fisico e sociale attraverso l'esplorazione e l'istruzione."
+
+#~ msgid ""
+#~ "Kim started Lookit as a graduate student, and now runs the project as a "
+#~ "research scientist in the Early Childhood Cognition Lab. Her three "
+#~ "children frequently provide feedback on studies."
+#~ msgstr ""
+#~ "Kim ha iniziato a lavorare con Lookit da studentessa e ora gestisce il "
+#~ "progetto come ricercatrice all'Early Childhood Cognition Lab. I suoi tre "
+#~ "figli forniscono spesso un feedback sugli studi."
+
+#~ msgid ""
+#~ "Mark organizes the Lookit Working Groups, which are groups of researchers "
+#~ "working to improve Lookit in a variety of ways."
+#~ msgstr ""
+#~ "Mark organizza i gruppi di lavoro di Lookit che sono gruppi di "
+#~ "ricercatori che lavorano per migliorare la piattaforma in diversi modi."
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr ""
+#~ "Le tue credenziali di accesso non funzionano. Si prega di riprovare."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Nuovo su Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nuova password:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Conferma password:"
+
+#, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "Il team di %(site_name)s"
+
+#~ msgid "Email address:"
+#~ msgstr "Indirizzo email:"
+
+#~ msgid "FAQ"
+#~ msgstr "FAQ"
+
+#~ msgid "Hi"
+#~ msgstr "Ciao"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Compleanno vuoto"
+
+#~ msgid " day"
+#~ msgstr " giorno"
+
+#~ msgid " days"
+#~ msgstr " giorni"
+
+#~ msgid " month"
+#~ msgstr " mese"
+
+#~ msgid " months"
+#~ msgstr " mesi"
+
+#~ msgid " year"
+#~ msgstr " anno"
+
+#~ msgid " years"
+#~ msgstr " anni"
+
+#~ msgid "Hide Form"
+#~ msgstr "Nascondi modulo"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr ""
+#~ "Crea un account familiare per iniziare a partecipare agli studi di Lookit!"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Il tuo account non ha accesso a questa pagina. Per procedere, effettua il "
+#~ "login con un account autorizzato."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Effettua il login per vedere questa pagina."
+
+#~ msgid "Compensation: "
+#~ msgstr "Compenso: "
+
+#~ msgid "None"
+#~ msgstr "Nessuno"
+
+#~ msgid "Current Studies"
+#~ msgstr "Studi disponibili"
+
+#~ msgid "See details"
+#~ msgstr "Vedi i dettagli"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Non stiamo conducendo alcuno studio in questo momento!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Cerchi altri modi per contribuire alla ricerca da casa? Dai un'occhiata a "
+#~ "<a href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> per ulteriori "
+#~ "studi!"
+
+#~ msgid "days"
+#~ msgstr "giorni"
+
+#~ msgid " until "
+#~ msgstr " fino a "
+
+#~ msgid " when "
+#~ msgstr " quando "
+
+#~ msgid "Study overview"
+#~ msgstr "Panoramica dello studio"
+
+#~ msgid "Back to list"
+#~ msgstr "Torna alla lista"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Criteri di ammissione"
+
 #~ msgid "Alumni &amp; Collaborators"
 #~ msgstr "Alumni &amp; Collaboratori"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "Per registrarsi come ricercatore, si prega di utilizzare"
-
 #~ msgid "this form"
 #~ msgstr "questo modulo"
-
-#~ msgid "instead"
-#~ msgstr "invece"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -4351,10 +4351,8 @@ msgstr "Durata"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Questo studio è condotto da"
+msgstr "Questo studio è condotto da %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-17 03:16-0500\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,7 +30,7 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "このアカウントは有効ではありません。"
 
-#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:146
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "メールアドレス"
 
@@ -289,451 +289,451 @@ msgid "External studies"
 msgstr "外部の研究・調査"
 
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:320 studies/fields.py:136
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "わからない／答えたくない"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:321 studies/fields.py:137
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "24週未満"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:322 studies/fields.py:138
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:323 studies/fields.py:139
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:324 studies/fields.py:140
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:325 studies/fields.py:141
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:326 studies/fields.py:142
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:327 studies/fields.py:143
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:328 studies/fields.py:144
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:329 studies/fields.py:145
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:330 studies/fields.py:146
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:331 studies/fields.py:147
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:332 studies/fields.py:148
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:333 studies/fields.py:149
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:334 studies/fields.py:150
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:335 studies/fields.py:151
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:336 studies/fields.py:152
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:337 studies/fields.py:153
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39週"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:338 studies/fields.py:154
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40週以上"
 
-#: accounts/models.py:43
+#: accounts/models.py:45
 msgid "male"
 msgstr "男性"
 
-#: accounts/models.py:44
+#: accounts/models.py:46
 msgid "female"
 msgstr "女性"
 
-#: accounts/models.py:45
+#: accounts/models.py:47
 msgid "open response"
 msgstr "自由記述"
 
-#: accounts/models.py:46 accounts/models.py:491
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "答えたくありません"
 
-#: accounts/models.py:85
+#: accounts/models.py:87
 #, fuzzy
 msgid "Can View Organization"
 msgstr "所属機関を見ることができる"
 
-#: accounts/models.py:86
+#: accounts/models.py:88
 #, fuzzy
 msgid "Can Edit Organization"
 msgstr "所属機関を編集することができる"
 
-#: accounts/models.py:87
+#: accounts/models.py:89
 #, fuzzy
 msgid "Can Create Organization"
 msgstr "所属機関を作成することができる"
 
-#: accounts/models.py:88
+#: accounts/models.py:90
 #, fuzzy
 msgid "Can Remove Organization"
 msgstr "所属機関を削除することができる"
 
-#: accounts/models.py:89
+#: accounts/models.py:91
 #, fuzzy
 msgid "Can View Experimenter"
 msgstr "研究者を見ることができる"
 
-#: accounts/models.py:90
+#: accounts/models.py:92
 #, fuzzy
 msgid "Can View Analytics"
 msgstr "統計を表示することができる"
 
-#: accounts/models.py:305
+#: accounts/models.py:324
 #, fuzzy
 msgid "Can Create User"
 msgstr "ユーザーを作成できる"
 
-#: accounts/models.py:306
+#: accounts/models.py:325
 #, fuzzy
 msgid "Can View User"
 msgstr "ユーザーを表示できる"
 
-#: accounts/models.py:307
+#: accounts/models.py:326
 #, fuzzy
 msgid "Can Edit User"
 msgstr "ユーザーを編集できる"
 
-#: accounts/models.py:308
+#: accounts/models.py:327
 #, fuzzy
 msgid "Can Remove User"
 msgstr "ユーザーを削除できる"
 
-#: accounts/models.py:309
+#: accounts/models.py:328
 #, fuzzy
 msgid "Can View User Permissions"
 msgstr "ユーザー権限を表示できる"
 
-#: accounts/models.py:310
+#: accounts/models.py:329
 #, fuzzy
 msgid "Can Edit User Permissions"
 msgstr "ユーザー権限を編集できる"
 
-#: accounts/models.py:311
+#: accounts/models.py:330
 #, fuzzy
 msgid "Can Read All User Data"
 msgstr "すべてのユーザーデータを読み取れる"
 
-#: accounts/models.py:312
+#: accounts/models.py:331
 #, fuzzy
 msgid "Can Read User Usernames"
 msgstr "ユーザー名を読み取れる"
 
-#: accounts/models.py:406
+#: accounts/models.py:425
 msgid "White"
 msgstr "白人"
 
-#: accounts/models.py:407
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "ヒスパニック系、ラテン系、スペイン系"
 
-#: accounts/models.py:408
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "黒人またはアフリカ系アメリカ人"
 
-#: accounts/models.py:409
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "アジア系"
 
-#: accounts/models.py:410
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "ネイティブアメリカンまたはアラスカ原住民族"
 
-#: accounts/models.py:411
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "中近東または北アフリカ"
 
-#: accounts/models.py:412
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "ハワイ先住民族またはその他の太平洋諸島民族"
 
-#: accounts/models.py:413
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "その他の人種・民族"
 
-#: accounts/models.py:416 accounts/models.py:425
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "現在高校生または高校中退"
 
-#: accounts/models.py:417 accounts/models.py:426
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "高校卒業または高等学校卒業程度認定（全教科）"
 
-#: accounts/models.py:418 accounts/models.py:427
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "現在大学生または大学中退"
 
-#: accounts/models.py:419 accounts/models.py:428
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "二年制大学卒業"
 
-#: accounts/models.py:420 accounts/models.py:429
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "四年制大学卒業"
 
-#: accounts/models.py:421 accounts/models.py:430
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "現在大学院生または大学院中退"
 
-#: accounts/models.py:422 accounts/models.py:431
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "大学院卒業"
 
-#: accounts/models.py:432
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "該当なし - 配偶者やパートナーなし"
 
-#: accounts/models.py:435 accounts/models.py:468
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:436 accounts/models.py:462
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:437 accounts/models.py:463
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:438 accounts/models.py:464
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:439
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:440
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:441
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:442
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:443
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:444
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:445
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:446
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "10以上"
 
-#: accounts/models.py:449
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "18歳未満"
 
-#: accounts/models.py:450
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:451
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:452
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:453
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:454
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:455
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:456
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:457
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:458
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:459
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70歳以上"
 
-#: accounts/models.py:465
+#: accounts/models.py:484
 msgid "Another number, or explain below"
 msgstr "他の数字を記載するか、以下で説明を加えてください。"
 
-#: accounts/models.py:469
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:470
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:471
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:472
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:473
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:474
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:475
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:476
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:477
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:478
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:479
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:480
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:481
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:482
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:483
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:484
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:485
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:486
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:487
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:488
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:489
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:490
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "200000以上"
 
-#: accounts/models.py:494
+#: accounts/models.py:513
 msgid "urban"
 msgstr "都市部"
 
-#: accounts/models.py:494
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "郊外"
 
-#: accounts/models.py:494
+#: accounts/models.py:513
 msgid "rural"
 msgstr "田舎"
 
-#: accounts/models.py:548
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "都道府県を選択してください"
 
-#: accounts/models.py:685
+#: accounts/models.py:717
 msgid "and"
 msgstr "と"
 
@@ -1193,7 +1193,7 @@ msgstr "男性"
 msgid "Female"
 msgstr "女性"
 
-#: studies/models.py:142
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -1202,7 +1202,7 @@ msgstr ""
 "連する研究を作成することができ、本研究室の研究・調査に追加することができま"
 "す。"
 
-#: studies/models.py:151
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "本研究室への参加を希望されたユーザー。"
 
@@ -1424,7 +1424,7 @@ msgstr "3歳〜4歳の幼児の調査"
 msgid "studies for school-aged kids & teens (5-17)"
 msgstr "5歳〜17歳の子供の調査"
 
-#: web/templates/web/base.html:16 web/templates/web/home.html:34
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
 msgid "Children Helping Science"
 msgstr "科学を助ける子どもたち"
 
@@ -1848,9 +1848,9 @@ msgid ""
 "(instead of just for one nonprofit or company), then it is possible it would "
 "appear on this website.</p>\n"
 "                <p>If a scientist wants to use this platform, their "
-"institution has to sign a contract with MIT where they agree to the <a href="
-"\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will be "
-"reviewed and approved by an institutional review board. Studies are also "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
 "subject to review and approval by Children Helping Science. As of April "
 "2023, we have agreements with over 90 universities,  including institutions "
 "in the United States, Canada, the United Kingdom, and European Union.</p>\n"
@@ -1864,11 +1864,12 @@ msgstr ""
 "学雑誌に結果を発表することを意図している場合、このウェブサイトに掲載される可"
 "能性があります。</p>\n"
 "                                <p>科学者がこのプラットフォームを使用したい場"
-"合、その機関はマサチューセッツ工科大学と契約を結び、<a href=\"%(termsofuse)s"
-"\">利用規約</a> に同意し、その研究・調査が機関審査委員会によって審査・承認さ"
-"れることを証明する必要があります。また、研究・調査にはChildren Helping "
-"Scienceによる審査と承認が必要です。2023年4月現在、米国、カナダ、英国、欧州連"
-"合（EU）の研究機関を含む50以上の大学と協定を結んでいます。</p> \n"
+"合、その機関はマサチューセッツ工科大学と契約を結び、<a "
+"href=\"%(termsofuse)s\">利用規約</a> に同意し、その研究・調査が機関審査委員会"
+"によって審査・承認されることを証明する必要があります。また、研究・調査には"
+"Children Helping Scienceによる審査と承認が必要です。2023年4月現在、米国、カナ"
+"ダ、英国、欧州連合（EU）の研究機関を含む50以上の大学と協定を結んでいます。</"
+"p> \n"
 
 #: web/templates/web/faq.html:129
 msgid ""
@@ -2172,9 +2173,9 @@ msgstr ""
 "ることになるでしょう。なお、データブラリーへのアクセスを許可された研究者は、"
 "研究室におけるデータの使用と同等の高い水準の注意を払って、これらのデータを取"
 "り扱うことに同意しなければなりません。データブラリーの詳細については、<a "
-"href=\"https://databrary.org/about.html\">ミッション</a>または<a href="
-"\"https://databrary.org/about/agreement.html\">許可されたユーザーの要件につい"
-"て</a>をご覧ください。</p>\n"
+"href=\"https://databrary.org/about.html\">ミッション</a>または<a "
+"href=\"https://databrary.org/about/agreement.html\">許可されたユーザーの要件"
+"について</a>をご覧ください。</p>\n"
 "        \t\t\t\t\t\t\t\t<p>次に、動画データの利用について、どの範囲での利用を"
 "許可するかをお尋ねします。</p>\n"
 "        \t\t\t\t\t\t\t\t<ul>\n"
@@ -2536,11 +2537,11 @@ msgstr "幼い子どもは、デジタル画面を見る時間を避けるべき
 #: web/templates/web/faq.html:496
 msgid ""
 "\n"
-"                <p>We agree with the American Academy of Pediatrics <a href="
-"\"https://pediatrics.aappublications.org/content/138/5/e20162591\" target="
-"\"_blank\" rel=\"noopener\">advice</a> that children learn best from people, "
-"not screens! However, our studies are not intended to educate children, but "
-"to learn from them.</p>\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
 "                <p>As part of a child's limited screen time, we hope that "
 "our studies will foster family conversation and engagement with science that "
 "offsets the few minutes spent watching a video instead of playing. And we do "
@@ -2549,12 +2550,12 @@ msgid ""
 "                "
 msgstr ""
 "\n"
-"<p>私たちは、アメリカ小児科学会（American Academy of Pediatrics）<a href="
-"\"https://pediatrics.aappublications.org/content/138/5/e20162591\" target="
-"\"_blank\" rel=\"noopener\">advice</a> の子どもたちはスクリーンを通してではな"
-"く、人から実際に学ぶのが一番だということだと同じ意見を持っています！しかし、"
-"私たちの研究は子どもたちを教育するためのものではなく、子どもたちから学ぶため"
-"のものであります。</p>\n"
+"<p>私たちは、アメリカ小児科学会（American Academy of Pediatrics）<a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> の子どもたちはスクリーンを通し"
+"てではなく、人から実際に学ぶのが一番だということだと同じ意見を持っています！"
+"しかし、私たちの研究は子どもたちを教育するためのものではなく、子どもたちから"
+"学ぶためのものであります。</p>\n"
 "<p>私たちの研究が家族の会話や科学への関心を育み、遊ぶ時間んの代わりにビデオを"
 "見ている数分を帳消しにしてくれることを願っています。そして、私たち自身でも "
 "\"実践 \"しています。私たちの研究に対して、私たち自身の子どもたちがたくさんの"
@@ -2702,10 +2703,10 @@ msgstr ""
 "差についての疑問や、さまざまな要因が相互作用することが結果にどのように影響す"
 "るかといった事柄が考えられます。</p>\n"
 "                                <p>もしあなたがこの活動を気に入ってくださった"
-"なら、私たちの心からの感謝も含めて、Lookitプラットフォーム (<a href="
-"\"%(url_home)s\">https://www.childrenhelpingscience.com</a>) をぜひお知り合い"
-"の方に共有してください。子どもの発達に関わる研究・調査は、あなたのような保護"
-"者の方の助けがなければ成立しません。</p>"
+"なら、私たちの心からの感謝も含めて、Lookitプラットフォーム (<a "
+"href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>) をぜひお知"
+"り合いの方に共有してください。子どもの発達に関わる研究・調査は、あなたのよう"
+"な保護者の方の助けがなければ成立しません。</p>"
 
 #: web/templates/web/faq.html:605
 msgid "What is the Parent Researcher Collaborative (PaRC)?"
@@ -2784,8 +2785,8 @@ msgstr ""
 "<p>個別の調査については、「調査の詳細」ページをご参照ください。このページに"
 "は、調査を実施している研究室の連絡先が常に記載されている。</p>\n"
 "                <p>このウェブサイトを運営している研究者と連絡をお取りになる場"
-"合は、以下のメールアドレスまでご連絡ください（英語のみ対応）。<a href="
-"\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"合は、以下のメールアドレスまでご連絡ください（英語のみ対応）。<a "
+"href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
 "                <p>参加中に技術的な問題が発生した場合は、下記までご連絡くださ"
 "い（英語のみ対応。 <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>"
 
@@ -2846,8 +2847,8 @@ msgid ""
 "                <p>If you are trying to participate in a study and having "
 "difficulties, please start by contacting the researchers who made that "
 "specific study.  If you still need help, you can also reach the Children "
-"Helping Science team for help at <a href=\"mailto:lookit-tech@mit.edu"
-"\">lookit-tech@mit.edu</a>.</p>\n"
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
 "                <p>If you are a researcher working on creating a study, you "
 "can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
 "index.html\">documentation</a>, and in our <a href = \"https://docs.google."
@@ -2864,8 +2865,8 @@ msgstr ""
 "                                <p>研究・調査を作成している研究者の方でヘルプ"
 "が必要な場合には、<a href=\"https://lookit.readthedocs.io/en/develop/index."
 "html\">こちらのドキュメント</a>、または<a href = \"https://docs.google.com/"
-"forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/viewform"
-"\">Slackコミュニティ</a>にて解決を図ることができます。</p>"
+"forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slackコミュニティ</a>にて解決を図ることができます。</p>"
 
 #: web/templates/web/faq.html:714
 msgid "What security measures do you implement?"
@@ -2891,9 +2892,9 @@ msgstr ""
 "\"https://lookit.readthedocs.io/en/develop/community-irb-and-legal-"
 "information.html#sub-processors-and-information-about-gdpr-compliance-dpas\">"
 "こちらのドキュメント</a>にて概要をお読みいただけます。また、最新のHECVAT (高"
-"等教育クラウド ベンダー評価ツール キット) について確認したい方は、<a href="
-"\"mailto:lookit@mit.edu\">lookit@mit.edu</a>までご連絡ください (英語対応の"
-"み)。</p>"
+"等教育クラウド ベンダー評価ツール キット) について確認したい方は、<a "
+"href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>までご連絡ください (英語対応"
+"のみ)。</p>"
 
 #: web/templates/web/faq.html:728
 msgid "For Researchers"
@@ -2947,8 +2948,8 @@ msgstr ""
 "                                <p>2023年4月現在、私たちは米国、カナダ、英"
 "国、欧州連合の機関を含む50以上の大学と協定を結んでいます。あなたの所属機関が"
 "既に協定を結んでいるかどうかがわからない場合や、書類を整えるのに支援が必要な"
-"場合は、こちらのメールアドレス <a href=\"mailto:lookit-tech@mit.edu"
-"\">lookit@mit.edu</a> までご連絡ください (英語対応のみ)。</p>\n"
+"場合は、こちらのメールアドレス <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit@mit.edu</a> までご連絡ください (英語対応のみ)。</p>\n"
 "                                <p>これらのステップを踏んでいる間でも、ラボア"
 "カウントを作成し、最初の研究・調査を作成し、研究者コミュニティによってピアレ"
 "ビューを受けることで、Children Helping Scienceプラットフォームの使用を開始す"
@@ -2976,10 +2977,10 @@ msgid ""
 "<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
 "viewthread?CommunityKey=bd3d326e-b7db-49bf-"
 "abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
-"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-home%%2Fdigestviewer"
-"%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-abbb-73642ac0576c%%26tab"
-"%%3Ddigestviewer&tab=digestviewer\">discussion forum</a> you might check out!"
-"</p>\n"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
 "                "
 msgstr ""
 "\n"
@@ -2992,10 +2993,10 @@ msgstr ""
 "Developmentも同様に <a href = \"https://commons.srcd.org/communities/"
 "community-home/digestviewer/viewthread?CommunityKey=bd3d326e-b7db-49bf-"
 "abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
-"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-home%%2Fdigestviewer"
-"%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-abbb-73642ac0576c%%26tab"
-"%%3Ddigestviewer&tab=digestviewer\">ディスカッションフォーラム</a>を設けてい"
-"るので、ぜひご確認ください！</p>"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">ディスカッション"
+"フォーラム</a>を設けているので、ぜひご確認ください！</p>"
 
 #: web/templates/web/garden/about.html:13
 msgid "What is Project Garden?"
@@ -3014,34 +3015,40 @@ msgid "Meet the GARDEN Scientists"
 msgstr "&nbsp;"
 
 #: web/templates/web/home.html:15
-msgid ""
-"ChildrenHelpingScience and Lookit have merged - click <a href='{{ url-"
-"participant-signup }}' class='alert-link'>here</a> to make an account or "
-"explore studies below!"
+#, fuzzy
+#| msgid "ChildrenHelpingScience and Lookit have merged!"
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr "Children Helping Scienceチーム（米国）"
+
+#: web/templates/web/home.html:16
+msgid "here"
 msgstr ""
 
-#: web/templates/web/home.html:17
-#| msgid "The Children Helping Science team"
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
 msgid "ChildrenHelpingScience and Lookit have merged!"
 msgstr "Children Helping Scienceチーム（米国）"
 
-#: web/templates/web/home.html:35
+#: web/templates/web/home.html:36
 msgid "Powered by Lookit"
 msgstr "提供：Lookit"
 
-#: web/templates/web/home.html:37
+#: web/templates/web/home.html:38
 msgid "Fun for Families, Serious for Science"
 msgstr "家族で楽しく、科学についてしっかりと知りたい方へ"
 
-#: web/templates/web/home.html:40
+#: web/templates/web/home.html:41
 msgid "Participate in a Study"
 msgstr "研究・調査に参加する"
 
-#: web/templates/web/home.html:51
+#: web/templates/web/home.html:52
 msgid "Help Science"
 msgstr "科学を助ける"
 
-#: web/templates/web/home.html:53
+#: web/templates/web/home.html:54
 msgid ""
 "This website has studies you and your child can participate in from your "
 "home, brought to you by researchers from universities around the world!"
@@ -3049,11 +3056,11 @@ msgstr ""
 "このwebサイトには、世界中の大学の研究者がお届けする、ご自宅から親子で参加でき"
 "る研究・調査が掲載されています！"
 
-#: web/templates/web/home.html:58
+#: web/templates/web/home.html:59
 msgid "From Home"
 msgstr "ご家庭から"
 
-#: web/templates/web/home.html:60
+#: web/templates/web/home.html:61
 msgid ""
 "You and your child use your computer to participate. Some studies can also "
 "be done on a tablet or phone."
@@ -3061,11 +3068,11 @@ msgstr ""
 "パソコンを使って親子で研究・調査に参加。タブレットやスマートフォンを使って参"
 "加できる研究・調査も一部あります。"
 
-#: web/templates/web/home.html:65
+#: web/templates/web/home.html:66
 msgid "With Fun Activities"
 msgstr "楽しい活動と一緒に"
 
-#: web/templates/web/home.html:67
+#: web/templates/web/home.html:68
 msgid ""
 "Many studies are either short games, or listening to a story and answering "
 "questions about it. Some are available at any time, and others are a "
@@ -3075,27 +3082,27 @@ msgstr ""
 "です。いつでも参加できるものもあれば、研究者とオンラインミーティングの日程調"
 "整をする場合もあります。"
 
-#: web/templates/web/home.html:72
+#: web/templates/web/home.html:73
 msgid "Join researchers from these schools, and many more!"
 msgstr "&nbsp;"
 
-#: web/templates/web/home.html:84
+#: web/templates/web/home.html:85
 msgid ""
 "Interested in participating in a project with many studies? Learn more about "
 msgstr "&nbsp;"
 
-#: web/templates/web/home.html:84
+#: web/templates/web/home.html:85
 msgid "Project GARDEN"
 msgstr "&nbsp;"
 
-#: web/templates/web/home.html:87
+#: web/templates/web/home.html:88
 msgid ""
 "In this series of studies, your child will help an animated fox named Fen "
 "find the “GARDEN Library” while playing games to help Children Helping "
 "Science understand children's development from many different angles!"
 msgstr "&nbsp;"
 
-#: web/templates/web/home.html:90
+#: web/templates/web/home.html:91
 msgid "See our current studies for different age groups:"
 msgstr "&nbsp;"
 
@@ -3730,8 +3737,7 @@ msgstr "以上の声明は2018年6月に最終更新されました。"
 #: web/templates/web/resources.html:14
 msgid "Find a developmental lab near you"
 msgstr ""
-"この情報は英語圏の方のみ対象となります　Find a "
-"developmental lab near you"
+"この情報は英語圏の方のみ対象となります　Find a developmental lab near you"
 
 #: web/templates/web/scientists.html:10
 msgid "Meet the Children Helping Science team"
@@ -3879,28 +3885,28 @@ msgstr "あなたはまだ外部の研究・調査に参加したことがあり
 msgid "Studies"
 msgstr "研究・調査"
 
-#: web/templates/web/studies-list.html:23
+#: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
 
-#: web/templates/web/studies-list.html:27
+#: web/templates/web/studies-list.html:29
 msgid "Clear"
 msgstr "削除する"
 
-#: web/templates/web/studies-list.html:60
+#: web/templates/web/studies-list.html:62
 msgid "No studies found."
 msgstr "研究・調査が見つかりません。"
 
-#: web/templates/web/studies-list.html:65
+#: web/templates/web/studies-list.html:67
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr "&nbsp;"
 
-#: web/templates/web/studies-list.html:68
+#: web/templates/web/studies-list.html:70
 msgid "Resources"
 msgstr "参考資料"
 
-#: web/templates/web/studies-list.html:69
+#: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
 msgstr "&nbsp;"
 
@@ -3948,23 +3954,26 @@ msgstr "現在の研究・調査"
 msgid "Duration"
 msgstr "期間"
 
-#: web/templates/web/study-detail.html:86
-msgid "This study is conducted by"
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
 msgstr "この研究・調査を実施している研究者／研究グループ"
 
-#: web/templates/web/study-detail.html:91
+#: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"
 msgstr "この研究・調査に参加してみませんか？"
 
-#: web/templates/web/study-detail.html:103
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "お子さんを選択してください"
 
-#: web/templates/web/study-detail.html:114
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "選択されていません"
 
-#: web/templates/web/study-detail.html:127
+#: web/templates/web/study-detail.html:132
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
 "If you can wait until he or she is old enough, the researchers will be able "
@@ -3974,7 +3983,7 @@ msgstr ""
 "が十分な年齢になるまでお待ちいただければ、研究者はあなたに補償し、収集した"
 "データを研究に使用することができます。"
 
-#: web/templates/web/study-detail.html:130
+#: web/templates/web/study-detail.html:135
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
 "welcome to try the study anyway, but researchers may not be able to "
@@ -3984,14 +3993,21 @@ msgstr ""
 "研究に参加することは歓迎しますが、研究者はあなたに補償したり、収集したデータ"
 "を研究に使用したりすることはできません。"
 
-#: web/templates/web/study-detail.html:133
-#, python-format
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| " Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but researchers may not be able "
+#| "to compensate you or use your data. Please review the “Who can "
+#| "participate” information for this study and contact the study researchers "
+#| "(%(contact)s) if you feel this is in error. "
 msgid ""
-" Your child does not meet the eligibility criteria listed for this study. "
+"Your child does not meet the eligibility criteria listed for this study. "
 "You're welcome to try the study anyway, but researchers may not be able to "
 "compensate you or use your data. Please review the “Who can participate” "
 "information for this study and contact the study researchers (%(contact)s) "
-"if you feel this is in error. "
+"if you feel this is in error."
 msgstr ""
 "␣あなたのお子さんは、この研究に記載されている参加資格を満たしていません。この"
 "研究に参加することは歓迎ですが、研究者はあなたに補償したり、あなたのデータを"
@@ -3999,7 +4015,7 @@ msgstr ""
 "報を確認し、これが誤りであると思われる場合は、研究者(%(contact)s)に連絡してく"
 "ださい。␣"
 
-#: web/templates/web/study-detail.html:145
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -4007,7 +4023,7 @@ msgstr ""
 "研究・調査プロトコルを更新するとどうなるかを簡単に確認する際には、上のボタン"
 "をクリックして送信されるURLをブックマークしてください。"
 
-#: web/templates/web/study-detail.html:149
+#: web/templates/web/study-detail.html:157
 msgid ""
 "This study runs on another website, and clicking to participate will take "
 "you to that link."
@@ -4015,7 +4031,7 @@ msgstr ""
 "この研究は別のウェブサイトで実施されており、参加をクリックするとそのリンクに"
 "移動します。"
 
-#: web/templates/web/study-detail.html:151
+#: web/templates/web/study-detail.html:159
 msgid ""
 "It will also make it possible for the researchers of this study to contact "
 "you, and will share your child's profile information with the researchers."
@@ -4023,11 +4039,11 @@ msgstr ""
 "また、この研究の研究者があなたに連絡することを可能にし、あなたのお子さんのプ"
 "ロフィール情報を研究者と共有します。"
 
-#: web/templates/web/study-detail.html:154
+#: web/templates/web/study-detail.html:162
 msgid "This study runs here on the Lookit platform."
 msgstr "この研究・調査はLookitのプラットフォーム上で行われます。"
 
-#: web/templates/web/study-detail.html:156
+#: web/templates/web/study-detail.html:164
 msgid ""
 "Clicking to participate will make it possible for the researchers of this "
 "study to contact you, and will share your child's profile information with "
@@ -4078,31 +4094,31 @@ msgstr ""
 "はオンラインミーティングです)。これから参加したい研究・調査を選んで、「参加す"
 "る」をクリックしてください。"
 
-#: web/views.py:113
+#: web/views.py:114
 msgid "Participant created."
 msgstr "参加者が作成されました。"
 
-#: web/views.py:156
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "人口統計学的データが保存されました。"
 
-#: web/views.py:222
+#: web/views.py:223
 msgid "Child added."
 msgstr "お子さんの情報が追加されました。"
 
-#: web/views.py:263
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "お子さんの情報が削除されました。"
 
-#: web/views.py:265
+#: web/views.py:266
 msgid "Child updated."
 msgstr "お子さんの情報が更新されました。"
 
-#: web/views.py:293
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "メール設定が保存されました。"
 
-#: web/views.py:658
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -3956,10 +3956,8 @@ msgstr "期間"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "この研究・調査を実施している研究者／研究グループ"
+msgstr "この研究・調査を実施している研究者／研究グループ %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr ""
 "구글 인증 (Google Authenticator)에서 제공된 유효한 6자리 일회용 비밀번호를 입"
@@ -37,43 +37,25 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "본 계정은 활성화되어있지 않습니다."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr "비밀번호는 귀하의 개인정보와 비슷하게 생성할 수 없습니다."
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "비밀번호는 최소 16자이상이 되어야 합니다."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "비밀번호는 자주쓰는 비밀번호가 아니어야 합니다."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "비밀번호는 숫자로만 구성될 수 없습니다."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "이메일 주소"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "별칭"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 #, fuzzy
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "현재 우리가 참여하고있는 연구의 다른 세션을 살펴보겠습니다"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "귀하의 자녀분(들) 중 한 명이 참여가능한 새로운 연구가 있습니다"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -81,7 +63,7 @@ msgstr ""
 "우리가 참여한 연구에 대한 새로운 알림이 있습니다 (예를 들어, 연구결과가 출판"
 "됨)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -89,109 +71,98 @@ msgstr ""
 "연구자가 귀하의 개별 응답에 대해 질문이 있습니다 (예를 들어, 귀하께서 연구 중"
 "에 기술적 문제를 보고하시는 경우)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "귀하의 가족형태는 어떻게 되십니까?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "국가"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 #, fuzzy
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr ""
 "다음 형태에 맞게 년/월/일을 입력해주십시오 (쉼표로 구분): 0000-00-00, "
 "0000-00-00, ..."
 
-#: accounts/forms.py:306
-#, fuzzy
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "숫자 형태로만 입력 - 대략적인 추측도 괜찮습니다!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "귀하께서는 어느 나라에 살고 계십니까?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 #, fuzzy
 msgid "What state do you live in?"
 msgstr "귀하는 어느 지역 (도, 특별시) 에 살고 계십니까?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "귀하께서 살고 계신 지역을 어떻게 설명 하시겠습니까?"
 
-#: accounts/forms.py:314
-#, fuzzy
-msgid "What language(s) does your family speak at home?"
-msgstr "귀하의 가족이 집에서 대화할 때 사용하는 언어(들)은 무엇입니까?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 #, fuzzy
 msgid "How many children do you have?"
 msgstr "귀하는 자녀분이 몇명 있으십니까?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "각 자녀분의 생년월일을 입력해주십시오:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 #, fuzzy
 msgid "How many parents/guardians do your children live with?"
 msgstr "귀하의 자녀분(들)은 몇 명의 부모/법적보호자와 함께 살고 있습니까?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "귀하의 만 나이는 무엇입니까?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "귀하의 성별은 무엇입니까?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "귀하의 성별은 무엇입니까?"
+
+#: accounts/forms.py:346
 #, fuzzy
 msgid "What is the highest level of education you've completed?"
 msgstr "귀하가 수료한 최고학력은 무엇입니까?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "귀하의 배우자가 수료한 최고학력은 무엇입니까?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "대략적인 연간 가족 소득은 얼마입니까 (한국 원화로)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "집에 아동도서가 몇 권 정도 있으십니까?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "저희에게 더 알려주시고 싶으신 부분이 있으십니까?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Lookit에 대해 어떻게 알게 되셨습니까?"
 
-#: accounts/forms.py:341
-#, fuzzy
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"귀하의 답변이 공동 양육권 계약 및 방문 규정으로 인해 답변이 다른 경우, 자녀분"
-"이 일반적으로 함께 살고있는 부모/법적 보호자 수를 입력하거나 설명해주십시오."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "생년월일"
+#: accounts/forms.py:357
+#, fuzzy
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "다른 인종, 민족 또는 출신"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 #, fuzzy
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
@@ -202,41 +173,44 @@ msgstr ""
 "줍니다. 저희는 다른 독자가 자녀분의 생년월일을 계산할 수 있는 형태의 정보를 "
 "절대로 출판하지 않습니다."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 #, fuzzy
 msgid "Birthdays cannot be in the future."
 msgstr "생일은 미래의 날짜일 수 없습니다."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "이름"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "생년월일"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "성별"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "임신 주 수 (출생 당시 __주)"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "저희에게 더 알려주시고 싶으신 부분이 있으십니까?"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 #, fuzzy
 msgid "Characteristics and conditions"
 msgstr "특성 및 조건"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
 msgstr "자녀분이 가정, 학교 또는 다른 보호자와 있을 때 노출되는 언어(들)"
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 #, fuzzy
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
@@ -249,526 +223,611 @@ msgstr ""
 "함할 수 있지만 (예 : \"영희가 참여할 수 있는 새로운 연구가 있습니다!\") 저희"
 "는 절대 자녀분의 이름을 공적으로 게시하거나 연구에 사용하지 않을 것입니다."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr "예를 들어, 발달 장애 또는 시력 및 청력 문제를 진단받은 적이 있습니다."
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 #, fuzzy
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr ""
 "출산까지 임신 하셨던 기간을 가장 가까운 정수로 내림하여 응답해주십시오 (예 "
 "36.5주 --> 36주)."
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "연구들"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+msgid "Scheduled studies"
+msgstr "현재 진행중인 연구들"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+#, fuzzy
+#| msgid "Meet the Lookit team"
+msgid "here on the Lookit platform"
+msgstr "Lookit 팀을 만나보십시오."
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "귀하의 지난 연구들"
+
+#: accounts/forms.py:517
+#, fuzzy
+msgid "External studies"
+msgstr "현재 진행중인 연구들"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "확실하지 않거나 답변하기를 원하지 않습니다"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "24주 미만"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39주"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40주 이상"
 
-#: accounts/models.py:80
+#: accounts/models.py:45
+msgid "male"
+msgstr "남성"
+
+#: accounts/models.py:46
+msgid "female"
+msgstr "여성"
+
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
+
+#: accounts/models.py:48 accounts/models.py:510
+msgid "prefer not to answer"
+msgstr "대답하고 싶지 않음"
+
+#: accounts/models.py:87
 #, fuzzy
 msgid "Can View Organization"
 msgstr "기관 보기"
 
-#: accounts/models.py:81
+#: accounts/models.py:88
 msgid "Can Edit Organization"
 msgstr "기관 편집하기"
 
-#: accounts/models.py:82
+#: accounts/models.py:89
 msgid "Can Create Organization"
 msgstr "기관 추가하기"
 
-#: accounts/models.py:83
+#: accounts/models.py:90
 msgid "Can Remove Organization"
 msgstr "기관 제거하기"
 
-#: accounts/models.py:84
+#: accounts/models.py:91
 msgid "Can View Experimenter"
 msgstr "연구자 보기"
 
-#: accounts/models.py:85
+#: accounts/models.py:92
 msgid "Can View Analytics"
 msgstr "분석내용 보기"
 
-#: accounts/models.py:280
+#: accounts/models.py:324
 msgid "Can Create User"
 msgstr "사용자 생성 가능"
 
-#: accounts/models.py:281
+#: accounts/models.py:325
 msgid "Can View User"
 msgstr "사용자 보기 가능"
 
-#: accounts/models.py:282
+#: accounts/models.py:326
 msgid "Can Edit User"
 msgstr "사용자 편집 가능"
 
-#: accounts/models.py:283
+#: accounts/models.py:327
 msgid "Can Remove User"
 msgstr "사용자 제거 가능"
 
-#: accounts/models.py:284
+#: accounts/models.py:328
 msgid "Can View User Permissions"
 msgstr "사용자 권한을 볼 수 있음"
 
-#: accounts/models.py:285
+#: accounts/models.py:329
 msgid "Can Edit User Permissions"
 msgstr "사용자 권한 편집 가능"
 
-#: accounts/models.py:286
+#: accounts/models.py:330
 msgid "Can Read All User Data"
 msgstr "모든 사용자 데이터를 읽을 수 있음"
 
-#: accounts/models.py:287
+#: accounts/models.py:331
 msgid "Can Read User Usernames"
 msgstr "사용자 이름을 읽을 수 있음"
 
-#: accounts/models.py:294 accounts/models.py:397
-msgid "male"
-msgstr "남성"
-
-#: accounts/models.py:295 accounts/models.py:398
-msgid "female"
-msgstr "여성"
-
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "기타"
-
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
-msgid "prefer not to answer"
-msgstr "대답하고 싶지 않음"
-
-#: accounts/models.py:387
+#: accounts/models.py:425
 msgid "White"
 msgstr "백인"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 #, fuzzy
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "히스패닉, 라틴계 또는 스페인계"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "흑인 또는 아프리카 계 미국인"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "아시아인"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "미국 원주민 또는 알래스카 원주민"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "중동인 또는 북아프리카인"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "하와이 원주민 또는 기타 태평양 섬 주민"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 #, fuzzy
 msgid "Another race, ethnicity, or origin"
 msgstr "다른 인종, 민족 또는 출신"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "고등학교 재학 중 및 중퇴"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 #, fuzzy
 msgid "high school diploma or GED"
 msgstr "고등학교 졸업 또는 검정고시 합격"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 #, fuzzy
 msgid "some or attending college"
 msgstr "대학 재학중 및 중퇴"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "2년제 대학 학위"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "4년제 대학 학위"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 #, fuzzy
 msgid "some or attending graduate or professional school"
 msgstr "일부 또는 대학원이나 전문 학교에 재학중 및 중퇴"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "대학원 또는 전문 학위"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "해당 없음-배우자 또는 애인 없음"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "10 이상"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "18 미만"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35 ~ 39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40 ~ 44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45 ~ 49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 #, fuzzy
 msgid "70 or over"
 msgstr "70 이상"
 
-#: accounts/models.py:450
-#, fuzzy
-msgid "3 or more"
-msgstr "3 이상"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-#, fuzzy
-msgid "varies"
-msgstr "상황에 따라 다름"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "월 평균 0-50만원 대 (연 평균 0-600만원 대)"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "월 평균 100만원 대 (연 평균1200만원 대)"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "월 평균 150만원 대 (연 평균 1800만원 대)"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "월 평균 200만원 대 (연 평균 2400만원 대)"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "월 평균 300만원 대 (연 평균 3600만원 대)"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "월 평균 400만원 대 (연 평균 4800만원 대)"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "월 평균 500만원 대 (연 평균 6000만원 대)"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "월 평균 600만원 대 (연 평균 7200만원 대)"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "월 평균 700만원 대 (연 평균 8400만원 대)"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "월 평균 800만원 대 (연 평균 9600만원 대)"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "월 평균 900만원 대 (연 평균 1억800만원 대)"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "월 평균 1000만원 대 (연 평균 1억2000만원 대)"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "월 평균 1100만원 대 (연 평균 1억3200만원 대)"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "월 평균 1200만원 대 (연 평균 1억4400만원 대)"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "월 평균 1300만원 대 (연 평균 1억5600만원 대)"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "월 평균 1400만원 대 (연 평균 1억6800만원 대)"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "월 평균 1500만원 대 (연 평균 1억8000만원 대)"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "월 평균 1600만원 대 (연 평균 1억9200만원 대)"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "월 평균 1700만원 대 (연 평균 2억400만원 대)"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "월 평균 1800만원 대 (연 평균 2억1600만원 대)"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "월 평균 1900만원 대 (연 평균 2억2800만원 대)"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "월 평균 2000만원 이상 (연 평균 2억4000만원 이상)"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "도시"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "교외"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "농/어촌 지역"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 #, fuzzy
 msgid "Select a State"
 msgstr "도/특별시 선택"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "관화(Gan)"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "계정 정보"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "로그인 정보 그리고/또는 별칭을 수정하십시오."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 #, fuzzy
 msgid "Demographic Survey"
 msgstr "인구 통계 조사"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 #, fuzzy
 msgid "Tell us more about yourself."
 msgstr "귀하에 대해 알려주십시오."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "자녀 정보"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "참가자 정보를 추가하거나 편집하십시오."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "이메일 환경 설정"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 #, fuzzy
 msgid "Edit when you can be contacted."
 msgstr "연락 원하실 때를 선택하십시오."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "나의 계정"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "계정 정보"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "저장"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 #, fuzzy
 msgid "Change Your Password"
 msgstr "비밀번호 변경"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "2단계 인증 관리"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -777,11 +836,18 @@ msgstr ""
 "용 비밀번호를 이 곳에 입력하시고, 제출 버튼을 클릭하시면, 이것은 삭제될 것입"
 "니다!"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "2단계 인증 설정하기"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "모든 참가자"
 
@@ -789,152 +855,66 @@ msgstr "모든 참가자"
 msgid "Participant ID"
 msgstr "참가자 아이디(ID)"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "마지막 활동:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "참가자 글로벌 ID:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-#, fuzzy
-msgid "Children"
-msgstr "자녀"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "만 나이"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "추가 정보"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 #, fuzzy
 msgid "No children profiles registered!"
 msgstr "등록된 자녀 정보가 없습니다!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "최신 인구 통계 정보"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "국가"
+
+#: accounts/templates/accounts/participant_detail.html:68
 #, fuzzy
 msgid "State"
 msgstr "도/특별시"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "지역 설명"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "가정에서 사용하는 언어(들)"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "자녀의 수"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "자녀분들의 현재 만 나이(들)"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "연구 응답"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "부모 또는 법적 보호자 수"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "법적 보호자에 대한 설명 :"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 #, fuzzy
 msgid "Race"
 msgstr "인종"
-
-#: exp/templates/exp/dashboard.html:16
-#, fuzzy
-msgid "Dashboard"
-msgstr "대시보드(계기판)"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "독일어(German)"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "영어(English)"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "스페인어(Spanish)"
-
-#: project/settings.py:231
-#, fuzzy
-msgid "Argentinian Spanish"
-msgstr "아르헨티나 스페인어"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "프랑스어(French)"
-
-#: project/settings.py:233
-msgid "Canadian French"
-msgstr "캐나다 프랑스어"
-
-#: project/settings.py:234
-msgid "Hebrew"
-msgstr "히브리어"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "이탈리아어 (Italian)"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "일본어(Japanese)"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "한국어(Korean)"
-
-#: project/settings.py:238
-msgid "Norwegian Bokmål"
-msgstr "노르웨이 보크몰"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "폴란드어(Polish)"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "포르투갈어(Portuguese)"
-
-#: project/settings.py:241
-msgid "Brazilian Portuguese"
-msgstr "브라질 포르투갈어"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "루마니아어(Romanian)"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "러시아어(Russian)"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "터키어(Turkish)"
-
-#: project/settings.py:245
-msgid "Simplified Chinese"
-msgstr "간체자"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "네덜란드어(Dutch)"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -989,6 +969,10 @@ msgstr "일곱 쌍둥이"
 msgid "Octuplet"
 msgstr "여덟 쌍둥이"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "영어(English)"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "암하라어(Amharic)"
@@ -1013,13 +997,25 @@ msgstr "세부아노어(Cebuano)"
 msgid "Chhattisgarhi"
 msgstr "차티스가르어(Chhattisgarhi)"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "네덜란드어(Dutch)"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "이집트계 통용 아랍어(Egyptian Spoken Arabic)"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "프랑스어(French)"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "관화(Gan)"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "독일어(German)"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -1034,162 +1030,204 @@ msgid "Hausa"
 msgstr "하우사어(Hausa)"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr "히브리어"
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "힌디어(Hindi)"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "이그보우어(Igbo)"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "인도네시아어(Indonesian)"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "이란계 페르시아어(Iranian Persian)"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "이탈리아어 (Italian)"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "일본어(Japanese)"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "자바어(Javanese)"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "진위안어(Jinyu)"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "칸나다어(Kannada)"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "크메르어(Khmer)"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "한국어(Korean)"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "마가히어(Magahi)"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "마이틸리어(Maithili)"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "말레이어(Malay)"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "말라얄람어(Malayalam)"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "표준 중국어(Mandarin)"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "마라티어(Marathi)"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "민난어(Min Nan)"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "모로코계 통용 아랍어(Moroccan Spoken Arabic)"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "북부 파슈토어(Northern Pashto)"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "북부 우즈베크어(Northern Uzbek)"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "오리야어(Odia)"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "폴란드어(Polish)"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "포르투갈어(Portuguese)"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "루마니아어(Romanian)"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "러시아어(Russian)"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "사라이키어(Saraiki)"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "신디어(Sindhi)"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "소말리어(Somali)"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "스페인어(Spanish)"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "순다어(Sunda)"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "타갈로그어(Tagalog)"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "타밀어(Tamil)"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "텔루구어(Telugu)"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "태국어(Thai)"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "터키어(Turkish)"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "우크라이나어(Ukrainian)"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "우르두어(Urdu)"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "베트남어(Vietnamese)"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "서부 펀자브어(Western Punjabi)"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "중국의 장쑤, 저장, 상하이에서 사용되는 중국어 (Wu)"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "중국의 후난에서 사용되는 중국어(Xiang Chinese)"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "요루바어(Yoruba)"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "유 중국어 및 광동어(Yue)"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "대답 하지 않음"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "기타"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "남성"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "여성"
 
-#: studies/models.py:113
+#: studies/models.py:143
 #, fuzzy
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
@@ -1198,39 +1236,208 @@ msgstr ""
 "이 연구실에 속한 사용자들입니다. 이 연구실의 사용자는 이 연구실과 관련된 연구"
 "를 만들 수 있으며, 이 연구실의 연구들에 추가 될 수 있습니다."
 
-#: studies/models.py:122
+#: studies/models.py:152
 #, fuzzy
 msgid "The Users who have requested to join this Lab."
 msgstr "이 연구실에 가입을 요청한 사용자들입니다."
 
-#: web/templates/frontpages/contact.html:15
+#: web/templates/registration/logged_out.html:5
+msgid "You've successfully logged out."
+msgstr "성공적으로 로그아웃 하셨습니다."
+
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 #, fuzzy
-msgid "Technical difficulties"
-msgstr "기술적인 어려움"
+msgid "Login"
+msgstr "로그인"
 
-#: web/templates/frontpages/contact.html:17
+#: web/templates/registration/login.html:25
+msgid "Forgot password?"
+msgstr "비밀번호를 잊으셨습니까?"
+
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
+
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr "귀하의 가족을 등록해주십시오!"
+
+#: web/templates/registration/password_change_done.html:9
 #, fuzzy
-msgid "Questions about the studies"
-msgstr "연구에 대한 질문들"
+msgid "Password changed"
+msgstr "비밀번호가 변경됨"
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
+#: web/templates/registration/password_change_done.html:12
 #, fuzzy
-msgid "For researchers"
-msgstr "연구자용"
+msgid "Your password was changed."
+msgstr "비밀번호가 변경되었습니다."
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
+#: web/templates/registration/password_change_form.html:12
+#, fuzzy
+msgid "Documentation"
+msgstr "선적 서류 보관 / 관련 기록"
 
-#: web/templates/frontpages/default.html:53
+#: web/templates/registration/password_change_form.html:14
+#, fuzzy
+msgid "Change password"
+msgstr "비밀번호 변경"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Log out"
+msgstr "로그아웃"
+
+#: web/templates/registration/password_change_form.html:18
+#, fuzzy
+msgid "Home"
+msgstr "홈(메인 페이지)"
+
+#: web/templates/registration/password_change_form.html:19
+#, fuzzy
+msgid "Password change"
+msgstr "비밀번호 변경"
+
+#: web/templates/registration/password_change_form.html:36
+msgid "Please correct the error below."
+msgstr "아래 오류를 수정하십시오."
+
+#: web/templates/registration/password_change_form.html:38
+msgid "Please correct the errors below."
+msgstr "아래 오류들을 수정하십시오."
+
+#: web/templates/registration/password_change_form.html:43
+msgid ""
+"Please enter your old password, for security's sake, and then enter your new "
+"password twice so we can verify you typed it in correctly."
+msgstr ""
+"보안을 위해 이전 암호를 입력 한 다음, 올바르게 입력했는지 확인할 수 있도록 "
+"새 암호를 두 번 입력하십시오."
+
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
+msgid "Change my password"
+msgstr "비밀번호 변경"
+
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "로그인"
+
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "비밀번호 재설정 완료"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "비밀번호가 설정되었습니다. 지금 바로 로그인 하실 수 있습니다."
+
+#: web/templates/registration/password_reset_confirm.html:8
+#, fuzzy
+msgid "Password reset confirmation"
+msgstr "비밀번호 재설정 확인"
+
+#: web/templates/registration/password_reset_confirm.html:11
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly."
+msgstr "올바르게 입력했는지 확인하기 위해 새 암호를 두 번 입력해 주십시오."
+
+#: web/templates/registration/password_reset_confirm.html:21
+#, fuzzy
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+"암호 재설정 링크가 유효하지 않습니다. 이미 사용된 링크일 수 있으니 새 비밀번"
+"호 재설정을 요청하십시오."
+
+#: web/templates/registration/password_reset_done.html:6
+msgid "Password reset link sent"
+msgstr "비밀번호 변경 링크가 전송됨"
+
+#: web/templates/registration/password_reset_done.html:9
+msgid ""
+"If an account exists with the email you entered, we've emailed instructions "
+"for resetting your password and you should receive them shortly."
+msgstr ""
+"귀하께서 입력해주신 이메일에 연결된 계정이 있다면, 곧 귀하의 이메일 주소로 비"
+"밀번호 재설정 안내문이 도착할 것입니다."
+
+#: web/templates/registration/password_reset_done.html:12
+msgid ""
+"If you don't receive an email, please check your spam folder and make sure "
+"you've entered the address you registered with. (You won't get an email "
+"unless there's already an account for that email address!)"
+msgstr ""
+"이메일을 받으시지 못하셨다면, 귀하의 스팸 폴더를 확인해주시고 귀하께서 등록하"
+"신 이메일 주소를 정확하게 입력하셨는지 확인해주시기 바랍니다. (귀하께서 이미 "
+"등록된 이메일 주소가 있으셔야만 안내문 이메일을 받으실 수 있습니다)."
+
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at Children Helping Science."
+msgstr ""
+"이 이메일은 %(site_name)s에서 사용자 계정에 대한 비밀번호 재설정을 요청하셨"
+"기 때문에 발송되었습니다."
+
+#: web/templates/registration/password_reset_email.html:4
+msgid "Please go to the following page and choose a new password:"
+msgstr "다음 페이지로 이동하여 새 비밀번호를 만드십시오:"
+
+#: web/templates/registration/password_reset_email.html:8
+#, fuzzy
+msgid "Your username, in case you've forgotten:"
+msgstr "사용자 이름, 잊어 버린 경우:"
+
+#: web/templates/registration/password_reset_email.html:9
+msgid "Thanks for using our site!"
+msgstr "저희 사이트를 이용해 주셔서 감사합니다!"
+
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "비밀번호 재설정"
+
+#: web/templates/registration/password_reset_form.html:8
+msgid "Password reset"
+msgstr "비밀번호 재설정하기"
+
+#: web/templates/registration/password_reset_form.html:11
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll email "
+"instructions for setting a new one."
+msgstr ""
+"비밀번호를 잊으셨습니까? 아래에 이메일 주소를 입력하시면 새 비밀번호 설정에 "
+"대한 지침을 이메일로 보내드립니다."
+
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "비밀번호 변경 링크가 전송됨"
+
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
 msgid ""
 "This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
 "findings, and conclusions or recommendations expressed in this material are "
 "those of the authors(s) and do not necessarily reflect the views of the "
 "National Science Foundation."
@@ -1243,48 +1450,308 @@ msgstr ""
 "또는 조언은 이 저자(들)의 것이며, 미국 국립과학재단의 관점을 반영하는 것이 아"
 "님을 밝힘니다."
 
-#: web/templates/frontpages/default.html:60 web/templates/frontpages/home.html:48
+#: web/templates/web/_footer.html:14
 msgid "Privacy"
 msgstr "개인정보정책"
 
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
+#: web/templates/web/_footer.html:17
 msgid "Contact us"
 msgstr "연구자와 연락하기"
 
-#: web/templates/frontpages/default.html:63
+#: web/templates/web/_footer.html:20
 msgid "Connect"
 msgstr "연결하기"
 
-#: web/templates/frontpages/faq.html:11
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr "로그아웃"
+
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "연구자"
+
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+#, fuzzy
+msgid "Children"
+msgstr "자녀"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "취소"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "자녀 정보 입력"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+#, fuzzy
+msgid "Child"
+msgstr "자녀"
+
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr "자녀 목록으로 돌아가기"
+
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr "삭제"
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "저장"
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "업데이트(최신정보)"
+
+#: web/templates/web/children-list.html:9
+#, fuzzy
+msgid "Update child"
+msgstr "자녀 정보 업데이트"
+
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "이름"
+
+#: web/templates/web/children-list.html:64
+msgid "No child profiles registered!"
+msgstr "등록된 자녀 정보가 없습니다!"
+
+#: web/templates/web/contact.html:10
+#, fuzzy
+msgid "Technical difficulties"
+msgstr "기술적인 어려움"
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+#, fuzzy
+msgid "Questions about the studies"
+msgstr "연구에 대한 질문들"
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+#, fuzzy
+msgid "For researchers"
+msgstr "연구자용"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+msgid "documentation"
+msgstr "선적 서류 보관 / 관련 기록"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
+msgid "Update demographics"
+msgstr "인구 통계 정보 업데이트"
+
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
+#, fuzzy
+msgid ""
+"One reason we are developing Internet-based experiments is to represent a "
+"more diverse group of families in our research. Your answers to these "
+"questions will help us understand what audience we reach, as well as how "
+"factors like speaking multiple languages or having older siblings affect "
+"children's learning."
+msgstr ""
+"저희가 인터넷 기반의 연구들을 개발하는 이유들 중 하나는, 저희 연구에 더 다양"
+"한 가족 집단을 대표하기 위해서입니다. 아래 질문들에 대한 귀하의 대답은 저희"
+"가 맞닿을 수 있는 대중과, 다국어 사용 및 형제 자매 등의 요인들이 어떻게 아이"
+"의 학습에 영향을 주는지를 이해하는 데에 도움이 될 것입니다."
+
+#: web/templates/web/demographic-data-update.html:47
+msgid ""
+"Even if you allow your study videos to be published for scientific or "
+"publicity purposes, your demographic information is never published in "
+"conjunction with your video."
+msgstr ""
+"귀하께서 참여 연구 동영상을 과학 또는 홍보 목적으로 게시하도록 허용하더라도 "
+"귀하의 인구 통계 정보는 절대로 영상과 접목되어 게시되지 않습니다."
+
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
 msgid "Frequently Asked Questions"
 msgstr "자주 묻는 질문들"
 
-#: web/templates/frontpages/faq.html:16
+#: web/templates/web/faq.html:12
 msgid "Participation"
 msgstr "연구 참여"
 
-#: web/templates/frontpages/faq.html:20
+#: web/templates/web/faq.html:22
 msgid "What is a 'study' about cognitive development?"
 msgstr "인지발달에 관한 ‘연구’란 어떤 것인가요?"
 
-#: web/templates/frontpages/faq.html:25
+#: web/templates/web/faq.html:30
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Cognitive development is the science "
+#| "of what kids understand and how they learn. Researchers in cognitive "
+#| "development are interested in questions like...</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li>what knowledge and abilities "
+#| "infants are born with, and what they have to learn from experience</li>\n"
+#| "                                    <li>how abilities like mathematical "
+#| "reasoning are organized and how they develop over time</li>\n"
+#| "                                    <li>what strategies children use to "
+#| "learn from the wide variety of data they observe</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>A study is meant to answer a very "
+#| "specific question about how children learn or what they know: for "
+#| "instance, 'Do three-month-olds recognize their parents' faces?'</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Cognitive development is the science of "
-"what kids understand and how they learn. Researchers in cognitive "
-"development are interested in questions like...</p>\n"
-"                                <ul>\n"
-"                                    <li>what knowledge and abilities infants "
-"are born with, and what they have to learn from experience</li>\n"
-"                                    <li>how abilities like mathematical "
-"reasoning are organized and how they develop over time</li>\n"
-"                                    <li>what strategies children use to "
-"learn from the wide variety of data they observe</li>\n"
-"                                </ul>\n"
-"                                <p>A study is meant to answer a very "
-"specific question about how children learn or what they know: for instance, "
-"'Do three-month-olds recognize their parents' faces?'</p>\n"
-"                                "
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
 msgstr ""
 "\n"
 "<p>인지발달에 대한 연구란 아동이 무엇을 이해하고 어떻게 배우는 지에 대해 공부"
@@ -1301,85 +1768,210 @@ msgstr ""
 "어떻게 배우고 무엇을 아는지를 공부합니다, 예: '3개월 영아들은 부모님의 얼굴"
 "을 알아볼 수 있는가?'</p>"
 
-#: web/templates/frontpages/faq.html:40
-msgid "How can we participate online?"
-msgstr "온라인으로 참여가 가능한가요?"
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
 
-#: web/templates/frontpages/faq.html:45
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
 msgid ""
 "\n"
 "                            <p>If you have a child and would like to "
-"participate, create an account and take a look at what we have available for "
-"your child's age range. You'll need a working webcam to participate.</p>\n"
-"                                <p>When you select a study, you'll be asked "
-"to read a consent form and record yourself stating that you and your child "
-"agree to participate. Then we'll guide you through what will happen during "
-"the study. Depending on your child's age, your child may answer questions "
-"directly or we may be looking for indirect signs of what she thinks is going "
-"on--like how long she looks at a surprising outcome.</p>\n"
-"                                <p>Some portions of the study will be "
-"automatically recorded using your webcam and sent securely to the Lookit "
-"platform. Trained researchers will watch the video and record your child's "
-"responses--for instance, which way he pointed, or how long she looked at "
-"each image. We'll put these together with responses from lots of other "
-"children to learn more about how kids think!</p>\n"
-"                            "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
 msgstr ""
-"\n"
-"<p>자녀가 있으시고 연구에 참여하고 싶으시다면, 계정을 만드시고 자녀의 나이에 "
-"맞는 연구들을 살펴보세요. 참여하시기 위해서는 화상카메라가 필요합니다.</p>\n"
-"                                <p>연구를 고르신 후, 동의서를 읽고 본인과 자"
-"녀가 연구 참여에 동의한다는 것을 녹화 해주시면 됩니다. 이후 연구에 대한 자세"
-"한 설명이 제공됩니다. 자녀분의 연령에 따라, 연구 방식이 달라집니다. 자녀분께"
-"서 질문에 직접 답변할 수도 있고 자녀분의 암묵적인 행동 (예: 시선 움직임)이 관"
-"찰될 수도 있습니다.</p>\n"
-"                                <p>연구의 일부분은 화상카메라를 통해 자동으"
-"로 녹화되며 Lookit 플랫폼에 안전하게 전송됩니다. 숙련된 연구자들이 비디오를 "
-"보며 자녀의 행동을 기록합니다 (예: 어떻게 손짓 했는지, 얼마 동안 그림을 보았"
-"는지). 이러한 아동들의 데이터를 분석하여 인지발달 연구가 진행됩니다!</p>"
 
-#: web/templates/frontpages/faq.html:56
-msgid "Who can create studies on Lookit?"
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Who can create studies on Lookit?"
+msgid "Who creates the studies?"
 msgstr "누가 Lookit에서 연구를 만들 수 있나요?"
 
-#: web/templates/frontpages/faq.html:61
+#: web/templates/web/faq.html:114
+#, python-format
 msgid ""
-"Any researcher with questions about how kids learn and grow can propose a "
-"Lookit study! Each institution using Lookit has to sign a contract with MIT "
-"where they agree to the <a href='/termsofuse'>Terms of Use</a> and certify "
-"that their studies will be reviewed and approved by an institutional review "
-"board. Studies are also subject to approval by Lookit. As of June 2020 we "
-"have agreements with 20 universities!"
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
 msgstr ""
-"아동이 어떻게 배우며 성장하는지에 관한 공부하는 연구자 누구나 Lookit 연구를 "
-"제안할 수 있습니다! Lookit을 사용하는 기관은 매사추세츠 공과대학(MIT)과 계약"
-"해야 하며, <a href='/termsofuse'>이용약관</a> 및 제안된 연구가 기관 검토위원"
-"회(IRB)에서 검토, 승인되는 것에 동의해야 합니다. 모든 연구는 Lookit의 승인을 "
-"거쳐야 합니다. 2020년 6월 기준 Lookit 은 20개의 대학들과 계약이 체결되었습니"
-"다."
 
-#: web/templates/frontpages/faq.html:69
-msgid "How do we provide consent to participate?"
-msgstr "연구 참여를 위해 어떻게 동의하나요?"
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
 
-#: web/templates/frontpages/faq.html:74
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+msgid "Why are you running studies online instead of in person?"
+msgstr "온라인으로 연구를 진행하는 이유는 무엇인가요?"
+
+#: web/templates/web/faq.html:159
 #, fuzzy
 msgid ""
 "\n"
-"                                <p>Rather than having the parent or legal "
-"guardian sign a form, we ask that you read aloud (or sign in ASL) a "
-"statement of consent which is recorded using your webcam. This statement "
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+"<ul>\n"
+"                                    <li>관심있는 가족들의 연구 참여를 더욱 쉽"
+"게함</li>\n"
+"                                    <li>보다 많은 아이들을 모집할 수 있음</"
+"li>\n"
+"                                    <li>대학 근처에 살고, 연구실을 방문 할 수"
+"있는 가족들뿐만 아니라 보다 많고 다양한 가족들이 참여할 수 있음</li>\n"
+"                                    <li>수개월 또는 수년으로 이어지는 종단 연"
+"구 경우, 계속 참여할 수 있음</li>\n"
+"                                    <li>아이들이 익숙하지 않은 장소보다는 집"
+"에서 참여하기 때문에 더 자연스러운 행동을 관찰할 수 있음</li>\n"
+"                                    <li>발달 장애가 있는 아동들이 쉽게 연구"
+"에 참여할 수 있는 시스템을 구축할 수 있음</li>\n"
+"                                    <li>연구를 수행하는 데 사용하는 절차를보"
+"다 투명하게 만들고 결과를 더 쉽게 replicate할 수 있음</li>\n"
+"                                    <li>연구자들이 진행하는 연구와 목적에 대"
+"해 가족들과 소통할 수 있음</li>\n"
+"                                </ul>"
+
+#: web/templates/web/faq.html:184
+msgid "How do we provide consent to participate?"
+msgstr "연구 참여를 위해 어떻게 동의하나요?"
+
+#: web/templates/web/faq.html:191
+#, fuzzy
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
 "holds the same weight as a signed form, but should be less hassle for you. "
 "It also lets us verify that you understand written English and that you "
 "understand you're being videotaped.</p>\n"
-"                                <p>Researchers watch these consent videos on "
-"a special page of the researcher interface, and record for each one whether "
-"the video shows informed consent. They cannot view other video or download "
-"data from a session unless they have confirmed that you consented to "
-"participate! If they see a consent video that does NOT clearly demonstrate "
-"informed consent--for instance, there was a technical problem and there's no "
-"audio--they may contact you to check, depending on your email settings.</p>\n"
-"                                "
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
 msgstr ""
 "\n"
 "<p>서면 서류를 작성하시는 대신, 부모님 또는 법적 보호자가 큰 소리로 연구 참"
@@ -1395,39 +1987,59 @@ msgstr ""
 "습니다. 간혹 연구자가 비디오에서 동의를 보지 못하면 (예: 기술적 결함) 다시 연"
 "락할수 있습니다.</p>"
 
-#: web/templates/frontpages/faq.html:80
-msgid "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-msgstr ""
-"https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-
-#: web/templates/frontpages/faq.html:89
+#: web/templates/web/faq.html:215
 msgid "How is our information kept secure and confidential?"
 msgstr "개인정보는 어떻게 보호되나요?"
 
-#: web/templates/frontpages/faq.html:94
+#: web/templates/web/faq.html:223
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>\n"
+#| "                                Researchers using Lookit agree to uphold "
+#| "a common set of standards about how data is protected and shared. For "
+#| "instance, they never publish children's names or birthdates, or "
+#| "information that could be used to calculate a birthdate.</p>\n"
+#| "                                <p>The Lookit researcher interface is "
+#| "designed with participant data protection as the top priority. For "
+#| "instance, a special interface lets researchers confirm consent videos "
+#| "before they are able to download any other data from your session. "
+#| "Research groups can control who has access to what data in a very fine-"
+#| "grained way, for instance allowing an assistant to confirm consent and "
+#| "send gift cards, but not download study data.</p>\n"
+#| "                                <p>All of your data, including video, is "
+#| "transmitted over a secure HTTPS connection to Lookit storage, and is "
+#| "encrypted at rest. We take security very seriously; in addition to making "
+#| "sure any software we use is up-to-date, cloud servers are configured "
+#| "securely, and unit tests cover checking that accessing data requires "
+#| "correct permissions, we conducted a risk assessment and detailed manual "
+#| "penetration testing with a security contractor prior to our 2020 launch.</"
+#| "p>\n"
+#| "                                <p>See also 'Who will see our video?'</"
+#| "p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>\n"
-"                                Researchers using Lookit agree to uphold a "
-"common set of standards about how data is protected and shared. For "
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
 "instance, they never publish children's names or birthdates, or information "
 "that could be used to calculate a birthdate.</p>\n"
-"                                <p>The Lookit researcher interface is "
-"designed with participant data protection as the top priority. For instance, "
-"a special interface lets researchers confirm consent videos before they are "
-"able to download any other data from your session. Research groups can "
-"control who has access to what data in a very fine-grained way, for instance "
-"allowing an assistant to confirm consent and send gift cards, but not "
-"download study data.</p>\n"
-"                                <p>All of your data, including video, is "
-"transmitted over a secure HTTPS connection to Lookit storage, and is "
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
 "encrypted at rest. We take security very seriously; in addition to making "
 "sure any software we use is up-to-date, cloud servers are configured "
 "securely, and unit tests cover checking that accessing data requires correct "
-"permissions, we conducted a risk assessment and detailed manual penetration "
-"testing with a security contractor prior to our 2020 launch.</p>\n"
-"                                <p>See also 'Who will see our video?'</p>\n"
-"                                "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
 msgstr ""
 "\n"
 "<p>\n"
@@ -1450,79 +2062,152 @@ msgstr ""
 "                                <p>또한 ‘누가 우리 비디오를 보나요?’를 참조하"
 "세요.</p>"
 
-#: web/templates/frontpages/faq.html:107
+#: web/templates/web/faq.html:239
 msgid "Who will see our video?"
 msgstr "누가 우리 비디오를 보나요?"
 
-#: web/templates/frontpages/faq.html:112
+#: web/templates/web/faq.html:246
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Lookit staff at MIT will have access "
+#| "to your video and other data in order to improve and promote the platform "
+#| "and help with troubleshooting. The researchers running the study you "
+#| "participated in will also have access to your video and other data (like "
+#| "responses to questions during the study, and information you fill out "
+#| "when registering a child) for research purposes. They will watch the "
+#| "video segments you send to mark down information specific to the study--"
+#| "for instance, what your child said, or how long he/she looked to the left "
+#| "versus the right of the screen. This research group may be at MIT or at "
+#| "another institution. All studies run on Lookit must be approved by an "
+#| "Institutional Review Board (IRB) that ensures participants' rights and "
+#| "welfare are protected. All researchers using Lookit also agree to Terms "
+#| "of Use that govern what data they can share and what sorts of studies are "
+#| "okay to run on Lookit; these rules are sometimes stricter than their own "
+#| "institution might be.  </p>\n"
+#| "                                <p>Whether anyone else may view the video "
+#| "depends on the privacy settings you select at the end of the study. There "
+#| "are two decisions to make: whether to share your data with Databrary, and "
+#| "how to allow your video clips to be used by the researchers you have "
+#| "selected.</p>\n"
+#| "                                <p>First, we ask if you would like to "
+#| "share your data (including video) with authorized users fo the secure "
+#| "data library Databrary. Data sharing will lead to faster progress in "
+#| "research on human development and behavior. Researchers who are granted "
+#| "access to the Databrary library must agree to treat the data with the "
+#| "same high standard of care they would use in their own laboratories. "
+#| "Learn more about Databrary's <a href=\"https://databrary.org/about."
+#| "html\">mission</a> or the <a href=\"https://databrary.org/access/"
+#| "responsibilities/investigators.html\">requirements for authorized users</"
+#| "a>.</p>\n"
+#| "                                <p>Next, we ask what types of uses of "
+#| "your video are okay with you.</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li><strong>Private</strong> This "
+#| "privacy level ensures that your video clips will be viewed only by "
+#| "authorized scientists (Lookit staff, the research group running the study "
+#| "and, if you have opted to share your data with Databrary, authorized "
+#| "Databrary users.) They will view the videos to record information about "
+#| "what your child did during the study--for instance, looking for 9 seconds "
+#| "at one image and 7 seconds at another image.</li>\n"
+#| "                                    <li><strong>Scientific and "
+#| "educational</strong> This privacy level gives permission to share your "
+#| "video clips with other researchers or students for scientific or "
+#| "educational purposes. For example, researchers might show a video clip in "
+#| "a talk at a scientific conference or an undergraduate class about "
+#| "cognitive development, or include an image or video in a scientific "
+#| "paper. In some circumstances, video or images may be available online, "
+#| "for instance as supplemental material in a scientific paper. Sharing "
+#| "videos with other researchers helps other groups trust and build on our "
+#| "work.</li>\n"
+#| "                                    <li><strong>Publicity</strong> This "
+#| "privacy level is for families who would be excited to see their child "
+#| "featured on the Lookit website or in the news! Selecting this privacy "
+#| "level gives permission to use your video clips to communicate about "
+#| "developmental studies and the Lookit platform with the public. For "
+#| "instance, we might post a short video clip on the Lookit website, on our "
+#| "Facebook page, or in a press release. Your video will never be used for "
+#| "commercial purposes.</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>If for some reason you do not select a "
+#| "privacy level, we treat the data as 'Private' and do not share with "
+#| "Databrary. Participants also have the option to withdraw all video "
+#| "besides consent at the end of the study if necessary (for instance, "
+#| "because someone was discussing state secrets in the background), and in "
+#| "this case it is automatically deleted. Privacy settings for completed "
+#| "sessions cannot automatically be changed retroactively. If you have any "
+#| "questions or concerns about privacy, please contact our team at <a "
+#| "href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Lookit staff at MIT will have access to "
-"your video and other data in order to improve and promote the platform and "
-"help with troubleshooting. The researchers running the study you "
-"participated in will also have access to your video and other data (like "
-"responses to questions during the study, and information you fill out when "
-"registering a child) for research purposes. They will watch the video "
-"segments you send to mark down information specific to the study--for "
-"instance, what your child said, or how long he/she looked to the left versus "
-"the right of the screen. This research group may be at MIT or at another "
-"institution. All studies run on Lookit must be approved by an Institutional "
-"Review Board (IRB) that ensures participants' rights and welfare are "
-"protected. All researchers using Lookit also agree to Terms of Use that "
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
 "govern what data they can share and what sorts of studies are okay to run on "
-"Lookit; these rules are sometimes stricter than their own institution might "
-"be.  </p>\n"
-"                                <p>Whether anyone else may view the video "
-"depends on the privacy settings you select at the end of the study. There "
-"are two decisions to make: whether to share your data with Databrary, and "
-"how to allow your video clips to be used by the researchers you have "
-"selected.</p>\n"
-"                                <p>First, we ask if you would like to share "
-"your data (including video) with authorized users fo the secure data library "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
 "Databrary. Data sharing will lead to faster progress in research on human "
 "development and behavior. Researchers who are granted access to the "
 "Databrary library must agree to treat the data with the same high standard "
 "of care they would use in their own laboratories. Learn more about "
-"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> "
-"or the <a href=\"https://databrary.org/access/responsibilities/investigators."
-"html\">requirements for authorized users</a>.</p>\n"
-"                                <p>Next, we ask what types of uses of your "
-"video are okay with you.</p>\n"
-"                                <ul>\n"
-"                                    <li><strong>Private</strong> This "
-"privacy level ensures that your video clips will be viewed only by "
-"authorized scientists (Lookit staff, the research group running the study "
-"and, if you have opted to share your data with Databrary, authorized "
-"Databrary users.) They will view the videos to record information about what "
-"your child did during the study--for instance, looking for 9 seconds at one "
-"image and 7 seconds at another image.</li>\n"
-"                                    <li><strong>Scientific and educational</"
-"strong> This privacy level gives permission to share your video clips with "
-"other researchers or students for scientific or educational purposes. For "
-"example, researchers might show a video clip in a talk at a scientific "
-"conference or an undergraduate class about cognitive development, or include "
-"an image or video in a scientific paper. In some circumstances, video or "
-"images may be available online, for instance as supplemental material in a "
-"scientific paper. Sharing videos with other researchers helps other groups "
-"trust and build on our work.</li>\n"
-"                                    <li><strong>Publicity</strong> This "
-"privacy level is for families who would be excited to see their child "
-"featured on the Lookit website or in the news! Selecting this privacy level "
-"gives permission to use your video clips to communicate about developmental "
-"studies and the Lookit platform with the public. For instance, we might post "
-"a short video clip on the Lookit website, on our Facebook page, or in a "
-"press release. Your video will never be used for commercial purposes.</li>\n"
-"                                </ul>\n"
-"                                <p>If for some reason you do not select a "
-"privacy level, we treat the data as 'Private' and do not share with "
-"Databrary. Participants also have the option to withdraw all video besides "
-"consent at the end of the study if necessary (for instance, because someone "
-"was discussing state secrets in the background), and in this case it is "
-"automatically deleted. Privacy settings for completed sessions cannot "
-"automatically be changed retroactively. If you have any questions or "
-"concerns about privacy, please contact our team at <a href=\"mailto:"
-"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
-"                                "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
 msgstr ""
 "\n"
 " <p>MIT의 Lookit 직원은 플랫폼 개선 및 홍보, 문제 해결을 돕기 위해 귀하의 비"
@@ -1544,8 +2229,8 @@ msgstr ""
 "사용자와 데이터를 (비디오 포함) 공유할 것인지 묻습니다. 데이터 공유는 인간의 "
 "발달과 행동에 대한 연구의 빠른 진전에 도움될 것입니다. Databrary에 대한 접근 "
 "권한이 부여된 연구자는 자신의 연구실에서 사용하는 것과 동일한 수준의 관리로 "
-"데이터를 처리하는데 동의해야합니다. Learn more about Databrary's <a href="
-"\"https://databrary.org/about.html\">사명</a> 혹은 <a href=\"https://"
+"데이터를 처리하는데 동의해야합니다. Learn more about Databrary's <a "
+"href=\"https://databrary.org/about.html\">사명</a> 혹은 <a href=\"https://"
 "databrary.org/access/responsibilities/investigators.html\">승인된 사용자에 대"
 "한 요구 사항</a>에 대해 자세히 알아보세요.</p>\n"
 "                                <p>다음으로, 귀하의 동영상 사용 유형이 귀하에"
@@ -1582,11 +2267,11 @@ msgstr ""
 "나 우려 사항이 있으면 <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>로 "
 "문의하십시오.</p>"
 
-#: web/templates/frontpages/faq.html:130
+#: web/templates/web/faq.html:269
 msgid "What information do researchers use from our video?"
 msgstr "연구자들은 녹화된 비디오에서 어떤 정보를 사용하나요?"
 
-#: web/templates/frontpages/faq.html:136
+#: web/templates/web/faq.html:278
 msgid ""
 "For children under about two years old, we usually design our studies to let "
 "their eyes do the talking! We're interested in where on the screen your "
@@ -1600,7 +2285,7 @@ msgstr ""
 "(calibration)을 통해 아이가 화면의 오른쪽 또는 왼쪽을 보고 있는지 정확히 파악"
 "하며 비디오를 분석합니다."
 
-#: web/templates/frontpages/faq.html:143
+#: web/templates/web/faq.html:290
 msgid ""
 "Here's an example of a few children watching our calibration video--it's "
 "easy to see that they look to one side and then the other."
@@ -1608,7 +2293,7 @@ msgstr ""
 "다음은 시선 교정(calibration) 비디오를 보는 몇몇 어린이들의 예입니다 - 아이들"
 "이 화면의 한 쪽을 보았는지 또는 다른 한 쪽을 보았는지를 볼 수 있습니다."
 
-#: web/templates/frontpages/faq.html:149
+#: web/templates/web/faq.html:302
 msgid ""
 "Your child's decisions about where to look can give us lots of information "
 "about what he or she understands. Here are some of the techniques labs use "
@@ -1618,37 +2303,36 @@ msgstr ""
 "많은 정보를 알 수 있습니다. 다음은 아동이 학습하는 방법에 대해 자세히 알아보"
 "기 위해 연구실에서 사용하는 몇 가지 기술입니다."
 
-#: web/templates/frontpages/faq.html:150
+#: web/templates/web/faq.html:304
 msgid "Habituation"
 msgstr "습관화"
 
-#: web/templates/frontpages/faq.html:151
+#: web/templates/web/faq.html:305
 #, fuzzy
 msgid ""
 "\n"
-"                                <p>In a habituation study, we first show "
-"infants many examples of one type of object or event, and they lose interest "
-"over time. Infants typically look for a long time at the first pictures, but "
-"then they start to look away more quickly. Once their looking times are much "
-"less than they were initially, we show either a picture from a new category "
-"or a new picture from the familiar category. If infants now look longer to "
-"the novel example, we can tell that they understood--and got bored of--the "
-"category we showed initially.</p>\n"
-"                                <p>Habituation requires waiting for each "
-"individual infant to achieve some threshold of \"boredness\"--for instance, "
-"looking half as long at a picture as he or she did initially. Sometimes this "
-"is impractical, and we use familiarization instead. In a familiarization "
-"study, we show all babies the same number of examples, and then see how "
-"interested they are in the familiar versus a new category. Younger infants "
-"and those who have seen few examples tend to show a familiarity preference--"
-"they look longer at images similar to what they have seen before. Older "
-"infants and those who have seen many examples tend to show a novelty "
-"preference--they look longer at images that are different from the ones they "
-"saw before. You probably notice the same phenomenon when you hear a new song "
-"on the radio: initially you don't recognize it; after it's played several "
-"times you may like it and sing along; after it's played hundreds of times "
-"you would choose to listen to anything else.</p>\n"
-"                                "
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
 msgstr ""
 "<p>습관화 연구에서는 연구자가 먼저 한가지 유형의 물건이나 현상에 대한 많은 예"
 "제를 유아에게 보여줍니다. 그리고 영유아는 시간이 지남에 따라 반복되는 물건 또"
@@ -1671,12 +2355,12 @@ msgstr ""
 "라 부를 수 있습니다. 수백 번 재생한 후에는 다른 것을 듣기를 선택하실 수도 있"
 "습니다."
 
-#: web/templates/frontpages/faq.html:156
+#: web/templates/web/faq.html:308
 #, fuzzy
 msgid "Violation of expectation"
 msgstr "기대 위배 패러다임"
 
-#: web/templates/frontpages/faq.html:157
+#: web/templates/web/faq.html:310
 msgid ""
 "Infants and children already have rich expectations about how events work. "
 "Children (and adults for that matter) tend to look longer at things they "
@@ -1687,12 +2371,12 @@ msgstr ""
 "이 (및 성인)은 놀라운 것을 더 오래 보는 경향이 있으므로, 어떤 경우에는 그들"
 "이 얼마나 놀랐는지의 척도로, 보는 시간을 재기도 합니다."
 
-#: web/templates/frontpages/faq.html:158
+#: web/templates/web/faq.html:312
 #, fuzzy
 msgid "Preferential looking"
 msgstr "보기 선호 과제"
 
-#: web/templates/frontpages/faq.html:159
+#: web/templates/web/faq.html:314
 msgid ""
 "Even when they seem to be passive observers, children are making lots of "
 "decisions about where to look and what to pay attention to. In this "
@@ -1710,12 +2394,12 @@ msgstr ""
 "는 참가자에게 '박수치고 있는 행동을 찾으세요'라는 문장을 들었을 때 왼쪽을 보"
 "고있는 모습을 보여줍니다: 참가자가 보는 화면은 상단에 표시됩니다."
 
-#: web/templates/frontpages/faq.html:165
+#: web/templates/web/faq.html:325
 #, fuzzy
 msgid "Predictive looking"
 msgstr "보기 예측 과제"
 
-#: web/templates/frontpages/faq.html:166
+#: web/templates/web/faq.html:327
 msgid ""
 "Children can often make sophisticated predictions about what they expect to "
 "see or hear next. One way we can see those predictions in young children is "
@@ -1736,7 +2420,7 @@ msgstr ""
 "이 음절을 들을 때 어디를 보는지를 보며, 아이들이 이러한 관계를 어떻게 배우고 "
 "일반화하는지 알 수 있습니다."
 
-#: web/templates/frontpages/faq.html:168
+#: web/templates/web/faq.html:330
 #, fuzzy
 msgid ""
 "Older children may simply be able to answer spoken questions about what they "
@@ -1748,7 +2432,7 @@ msgstr ""
 "에 대답할 수 있습니다. 예를 들어, 두 명의 여성이 한가지 물체에 다른 이름을 불"
 "렀고 아이들에게 물체의 맞는 이름이 무엇인지 물을 수 있습니다."
 
-#: web/templates/frontpages/faq.html:174
+#: web/templates/web/faq.html:342
 msgid ""
 "Another way we can learn about how older children (and adults) think is to "
 "measure their reaction times. For instance, we might ask you to help your "
@@ -1762,88 +2446,7 @@ msgstr ""
 "을 도와달라고 요청할 수 있습니다. 그리고 연구자들은 얼마나 빠르게 키를 누르"
 "는 지에 영향을 미치는 요인을 살펴볼 수 있습니다."
 
-#: web/templates/frontpages/faq.html:181
-msgid "Why are you running studies online instead of in person?"
-msgstr "온라인으로 연구를 진행하는 이유는 무엇인가요?"
-
-#: web/templates/frontpages/faq.html:186
-msgid ""
-"Traditionally, developmental studies happen in a quiet room in a university "
-"lab. Researchers call or email local parents to see if they'd like to take "
-"part and schedule an appointment for them to come visit the lab. Why "
-"complement these in-lab studies with online ones? We're hoping to..."
-msgstr ""
-"일반적으로 발달 연구는 대학교 연구실의 조용한 공간에서 이루어집니다. 연구자들"
-"은 부모님께 전화 또는 이메일을 보내 참여하고 싶은지 의사를 물어보고 연구실을 "
-"방문하도록 약속을 잡습니다. 이러한 일반적인 방법과 달리 저희가 온라인으로 연"
-"구를 진행하는 이유는 아래와 같습니다."
-
-#: web/templates/frontpages/faq.html:187
-#, fuzzy
-msgid ""
-"\n"
-"                                <ul>\n"
-"                                    <li>Make it easier for you to take part "
-"in research, especially for families without a stay-at-home parent</li>\n"
-"                                    <li>Work with more kids when needed--"
-"right now a limiting factor in designing studies is the time it takes to "
-"recruit participants</li>\n"
-"                                    <li>Draw conclusions from a more "
-"representative population of families--not just those who live near a "
-"university and are able to visit the lab during the day.\n"
-"                                    </li>\n"
-"                                    <li>Make it easier for families to "
-"continue participating in longitudinal studies, which may involve multiple "
-"testing sessions separated by months or years</li>\n"
-"                                    <li>Observe more natural behavior "
-"because children are at home rather than in an unfamiliar place</li>\n"
-"                                    <li>Create a system for learning about "
-"special populations--for instance, children with specific developmental "
-"disorders</li>\n"
-"                                    <li>Make the procedures we use in doing "
-"research more transparent, and make it easier to replicate our findings</"
-"li>\n"
-"                                    <li>Communicate with families about the "
-"research we're doing and what we can learn from it</li>\n"
-"                                </ul>\n"
-"                                "
-msgstr ""
-"<ul>\n"
-"                                    <li>관심있는 가족들의 연구 참여를 더욱 쉽"
-"게함</li>\n"
-"                                    <li>보다 많은 아이들을 모집할 수 있음</"
-"li>\n"
-"                                    <li>대학 근처에 살고, 연구실을 방문 할 수"
-"있는 가족들뿐만 아니라 보다 많고 다양한 가족들이 참여할 수 있음</li>\n"
-"                                    <li>수개월 또는 수년으로 이어지는 종단 연"
-"구 경우, 계속 참여할 수 있음</li>\n"
-"                                    <li>아이들이 익숙하지 않은 장소보다는 집"
-"에서 참여하기 때문에 더 자연스러운 행동을 관찰할 수 있음</li>\n"
-"                                    <li>발달 장애가 있는 아동들이 쉽게 연구"
-"에 참여할 수 있는 시스템을 구축할 수 있음</li>\n"
-"                                    <li>연구를 수행하는 데 사용하는 절차를보"
-"다 투명하게 만들고 결과를 더 쉽게 replicate할 수 있음</li>\n"
-"                                    <li>연구자들이 진행하는 연구와 목적에 대"
-"해 가족들과 소통할 수 있음</li>\n"
-"                                </ul>"
-
-#: web/templates/frontpages/faq.html:206
-msgid "When will we see the results of the study?"
-msgstr "연구 결과는 언제 볼 수 있나요?"
-
-#: web/templates/frontpages/faq.html:211
-msgid ""
-"The process of publishing a scientific study, from starting data collection "
-"to seeing the paper in a journal, can take several years. You can check the "
-"Lookit home page for updates on papers, or set your communication "
-"preferences to be notified when we have results from studies you "
-"participated in."
-msgstr ""
-"데이터 수집을 시작하고 학술지에서 논문이 출판되기까지 과정은 몇 년이 걸릴 수 "
-"있습니다. Lookit 홈페이지에서 논문 업데이트를 확인하거나 참여한 연구 결과가있"
-"을 때 알림을 받도록 커뮤니케이션 선호도를 설정하실 수 있습니다."
-
-#: web/templates/frontpages/faq.html:218
+#: web/templates/web/faq.html:355
 msgid ""
 "My child wasn't paying attention, or we were interrupted. Can we try the "
 "study again?"
@@ -1851,7 +2454,7 @@ msgstr ""
 "연구 참여 도중 아이가 주의를 기울이지 않았거나 방해받았습니다. 참여를 다시 시"
 "도 할 수 있나요?"
 
-#: web/templates/frontpages/faq.html:223
+#: web/templates/web/faq.html:364
 msgid ""
 "Certainly--thanks for your dedication! You may see a warning that you have "
 "already participated in the study when you go to try it again, but you can "
@@ -1862,14 +2465,14 @@ msgstr ""
 "만 무시하셔도됩니다. 귀하의 이전 참여 기록이 있기 때문에 이전에 연구를 시도했"
 "다고 따로 알려주실 필요는 없습니다. "
 
-#: web/templates/frontpages/faq.html:230
+#: web/templates/web/faq.html:377
 msgid ""
 "My child is outside the age range. Can he/she still participate in this "
 "study?"
 msgstr ""
 "제 아이는 연구 참여 연령대를 벗어났습니다. 이 연구에 계속 참여할 수 있나요?"
 
-#: web/templates/frontpages/faq.html:235
+#: web/templates/web/faq.html:386
 #, fuzzy
 msgid ""
 "Sure! We may not be able to use his or her data in our research directly, "
@@ -1884,13 +2487,13 @@ msgstr ""
 "이가 연구에 참여할 수 있는 최소 연령 미만인 경우 조금 더 기다리신 뒤에 참여하"
 "시길 추천드립니다."
 
-#: web/templates/frontpages/faq.html:242
+#: web/templates/web/faq.html:399
 #, fuzzy
 msgid "My child was born prematurely. Should we use his/her adjusted age?"
 msgstr ""
 "제 아이는 예정일보다 일찍 (조산) 태어났습니다. 조정된 나이를 사용해야 하나요?"
 
-#: web/templates/frontpages/faq.html:247
+#: web/templates/web/faq.html:408
 #, fuzzy
 msgid ""
 "For study eligibility, we usually use the child's chronological age (time "
@@ -1901,7 +2504,7 @@ msgstr ""
 "시간)을 사용합니다. 특정 연구에 대해 조정된 나이가 중요한 경우, 연구 자격 기"
 "준에서 이를 명확히 할 것입니다."
 
-#: web/templates/frontpages/faq.html:254
+#: web/templates/web/faq.html:421
 msgid ""
 "Our family speaks a language other than English at home. Can my child "
 "participate?"
@@ -1909,7 +2512,7 @@ msgstr ""
 "우리 가족은 집에서 한국어가 아닌 다른 언어를 사용합니다. 우리 아이가 참여할 "
 "수 있나요?"
 
-#: web/templates/frontpages/faq.html:259
+#: web/templates/web/faq.html:430
 #, fuzzy
 msgid ""
 "Sure! Right now, instructions for children and parents are written only in "
@@ -1927,7 +2530,7 @@ msgstr ""
 "릴 것입니다. 또한 인구 통계 조사에서 자녀가 사용하는 언어나 말하기를 배우고있"
 "는 언어를 표시 하실 수 있습니다."
 
-#: web/templates/frontpages/faq.html:266
+#: web/templates/web/faq.html:443
 msgid ""
 "My child has been diagnosed with a developmental disorder or has special "
 "needs. Can he/she still participate?"
@@ -1935,20 +2538,32 @@ msgstr ""
 "제 아이가 발달 장애 진단을 받았거나 특별한 도움이 필요합니다. 그래도 연구에 "
 "참여할 수 있습니까?"
 
-#: web/templates/frontpages/faq.html:271
+#: web/templates/web/faq.html:451
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Of course! We're interested in how all "
+#| "children learn and grow. If you'd like, you can make a note of any "
+#| "developmental disorders in the comments section at the end of the study. "
+#| "We are excited that in the future, online studies may help more families "
+#| "participate in research to better understand their own children's "
+#| "diagnoses.</p>\n"
+#| "                                <p>One note: most of our studies include "
+#| "both images and sound, and may be hard to understand if your child is "
+#| "blind or deaf. If you can, please feel free to help out by describing "
+#| "images or signing.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Of course! We're interested in how all "
-"children learn and grow. If you'd like, you can make a note of any "
-"developmental disorders in the comments section at the end of the study. We "
-"are excited that in the future, online studies may help more families "
-"participate in research to better understand their own children's diagnoses."
-"</p>\n"
-"                                <p>One note: most of our studies include "
-"both images and sound, and may be hard to understand if your child is blind "
-"or deaf. If you can, please feel free to help out by describing images or "
-"signing.</p>\n"
-"                                "
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
 msgstr ""
 "\n"
 "<p>물론입니다! 우리는 모든 아이들이 어떻게 배우고 성장하는지에 관심이 있습니"
@@ -1959,13 +2574,13 @@ msgstr ""
 "시각 장애 또는 청각 장애가 있으신 경우 이해가 어려울 수 있습니다. 가능하시다"
 "면 이미지를 말 또는 수화를 통해 도와주셔도 됩니다.</p>"
 
-#: web/templates/frontpages/faq.html:281
+#: web/templates/web/faq.html:466
 msgid ""
 "I have multiple children in the age range for a study. Can they participate "
 "together?"
 msgstr "연구 대상 연령대에 여러 자녀가 있습니다. 함께 참여할 수 있습니까?"
 
-#: web/templates/frontpages/faq.html:286
+#: web/templates/web/faq.html:475
 msgid ""
 "If possible, we ask that each child participate separately. When children "
 "participate together they generally influence each other. That's a "
@@ -1976,27 +2591,27 @@ msgstr ""
 "하면 일반적으로 서로에게 영향을 미칩니다. 그것은 그 자체로 흥미있는 주제이지"
 "만 일반적으로 우리 연구의 초점은 아닙니다."
 
-#: web/templates/frontpages/faq.html:293
+#: web/templates/web/faq.html:488
 msgid "But I've heard that young children should avoid 'screen time.'"
 msgstr ""
 "하지만 어린 아이들은 '영상매체에 노출되는 시간'(screen time)을 피해야한다고 "
 "들었습니다. "
 
-#: web/templates/frontpages/faq.html:298
+#: web/templates/web/faq.html:496
 #, fuzzy
 msgid ""
 "\n"
-"                                <p>We agree with the American Academy of "
-"Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
-"e20162591\" target=\"_blank\">advice</a> that children learn best from "
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
 "people, not screens! However, our studies are not intended to educate "
 "children, but to learn from them.</p>\n"
-"                                <p>As part of a child's limited screen time, "
-"we hope that our studies will foster family conversation and engagement with "
-"science that offsets the few minutes spent watching a video instead of "
-"playing. And we do \"walk the walk\"--our own young children provide lots of "
-"feedback on our studies!</p>\n"
-"                                "
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
 msgstr ""
 "<p> 우리는 미국 소아과 협회 <a href=\"https://pediatrics.aappublications.org/"
 "content/138/5/e20162591\" target=\"_blank\"> 조언 </a>, 즉 어린이는 스크린이 "
@@ -2006,11 +2621,11 @@ msgstr ""
 "<p> **수정** 어린이의 제한된 영상매체에 노출되는 시간, 우리의 연구가 가족과"
 "의 대화와 과학에 대한 참여를 촉진하기 바랍니다! </p>"
 
-#: web/templates/frontpages/faq.html:308
+#: web/templates/web/faq.html:510
 msgid "Will we be paid for our participation?"
 msgstr "연구 참여에 대한 보상이 있습니까?"
 
-#: web/templates/frontpages/faq.html:313
+#: web/templates/web/faq.html:518
 msgid ""
 "Some research groups provide gift cards or other compensation for completing "
 "their studies, and others rely on volunteers. (This often depends on the "
@@ -2021,92 +2636,185 @@ msgstr ""
 "자원 봉사자에게 의존합니다. (이것은 종종 연구를 수행하는 대학의 규칙에 따라 "
 "다릅니다.) 연구 보상 관련 정보는 연구 설명 페이지에서 확인하실 수 있습니다."
 
-#: web/templates/frontpages/faq.html:320
-msgid "Can I get my child's results?"
-msgstr "내 자녀의 연구 결과를 받을 수 있습니까?"
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
 
-#: web/templates/frontpages/faq.html:325
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "                                <p>For some studies, yes! Usually, "
-#| "developmental researchers only interpret children's abilities and "
-#| "developmental trends at a group level, and the individual data collected "
-#| "just isn't very interpretable. But for \"Your baby, the physicist\" and "
-#| "other longitudinal studies (where you come back for more than one "
-#| "session), we can sometimes collect enough data to give you a report of "
-#| "your child's responses after you complete all the sessions.</p>\n"
-#| "                                <p>Please note that none of the measures "
-#| "we collect are diagnostic! For instance, while we hope you'll be "
-#| "interested to learn that your child looked 70%% of the time at videos "
-#| "where things fell up versus falling down, we won't be able to tell you "
-#| "whether this means your child is going to be especially good at physics.</"
-#| "p>\n"
-#| "                                <p>If you're interested in getting "
-#| "individual results right away, please see our <a "
-#| "href='resources'>Resources</a> section for fun at-home activities you can "
-#| "try with your child.</p>\n"
-#| "                                "
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
 msgid ""
 "\n"
-"                                <p>For some studies, yes! Usually, "
-"developmental researchers only interpret children's abilities and "
-"developmental trends at a group level, and the individual data collected "
-"just isn't very interpretable. But for \"Your baby, the physicist\" and "
-"other longitudinal studies (where you come back for more than one session), "
-"we can sometimes collect enough data to give you a report of your child's "
-"responses after you complete all the sessions.</p>\n"
-"                                <p>Please note that none of the measures we "
-"collect are diagnostic! For instance, while we hope you'll be interested to "
-"learn that your child looked 70%% of the time at videos where things fell up "
-"versus falling down, we won't be able to tell you whether this means your "
-"child is going to be especially good at physics.</p>\n"
-"                                <p>If you're interested in getting "
-"individual results right away, please see our <a href='resources'>Resources</"
-"a> section for fun at-home activities you can try with your child.</p>\n"
-"                                "
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
 msgstr ""
-"\n"
-"<p>일부 연구의 경우 귀하 자녀의 결과를 받으실 수 있습니다! 일반적으로 발달 연"
-"구자들은 개별 단계가 아닌 집단 단계에서 아동의 능력과 발달 경향성을 해석합니"
-"다. 그러나 '아기, 물리학자\" 및 다른 종적 연구 (여러 세션을 위해 반복하여 참"
-"여하는 연구) 경우 모든 세션을 완료한 후 자녀의 결과에 대한 보고서를 제공할 "
-"수 있습니다.</p>\n"
-"\n"
-"<p>저희가 수집하는 어떤 데이터도 그 어떤 진단에 쓰일 수 없다는 점을 기억해주"
-"세요! 예를 들어, 자녀가 물건이 넘어지거나 떨어지는 비디오를 70% 만큼 봤다는 "
-"사실만으로, 자녀가 물리학에 뛰어날 것이란 걸 예측할 수는 없습니다.</p>\n"
-"\n"
-"<p>개별 결과를 즉시 얻고 싶으시면, <a href='resources'>참고 자료실</a>창에서 "
-"자녀와 함께 할 수 있는 재미있는 활동들을 참조하십시오.</p>"
 
-#: web/templates/frontpages/faq.html:335
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
 msgid "Technical"
 msgstr "기술 관련 자주 묻는 질문들"
 
-#: web/templates/frontpages/faq.html:339
+#: web/templates/web/faq.html:652
 msgid "What browsers are supported?"
 msgstr "어떤 브라우저가 지원됩니까?"
 
-#: web/templates/frontpages/faq.html:344
+#: web/templates/web/faq.html:660
+#, fuzzy
+#| msgid ""
+#| "Lookit supports recent versions of Chrome and Firefox. We are not "
+#| "currently able to support Internet Explorer or Safari."
 msgid ""
-"Lookit supports recent versions of Chrome and Firefox. We are not currently "
-"able to support Internet Explorer or Safari."
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
 msgstr ""
 "Lookit은 최신 버전의 Chrome 및 Firebox를 지원합니다. 현재 Internet Explorer "
 "또는 Safari를 지원할 수 없습니다."
 
-#: web/templates/frontpages/faq.html:351
+#: web/templates/web/faq.html:672
 msgid "Can we do a study on my phone or tablet?"
 msgstr "휴대전화나 태블릿으로 연구에 참여할 수 있습니까?"
 
-#: web/templates/frontpages/faq.html:357
+#: web/templates/web/faq.html:679
+#, fuzzy
+#| msgid ""
+#| "Not yet! Because we're measuring kids' looking patterns, we need a "
+#| "reasonably stable view of their eyes and a big enough screen that we can "
+#| "tell whether they're looking at the left or the right side of it. We're "
+#| "excited about the potential for touchscreen studies that allow us to "
+#| "observe infants and toddlers exploring, though!"
 msgid ""
-"Not yet! Because we're measuring kids' looking patterns, we need a "
-"reasonably stable view of their eyes and a big enough screen that we can "
-"tell whether they're looking at the left or the right side of it. We're "
-"excited about the potential for touchscreen studies that allow us to observe "
-"infants and toddlers exploring, though!"
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
 msgstr ""
 "아직은 휴대전화나 태블릿을 이용해 연구 참여가 불가능합니다. 우리는 아이들의 "
 "시각(looking) 패턴을 측정하기 때문에 아이들의 눈에 대한 상당히 안정적인 시야"
@@ -2114,92 +2822,318 @@ msgstr ""
 "이 필요합니다. 우리는 영유아가 탐험하는것을 관찰할 수 있는 터치 스크린 연구"
 "의 잠재력에 대해 기대하고 있습니다."
 
-#: web/templates/frontpages/home.html:11
-msgid "the online child lab"
-msgstr "온라인 아동 연구실 "
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
 
-#: web/templates/frontpages/home.html:12
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
 #, fuzzy
-msgid "A project of the MIT Early Childhood Cognition Lab"
-msgstr "MIT 유아기 인지 연구실의 프로젝트"
+msgid "What security measures do you implement?"
+msgstr "귀하는 어느 지역 (도, 특별시) 에 살고 계십니까?"
 
-#: web/templates/frontpages/home.html:12
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+msgid "For Researchers"
+msgstr "연구자용"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "귀하의 만 나이는 무엇입니까?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "참여하시려면 로그인하십시오."
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+msgid "Meet the GARDEN Scientists"
+msgstr "연구자들"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
 #, fuzzy
 #| msgid "Participation"
 msgid "Participate in a Study"
 msgstr "연구 참여"
 
-#: web/templates/frontpages/home.html:22
-msgid "Bringing science home"
-msgstr "집에서 진행하는 연구"
-
-#: web/templates/frontpages/home.html:23
-msgid ""
-"Here at MIT's Early Childhood Cognition Lab, we're trying a new approach in "
-"developmental psychology: bringing the experiments to you."
+#: web/templates/web/home.html:52
+msgid "Help Science"
 msgstr ""
-"MIT에서 진행하는 유아기 인지 연구실입니다, 저희는 여러분들이 연구에 참여하실 "
-"수 있도록 발달 심리학에 대한 새로운 접근을 시도하고 있습니다."
 
-#: web/templates/frontpages/home.html:29
-msgid "Help us understand how your child thinks"
-msgstr "귀하의 자녀가 어떻게 생각 하는지에 대한 이해를 돕는데 참여해 주세요"
-
-#: web/templates/frontpages/home.html:30
+#: web/templates/web/home.html:54
 msgid ""
-"Your family can contribute to research about how children learn by doing fun "
-"activities together, right in your web browser."
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
 msgstr ""
-"귀하의 가족은 이 웹 브라우저에서 함께 재미있는 활동을 함으로써 아이들이 어떻"
-"게 배우는지에 대한 연구에 기여할 수 있습니다."
 
-#: web/templates/frontpages/home.html:36
-msgid "Participate whenever and wherever"
-msgstr "연구에 언제든 어디서든 참여해보십시오."
+#: web/templates/web/home.html:59
+#, fuzzy
+msgid "From Home"
+msgstr "홈(메인 페이지)"
 
-#: web/templates/frontpages/home.html:37
+#: web/templates/web/home.html:61
 msgid ""
-"Log in or create an account at the top right to get started! You can "
-"participate with your child from any computer with a webcam."
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
 msgstr ""
-"우측 상단에서 로그인을 하시거나 계정을 생성하여 시작하십시오! 화상 카메라가 "
-"달린 컴퓨터를 사용하여 아이와 연구에 참여하실 수 있습니다."
 
-#: web/templates/frontpages/privacy.html:11
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
+msgid "I would like to be contacted when:"
+msgstr "다음의 경우에 연락을 받고 싶습니다:"
+
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "참여하시려면 로그인하십시오."
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "계정 만들기"
+
+#: web/templates/web/participant-signup.html:13
+msgid "Create Participant Account"
+msgstr "연구 참여자 계정 만들기"
+
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "연구자로서 등록하시려면 이것을 사용해주십시오"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+msgid "instead."
+msgstr "대신"
+
+#: web/templates/web/participant-signup.html:28
+msgid ""
+"By clicking 'Create Account', I agree that I have read and accepted the "
+msgstr "'계정 만들기'를 클릭하여 다음 내용을 읽고 수락하는 것에 동의합니다. "
+
+#: web/templates/web/participant-signup.html:28
+msgid "Privacy Statement"
+msgstr "개인 정보 보호 정책"
+
+#: web/templates/web/privacy.html:9
 msgid "Privacy statement"
 msgstr "개인정보보호방침"
 
-#: web/templates/frontpages/privacy.html:17
+#: web/templates/web/privacy.html:11
 msgid "Introduction"
 msgstr "개요"
 
-#: web/templates/frontpages/privacy.html:18
+#: web/templates/web/privacy.html:14
+#, fuzzy
+#| msgid ""
+#| "Lookit is committed to supporting the privacy of individuals who enroll "
+#| "on our Platform to conduct\n"
+#| "                research or serve as research subjects. This Privacy "
+#| "Statement explains how we handle and use the\n"
+#| "                personal information we collect about our researchers and "
+#| "research participant community."
 msgid ""
 "Lookit is committed to supporting the privacy of individuals who enroll on "
 "our Platform to conduct\n"
-"                research or serve as research subjects. This Privacy "
-"Statement explains how we handle and use the\n"
-"                personal information we collect about our researchers and "
-"research participant community."
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
 msgstr ""
 "Lookit은 연구 진행 및 연구 참여 목적으로 본 플랫폼에 등록된 (개인의) 개인정보"
 "보호 방침을 수립하고 이를 따를 것을 알려드립니다. 이 개인정보보호정책 안내문"
 "은 우리 연구자들과 연구참여자들로부터 수집한 개인정보를 어떻게 관리하고 사용"
 "하는지 설명합니다."
 
-#: web/templates/frontpages/privacy.html:22
+#: web/templates/web/privacy.html:19
 msgid "For participants"
 msgstr "참가자용 안내문"
 
-#: web/templates/frontpages/privacy.html:24
+#: web/templates/web/privacy.html:22
+#, fuzzy
+#| msgid ""
+#| "Lookit is a platform that many different researchers use to conduct "
+#| "studies about how children learn and\n"
+#| "                develop. It is run by the MIT Early Childhood Cognition "
+#| "Lab, which has access to all of the data\n"
+#| "                collected on Lookit. Researchers using Lookit to conduct "
+#| "studies only access your personal information\n"
+#| "                if you choose to participate in their study."
 msgid ""
 "Lookit is a platform that many different researchers use to conduct studies "
 "about how children learn and\n"
-"                develop. It is run by the MIT Early Childhood Cognition Lab, "
-"which has access to all of the data\n"
-"                collected on Lookit. Researchers using Lookit to conduct "
-"studies only access your personal information\n"
-"                if you choose to participate in their study."
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
 msgstr ""
 "Lookit은 다수의 다양한 연구자들이 아동의 학습과 발달에 대한 연구를 진행하기 "
 "위해 사용하는 플랫폼입니다. Lookit은 메사추세츠 공과대학 소속 유아기 인지 연"
@@ -2208,35 +3142,54 @@ msgstr ""
 "여 연구를 진행하는 연구자들은 귀하께서 연구 참여를 선택하신 경우에만 귀하의 "
 "개인 정보에 접근이 가능합니다."
 
-#: web/templates/frontpages/privacy.html:29
-#: web/templates/frontpages/privacy.html:142
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
 msgid "What personal information we collect"
 msgstr "수집되는 개인 정보 안내"
 
-#: web/templates/frontpages/privacy.html:31
+#: web/templates/web/privacy.html:30
 msgid "We collect the following kinds of personal information:"
 msgstr "다음과 같은 개인정보 항목들이 수집됩니다."
 
-#: web/templates/frontpages/privacy.html:32
+#: web/templates/web/privacy.html:33
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Account data: basic contact information that may "
+#| "include your email address, nickname, mailing\n"
+#| "                    address, and contact preferences.</li>\n"
+#| "                <li>Child data: basic biographical information about your "
+#| "child(ren), including nickname, date of birth,\n"
+#| "                    and gestational age at birth.</li>\n"
+#| "                <li>Demographic data: background and biographical "
+#| "information such as your native language, race, age,\n"
+#| "                    educational background, and family history of "
+#| "particular medical conditions.</li>\n"
+#| "                <li>Study data: responses collected during particular "
+#| "studies conducted on Lookit, including webcam\n"
+#| "                    video of your family participating in the study, text "
+#| "entered in forms, the particular images that\n"
+#| "                    were shown, the timing of progression through the "
+#| "study, etc.</li>\n"
+#| "            </ul>"
 msgid ""
 "<ul>\n"
-"                <li>Account data: basic contact information that may include "
-"your email address, nickname, mailing\n"
-"                    address, and contact preferences.</li>\n"
-"                <li>Child data: basic biographical information about your "
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
 "child(ren), including nickname, date of birth,\n"
-"                    and gestational age at birth.</li>\n"
-"                <li>Demographic data: background and biographical "
-"information such as your native language, race, age,\n"
-"                    educational background, and family history of particular "
-"medical conditions.</li>\n"
-"                <li>Study data: responses collected during particular "
-"studies conducted on Lookit, including webcam\n"
-"                    video of your family participating in the study, text "
-"entered in forms, the particular images that\n"
-"                    were shown, the timing of progression through the study, "
-"etc.</li>\n"
-"            </ul>"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
 msgstr ""
 "<ul>\n"
 "                <li>계정 정보: 기본 연락 정보로, 귀하의 이메일 주소, 별칭, 우"
@@ -2250,27 +3203,33 @@ msgstr ""
 "중 제시된 특정 이미지 (그림), 또는 연구 진행 과정 기록을 포함합니다.</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:44
-#: web/templates/frontpages/privacy.html:147
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
 msgid "How we collect personal information about you"
 msgstr "귀하의 개인정보 수집 절차"
 
-#: web/templates/frontpages/privacy.html:46
+#: web/templates/web/privacy.html:48
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is the information you "
+#| "provide to us when registering\n"
+#| "                for a Lookit account, registering your children, updating "
+#| "your account or your children’s profiles,\n"
+#| "                completing or updating surveys, or participating in "
+#| "individual Lookit studies."
 msgid ""
 "The information we collect and maintain about you is the information you "
 "provide to us when registering\n"
-"                for a Lookit account, registering your children, updating "
-"your account or your children’s profiles,\n"
-"                completing or updating surveys, or participating in "
-"individual Lookit studies."
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
 msgstr ""
 "Lookit이 수집하고 보유하는 귀하의 정보는 귀하께서 Lookit 계정을 등록하실 경"
 "우, 귀하 본인 또는 자녀분(들)의 프로필을 업데이트 하시는 경우, 설문지 작성 완"
 "료 및 업데이트하시는 경우, 또는 개인 Lookit 연구에 참여하시는 경우에 귀하께"
 "서 제공해주시는 정보입니다."
 
-#: web/templates/frontpages/privacy.html:50
-#: web/templates/frontpages/privacy.html:167
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
 msgid "When we share your personal information"
 msgstr ""
 "Lookit이 수집하고 보유하는 귀하의 정보는 귀하께서 Lookit 계정을 등록하실 경"
@@ -2278,7 +3237,7 @@ msgstr ""
 "료 및 업데이트하시는 경우, 또는 개인 Lookit 연구에 참여하시는 경우에 귀하께"
 "서 제공해주시는 정보입니다."
 
-#: web/templates/frontpages/privacy.html:52
+#: web/templates/web/privacy.html:56
 msgid ""
 "When you participate in a Lookit study, we share the following information "
 "with the research group conducting the study:"
@@ -2286,15 +3245,26 @@ msgstr ""
 "귀하께서 Lookit 연구에 참여하시는 경우, 연구를 진행하는 연구자 집단과 아래의 "
 "정보를 공유합니다:"
 
-#: web/templates/frontpages/privacy.html:54
+#: web/templates/web/privacy.html:60
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>Your account data </li>\n"
+#| "                <li>The child data for the child who is participating</"
+#| "li>\n"
+#| "                <li>Your demographic data</i>\n"
+#| "                <li>The study data for this particular study session</"
+#| "li>\n"
+#| "            </ul>"
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>Your account data </li>\n"
-"                <li>The child data for the child who is participating</li>\n"
-"                <li>Your demographic data</i>\n"
-"                <li>The study data for this particular study session</li>\n"
-"            </ul>"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
 msgstr ""
 "\n"
 "<ul>\n"
@@ -2304,7 +3274,7 @@ msgstr ""
 "                <li>특정 연구 세션의 연구 정보</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:61
+#: web/templates/web/privacy.html:68
 msgid ""
 "Your email address is not shared directly with the research group, although "
 "they can contact you via Lookit in accordance with your contact preferences."
@@ -2312,34 +3282,40 @@ msgstr ""
 "귀하의 이메일 주소는 연구자 집단에게 직접적으로 공개되지 않으나, 연구자들은 "
 "귀하의 연락 선호 방식을 준수하는 범위 내에서에 귀하에게 연락이 가능합니다."
 
-#: web/templates/frontpages/privacy.html:63
+#: web/templates/web/privacy.html:71
+#, fuzzy
+#| msgid ""
+#| "Researchers may publish the results of a study, including individual "
+#| "responses. However, although they\n"
+#| "                may publish the ages of participants, they may not "
+#| "publish participant birthdates (or information that\n"
+#| "                could be used to calculate birthdates)."
 msgid ""
 "Researchers may publish the results of a study, including individual "
 "responses. However, although they\n"
-"                may publish the ages of participants, they may not publish "
+"        may publish the ages of participants, they may not publish "
 "participant birthdates (or information that\n"
-"                could be used to calculate birthdates)."
+"    could be used to calculate birthdates)."
 msgstr ""
 "연구자들은 연구 결과를 출판할 수 있으며, 이는 개개인의 응답 내용을 포함할 수 "
 "있습니다. 그러나 연구자들은 연구참여자들의 연령은 공개할 수 있으나, 연구참여"
 "자의 생년월일은 (또는 생년월일을 계산할 수 있는 정보는) 공개하지 않을 수 있습"
 "니다"
 
-#: web/templates/frontpages/privacy.html:67
+#: web/templates/web/privacy.html:76
 #, fuzzy
 msgid ""
 "We and/or the researchers responsible for a study may share video of your "
 "family’s participation for\n"
-"                scientific, educational, and/or publicity purposes, but only "
-"if you choose at the conclusion of a study\n"
-"                to allow such usage. Researchers may also share your video "
-"and other data with Databrary if you choose\n"
-"                at the conclusion of a study to allow that. We don’t publish "
-"video of participants such that it can be\n"
-"                linked to individual demographic data (e.g., household "
-"income or number of parents/guardians), and\n"
-"                researchers must also agree not to do so in order to use "
-"Lookit."
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
 msgstr ""
 "Lookit과  Lookit 상의 연구를 담당하는 연구자들은 과학적, 교육적 그리고/또는 "
 "홍보용 목적으로 귀하의 가족의연구 참여 영상을 공유할 수 있으나, 이는 오직 귀"
@@ -2351,25 +3327,31 @@ msgstr ""
 "을 공개하지 않으며, Lookit을 사용하기 위해서는 연구자들 또한 이런 행위를 하"
 "지 않을 것임에 동의하도록 하고 있습니다."
 
-#: web/templates/frontpages/privacy.html:74
+#: web/templates/web/privacy.html:84
+#, fuzzy
+#| msgid ""
+#| "We don’t share, sell, publish, or otherwise disclose your contact "
+#| "information (email and/or mailing\n"
+#| "                address) to anyone but the researchers involved in a "
+#| "study. Researchers must also agree not to disclose\n"
+#| "                your contact information in order to use Lookit."
 msgid ""
 "We don’t share, sell, publish, or otherwise disclose your contact "
 "information (email and/or mailing\n"
-"                address) to anyone but the researchers involved in a study. "
+"        address) to anyone but the researchers involved in a study. "
 "Researchers must also agree not to disclose\n"
-"                your contact information in order to use Lookit."
+"        your contact information in order to use Lookit."
 msgstr ""
 "Lookit은 연구에 관여된 연구자들을 제외하고는 그 누구에게도 귀하의 연락처 정보"
 "(이메일 그리고/또는 우편 주소)를 공유, 판매, 출판, 또는 다른 방법으로 공개하"
 "지 않습니다. Lookit을 사용하기 위해서는 연구자들 또한 이런 행위를 하지 않을 "
 "것임에 동의하도록 하고 있습니다."
 
-#: web/templates/frontpages/privacy.html:78
-#: web/templates/frontpages/privacy.html:152
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
 msgid "How we use your personal information"
 msgstr "귀하의 개인 정보가 사용되는 경우"
 
-#: web/templates/frontpages/privacy.html:80
+#: web/templates/web/privacy.html:92
 msgid ""
 "We may use your personal information (account, child, demographic, and study "
 "data) for a variety of purposes, including to:"
@@ -2377,36 +3359,35 @@ msgstr ""
 "Lookit은 귀하의 개인 정보 (계정, 자녀, 인구통계적 정보, 그리고 연구 자료)를 "
 "다양한 목적으로 사용할 수 있으며, 이는 아래 경우를 포함할 수 있습니다:"
 
-#: web/templates/frontpages/privacy.html:81
+#: web/templates/web/privacy.html:94
 #, fuzzy
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research studies you have enrolled "
-"in, and information about which studies your\n"
-"                    children are eligible for</li>\n"
-"                <li>Send you information about studies you may be interested "
-"in, reminders to participate in multi-part\n"
-"                    studies, and/or results of studies you have participated "
-"in, subject to your contact preferences\n"
-"                </li>\n"
-"                <li>Improve the Lookit platform: e.g., detect and fix "
-"technical problems or identify new features that\n"
-"                    would be helpful</li>\n"
-"                <li>Develop data analysis tools for Lookit researchers </"
-"li>\n"
-"                <li>Provide technical support to study researchers</li>\n"
-"                <li>Assess the quality of data collected on the platform (e."
-"g., how well an observer can tell which\n"
-"                    direction children are looking)</li>\n"
-"                <li>Evaluate recruitment and family engagement efforts (e."
-"g., see how many participants come from rural\n"
-"                    vs. urban areas)</li>\n"
-"                <li>Recruit participants or researchers to use Lookit (e.g., "
-"sharing a short video clip of your child\n"
-"                    having fun – ONLY if you have chosen to allow use of the "
-"video for publicity)</li>\n"
-"            </ul>\n"
-"            "
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "                <li>귀하께서 참여를 등록하신 연구 및 귀하의 자녀가 참여할 수 "
@@ -2429,18 +3410,18 @@ msgstr ""
 "하의 자녀가 연구를 참여하면서 재밌어하는 영상을 공유)</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:100
+#: web/templates/web/privacy.html:113
 #, fuzzy
 msgid ""
 "Researchers use the data collected in their studies to address particular "
 "scientific questions. It may\n"
-"                also turn out that data collected for one study can help to "
+"            also turn out that data collected for one study can help to "
 "answer a related question later on. If\n"
-"                researchers are using any additional information about you "
-"in their study, beyond what is collected on\n"
-"                Lookit – for instance, if you are participating in a follow-"
-"up online session for an in-person study –\n"
-"                they must tell you that in the study consent form."
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
 msgstr ""
 "연구자들은 연구에 수집된 자료들을 사용하여 특정한 과학적 궁금증을 해결하고자 "
 "합니다. 어떤 경우, 한 연구에서 수집된 연구 자료가 이와 관련된 또 다른 연구 질"
@@ -2449,7 +3430,7 @@ msgstr ""
 "귀하께서 면대면으로 참여하셨던 연구의 후속 연구를 온라인에서 참여하는 경우 - "
 "연구자들은 그들의 연구 참여 동의서에 이 부분을 명시해야 합니다."
 
-#: web/templates/frontpages/privacy.html:106
+#: web/templates/web/privacy.html:120
 msgid ""
 "There are some basic rules about how personal information may be used that "
 "all Lookit researchers agree to, including:"
@@ -2457,17 +3438,28 @@ msgstr ""
 "Lookit의 모든 연구자들이 동의하는 개인 정보 사용 정책의 기본 방침들이 있으"
 "며, 이는 다음과 같은 내용을 포합합니다:"
 
-#: web/templates/frontpages/privacy.html:107
+#: web/templates/web/privacy.html:122
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>They may not use usernames, child nicknames, or "
+#| "contact information as a subject of research.</li>\n"
+#| "                <li>They may contact families by postal mail only in "
+#| "order to send compensation for study participation\n"
+#| "                    or materials needed for participation.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>They may not use usernames, child nicknames, or contact "
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
 "information as a subject of research.</li>\n"
-"                <li>They may contact families by postal mail only in order "
-"to send compensation for study participation\n"
-"                    or materials needed for participation.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "\n"
 "<ul>\n"
@@ -2477,26 +3469,31 @@ msgstr ""
 "송하는 경우에만 연구 참여 가족의 우편 주소를 사용할 수 있습니다.</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:114
-#: web/templates/frontpages/privacy.html:163
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+#, fuzzy
+#| msgid ""
+#| "If you have concerns about any of these purposes, or how we communicate "
+#| "with you, please contact us at\n"
+#| "                dataprotection@mit.edu. We will always respect a request "
+#| "by you to stop processing your personal\n"
+#| "                information (subject to our legal obligations)."
 msgid ""
 "If you have concerns about any of these purposes, or how we communicate with "
 "you, please contact us at\n"
-"                dataprotection@mit.edu. We will always respect a request by "
-"you to stop processing your personal\n"
-"                information (subject to our legal obligations)."
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
 msgstr ""
 "귀하께서 위의 목적들 또는 저희가 귀하와 의사소통 하는 방법에 대해 우려되는 부"
 "분이 있으신 경우,  dataprotection@mit.edu로 연락주시기 바랍니다. Lookit은 귀"
 "하께서 (Lookit의 법적 의무 충족에 필요한) 귀하의 개인정보를 처리하는 것에 대"
 "한 중단 요청을 언제나 존중할 것입니다. "
 
-#: web/templates/frontpages/privacy.html:118
-#: web/templates/frontpages/privacy.html:171
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
 msgid "How your information is stored and secured"
 msgstr "귀하의 정보의 보호 및 보관 방법"
 
-#: web/templates/frontpages/privacy.html:120
+#: web/templates/web/privacy.html:138
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2521,23 +3518,23 @@ msgstr "귀하의 정보의 보호 및 보관 방법"
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection, "
-"and all video data is encrypted at rest on\n"
-"                the storage systems used by Lookit to provide data to "
-"researchers. Researchers are responsible for their\n"
-"                own secure storage of data once they obtain it from Lookit. "
-"You should be aware, however, that since the\n"
-"                internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be accessed,\n"
-"                disclosed, altered, or destroyed by breach of any of our "
-"physical, technical, or managerial safeguards.\n"
-"                It's your responsibility to protect the security of your "
-"account details, including your username and\n"
-"                password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
 msgstr ""
 "저희는 귀하께서 제공해주시는 개인정보의 보호 목적으로 기획된 산업표준의 보안 "
 "방화벽을 설치하였습니다. 또한 저희는 만약의 정보 유출 및 침해 가능성에 대비하"
@@ -2552,26 +3549,38 @@ msgstr ""
 "가능함을 알려드립니다. 개인의 사용자명과 비밀번호를 포함하여 개인 계정의 세"
 "부 정보에 대한 보안 유지에 대해서는 개인에게 책임이 있음을 알려드립니다."
 
-#: web/templates/frontpages/privacy.html:131
-#: web/templates/frontpages/privacy.html:182
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
 #, fuzzy
 msgid "How long we keep your personal information"
 msgstr "귀하의 정보를 보관하는 기간 관련"
 
-#: web/templates/frontpages/privacy.html:133
+#: web/templates/web/privacy.html:153
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you wish\n"
+#| "                to remove your account, we will retain a core set of "
+#| "information about you to fulfill administrative\n"
+#| "                tasks and legal obligations. If you have participated in "
+#| "Lookit studies, the personal information\n"
+#| "                already shared with those researchers may not generally "
+#| "be ‘taken back,’ as it is part of a scientific\n"
+#| "                dataset and removing your data could affect already "
+#| "published findings."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you wish\n"
-"                to remove your account, we will retain a core set of "
-"information about you to fulfill administrative\n"
-"                tasks and legal obligations. If you have participated in "
-"Lookit studies, the personal information\n"
-"                already shared with those researchers may not generally be "
-"‘taken back,’ as it is part of a scientific\n"
-"                dataset and removing your data could affect already "
-"published findings."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
 msgstr ""
 "저희는 저희 연구 공동체와의 관계를 영구적인 관계로 인식합니다. 즉, 저희는 귀"
 "하께서 저희의 연락을 더이상 받고 싶지 않으실 때 까지 귀하의 정보 기록을 유지"
@@ -2581,29 +3590,34 @@ msgstr ""
 "며, 귀하 정보의 삭제가 이미 출판된 해당 연구자의 결과물에 영향을 줄 수 있으므"
 "로, 대다수의 경우 연구자로부터 귀하의 정보를 다시 회수하기는 어려울 것입니다."
 
-#: web/templates/frontpages/privacy.html:144
+#: web/templates/web/privacy.html:165
 #, fuzzy
 msgid ""
 "We may collect basic biographic/contact information about you and your "
 "representative organization,\n"
-"                including name, title, business addresses, phone numbers, "
-"and email addresses."
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
 msgstr ""
 "저희는 개인과 개인을 대표하는 기관의 기본적인 소개 및 연락처 정보를 수집할 "
 "수 있으며, 이는 연구자의 이름, 직함, 직장 주소, 전화 번호, 그리고 이메일 주소"
 "를 포함할 수 있습니다."
 
-#: web/templates/frontpages/privacy.html:149
+#: web/templates/web/privacy.html:172
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is that which you have "
+#| "provided to us when registering\n"
+#| "                to use Lookit, updating your profile, or creating or "
+#| "editing a study."
 msgid ""
 "The information we collect and maintain about you is that which you have "
 "provided to us when registering\n"
-"                to use Lookit, updating your profile, or creating or editing "
-"a study."
+"        to use Lookit, updating your profile, or creating or editing a study."
 msgstr ""
 "저희가 수집하고 보관하는 개인 정보는 개인이 Lookit에 등록하고, 프로필을 업데"
 "이트 하고, 연구를 생성 또는 수정하는 정보입니다."
 
-#: web/templates/frontpages/privacy.html:154
+#: web/templates/web/privacy.html:179
 msgid ""
 "We use your personal information for a number of legitimate purposes, "
 "including the performance of contractual obligations. Specifically, we use "
@@ -2612,19 +3626,19 @@ msgstr ""
 "저희는 여러 법적인 사유로 귀하의 개인정보를 사용하며, 이는 계약적인 의무의 시"
 "행을 포함합니다. 저희는 개인의 정보를 아래에 명시된 목적으로 사용합니다:"
 
-#: web/templates/frontpages/privacy.html:155
+#: web/templates/web/privacy.html:181
 #, fuzzy
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research services for which you "
-"have enrolled. </li>\n"
-"                <li>Perform administrative tasks and for internal record "
-"keeping purposes.</li>\n"
-"                <li>Create and analyze aggregated (fully anonymized) "
-"information about our users for statistical\n"
-"                    research purposes in support of our mission.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "                <li>개인이 등록한 연구 서비스 제공 목적. </li>\n"
@@ -2633,11 +3647,11 @@ msgstr ""
 "합 (전수 암호화 된) 사용자의 정보를 생성 및 분석 목적.</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:169
+#: web/templates/web/privacy.html:196
 msgid "We do not share your personal information with any third parties."
 msgstr "저희는 그 어느 제 3자와도 개인의 개인 정보를 공유하지 않습니다."
 
-#: web/templates/frontpages/privacy.html:173
+#: web/templates/web/privacy.html:201
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2658,19 +3672,19 @@ msgstr "저희는 그 어느 제 3자와도 개인의 개인 정보를 공유하
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection. "
-"You should be aware, however, that since\n"
-"                the internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be\n"
-"                accessed, disclosed, altered, or destroyed by breach of any "
-"of our physical, technical, or managerial\n"
-"                safeguards. It's your responsibility to protect the security "
-"of your account details, including your\n"
-"                username and password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
 msgstr ""
 "저희는 개인이 제공하는 개인정보의 보호 목적으로 기획된 산업표준의 보안 방화벽"
 "을 설치하였습니다. 저희는 또한 만약의 정보 유출 및 침해 가능성에 대비하여 주"
@@ -2682,15 +3696,24 @@ msgstr ""
 "을 알려드립니다. 개인의 사용자명과 비밀번호를 포함하여 개인 계정의 세부 정보"
 "에 대한 보안 유지에 대해서는 개인에게 책임이 있음을 알려드립니다."
 
-#: web/templates/frontpages/privacy.html:184
+#: web/templates/web/privacy.html:214
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you no\n"
+#| "                longer wish to hear from Lookit, we will retain a core "
+#| "set of information about you to fulfill\n"
+#| "                administrative tasks and legal obligations."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you no\n"
-"                longer wish to hear from Lookit, we will retain a core set "
-"of information about you to fulfill\n"
-"                administrative tasks and legal obligations."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
 msgstr ""
 "저희는 저희 연구 공동체와의 관계를 평생의 관계로 인식합니다. 즉, 저희는 개인"
 "이 저희의 연락을 더이상 받고 싶지 않을 때 까지 개인의 정보 기록을 유지할 것입"
@@ -2698,25 +3721,36 @@ msgstr ""
 "의 계정을 삭제하고 싶으신 경우, 저희는 행정적 처리와 법적인 의무를 충족시키"
 "기 위한 핵심적인 정보를 유지할 것입니다."
 
-#: web/templates/frontpages/privacy.html:189
+#: web/templates/web/privacy.html:220
 msgid "For everyone"
 msgstr "모든 사용자용"
 
-#: web/templates/frontpages/privacy.html:191
+#: web/templates/web/privacy.html:221
 msgid "Rights for individuals in the European Economic Area"
 msgstr "유럽 경제 지역의 개인의 권리"
 
-#: web/templates/frontpages/privacy.html:192
+#: web/templates/web/privacy.html:224
+#, fuzzy
+#| msgid ""
+#| "You have the right in certain circumstances to (1) access your personal "
+#| "information; (2) to correct or\n"
+#| "                erase information; (3) restrict processing; and (4) "
+#| "object to communications, direct marketing, or\n"
+#| "                profiling. To the extent applicable, the EU’s General "
+#| "Data Protection Regulation provides further\n"
+#| "                information about your rights. You also have the right to "
+#| "lodge complaints with your national or\n"
+#| "                regional data protection authority."
 msgid ""
 "You have the right in certain circumstances to (1) access your personal "
 "information; (2) to correct or\n"
-"                erase information; (3) restrict processing; and (4) object "
-"to communications, direct marketing, or\n"
-"                profiling. To the extent applicable, the EU’s General Data "
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
 "Protection Regulation provides further\n"
-"                information about your rights. You also have the right to "
-"lodge complaints with your national or\n"
-"                regional data protection authority."
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
 msgstr ""
 "귀하는 (1) 귀하의 개인 정보를 열람; (2) 정보를 수정 또는 삭제; (3) 귀하의 정"
 "보 처리를 제한; (4) 직접적 마케팅 및 프로파일링을 반대할 수 있는 권리가 있습"
@@ -2725,23 +3759,40 @@ msgstr ""
 "귀하는 또한 귀하의 국가 또는 귀하의 지역 데이터 보호 관리자에 대하여 이의를 "
 "제기할 수 있는 권리가 있습니다."
 
-#: web/templates/frontpages/privacy.html:198
+#: web/templates/web/privacy.html:231
+#, fuzzy
+#| msgid ""
+#| "If you are inclined to exercise these rights, we request an opportunity "
+#| "to discuss with you any concerns\n"
+#| "                you may have. To protect the personal information we "
+#| "hold, we may also request further information to\n"
+#| "                verify your identify when exercising these rights. Upon a "
+#| "request to erase information, we will maintain\n"
+#| "                a core set of personal data to ensure we do not contact "
+#| "you inadvertently in the future, as well as any\n"
+#| "                information necessary for archival purposes. We may also "
+#| "need to retain some financial information for\n"
+#| "                legal purposes, including US IRS compliance. In the event "
+#| "of an actual or threatened legal claim, we may\n"
+#| "                retain your information for purposes of establishing, "
+#| "defending against or exercising our rights with\n"
+#| "                respect to such claim."
 msgid ""
 "If you are inclined to exercise these rights, we request an opportunity to "
 "discuss with you any concerns\n"
-"                you may have. To protect the personal information we hold, "
-"we may also request further information to\n"
-"                verify your identify when exercising these rights. Upon a "
-"request to erase information, we will maintain\n"
-"                a core set of personal data to ensure we do not contact you "
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
 "inadvertently in the future, as well as any\n"
-"                information necessary for archival purposes. We may also "
-"need to retain some financial information for\n"
-"                legal purposes, including US IRS compliance. In the event of "
-"an actual or threatened legal claim, we may\n"
-"                retain your information for purposes of establishing, "
-"defending against or exercising our rights with\n"
-"                respect to such claim."
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
 msgstr ""
 "귀하는 위의 권리들을 시행하고 싶으신 경우, Lookit은 귀하의 의견을 함께 논의"
 "할 기회를 요청합니다. 귀하가 위의 권리들을 시행하는 경우, Lookit에 보관된 개"
@@ -2754,23 +3805,23 @@ msgstr ""
 "적 대응을 설립하거나 해당 법적 분쟁에 대한 Lookit의 권리 시행을 위하여 귀하"
 "의 정보를 복구할 수 있습니다."
 
-#: web/templates/frontpages/privacy.html:207
+#: web/templates/web/privacy.html:241
 #, fuzzy
 msgid ""
 "By providing information directly to Lookit, you consent to the transfer of "
 "your personal information\n"
-"                outside of the European Economic Area to the United States. "
-"You understand that the current laws and\n"
-"                regulations of the United States may not provide the same "
-"level of protection as the data and privacy\n"
-"                laws and regulations of the EEA."
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
 msgstr ""
 "귀하의 정보를 직접 Lookit에게 제공함으로써, 귀하는 귀하의 정보를 유럽 경제지"
 "역의 외부인 미국에 귀하의 개인 정보를 제공하는 것에 동의합니다. 귀하는 현재"
 "의 미국의 법률과 규정이 유럽 경제지역(EEA) 과 같은 수준의 정보 보안 및 보호"
 "를 제공하지 않을 수 있음을 이해하고 있습니다."
 
-#: web/templates/frontpages/privacy.html:212
+#: web/templates/web/privacy.html:246
 msgid ""
 "You are under no statutory or contractual obligation to provide any personal "
 "data to us."
@@ -2778,22 +3829,28 @@ msgstr ""
 "귀하는 귀하의 개인 정보를 Lookit에게 제공할 그 어떤 신분적 또는 계약적 의무"
 "가 없습니다."
 
-#: web/templates/frontpages/privacy.html:214
+#: web/templates/web/privacy.html:248
 msgid "Additional Information"
 msgstr "추가적인 정보"
 
-#: web/templates/frontpages/privacy.html:216
+#: web/templates/web/privacy.html:251
+#, fuzzy
+#| msgid ""
+#| "We may change this Privacy Statement from time to time. If we make any "
+#| "significant changes in the way we\n"
+#| "                treat your personal information we will make this clear "
+#| "on our website or by contacting you directly."
 msgid ""
 "We may change this Privacy Statement from time to time. If we make any "
 "significant changes in the way we\n"
-"                treat your personal information we will make this clear on "
-"our website or by contacting you directly."
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
 msgstr ""
 "Lookit은 종종 개인 정보 정책을 수정할 수 있습니다. 귀하의 개인정보를 사용하"
 "는 방식에 상당한 변화가 있을 경우 이 부분을 웹사이트에 올리거나 귀하를 직접 "
 "연락함으로써 명확하게 전달할 것을 약속합니다."
 
-#: web/templates/frontpages/privacy.html:220
+#: web/templates/web/privacy.html:255
 msgid ""
 "The controller for your personal information is MIT. We can be contacted at "
 "dataprotection@mit.edu."
@@ -2801,516 +3858,126 @@ msgstr ""
 "귀하의 개인 정보를 관리하는 기관은 매사추세츠 공과대학교(MIT) 입니다. 이와 관"
 "련한 연락은 dataprotection@mit.edu로 해주시기 바랍니다."
 
-#: web/templates/frontpages/privacy.html:222
+#: web/templates/web/privacy.html:257
 msgid "This policy was last updated in June 2018."
 msgstr "이 정책은 2018년 6월에 마지막으로 수정되었습니다."
 
-#: web/templates/frontpages/scientists.html:27
-msgid "Meet the Lookit team"
-msgstr "Lookit 팀을 만나보십시오."
-
-#: web/templates/frontpages/scientists.html:33
-msgid "Core Team"
-msgstr "핵심 팀"
-
-#: web/templates/frontpages/scientists.html:38
-msgid ""
-"Rico is Lookit's lead software engineer, working on planning and adding "
-"features for both participants and researchers."
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
 msgstr ""
-"리코는 참여자와 연구자를 위한 기능을 계획하고 추가하는 Lookit 소프트웨어 엔지"
-"지어의 리더입니다."
 
-#: web/templates/frontpages/scientists.html:43
-msgid ""
-"Laura is the PI of the Early Childhood Cognition Lab. She conducts research "
-"about how children arrive at a common-sense understanding of the physical "
-"and social world through exploration and instruction."
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
 msgstr ""
-"로라는 유아기 인지 연구실의 연구책임자입니다. 그녀는 아이들이 어떻게 탐구 및 "
-"교육을 통해 신체적, 사회적 세계에 대한 상식적인 이해에 도달하는지에 대한 연구"
-"합니다."
 
-#: web/templates/frontpages/scientists.html:49
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
 msgid ""
-"Kim started Lookit as a graduate student, and now runs the project as a "
-"research scientist in the Early Childhood Cognition Lab. Her three children "
-"frequently provide feedback on studies."
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
 msgstr ""
-"킴은 대학생으로서 Lookit을 시작하였고, 지금은 유아기 인지 연구실에서 연구자로"
-"서 프로젝트를 진행하고 있습니다."
 
-#: web/templates/frontpages/scientists.html:54
-msgid ""
-"Mark organizes the Lookit Working Groups, which are groups of researchers "
-"working to improve Lookit in a variety of ways."
-msgstr ""
-"마크는 다양한 방식으로 Lookit을 개선하기 위해 일하는 연구원이 모인 Lookit 워"
-"킹 그룹을 조직하였습니다."
-
-#: web/templates/registration/logged_out.html:6
-msgid "You've successfully logged out."
-msgstr "성공적으로 로그아웃 하셨습니다."
-
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr "귀하의 정보로 로그인에 실패했습니다. 다시 시도해 주십시오."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
-#, fuzzy
-msgid "Login"
-msgstr "로그인"
-
-#: web/templates/registration/login.html:34
-msgid "Forgot password?"
-msgstr "비밀번호를 잊으셨습니까?"
-
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Lookit에 처음이십니까?"
-
-#: web/templates/registration/login.html:36
-msgid "Register your family!"
-msgstr "귀하의 가족을 등록해주십시오!"
-
-#: web/templates/registration/password_change_done.html:11
-#, fuzzy
-msgid "Password changed"
-msgstr "비밀번호가 변경됨"
-
-#: web/templates/registration/password_change_done.html:15
-#, fuzzy
-msgid "Your password was changed."
-msgstr "비밀번호가 변경되었습니다."
-
-#: web/templates/registration/password_change_form.html:4
-#, fuzzy
-msgid "Documentation"
-msgstr "선적 서류 보관 / 관련 기록"
-
-#: web/templates/registration/password_change_form.html:4
-#, fuzzy
-msgid "Change password"
-msgstr "비밀번호 변경"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Log out"
-msgstr "로그아웃"
-
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
-#, fuzzy
-msgid "Home"
-msgstr "홈(메인 페이지)"
-
-#: web/templates/registration/password_change_form.html:8
-#, fuzzy
-msgid "Password change"
-msgstr "비밀번호 변경"
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the error below."
-msgstr "아래 오류를 수정하십시오."
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the errors below."
-msgstr "아래 오류들을 수정하십시오."
-
-#: web/templates/registration/password_change_form.html:26
-msgid ""
-"Please enter your old password, for security's sake, and then enter your new "
-"password twice so we can verify you typed it in correctly."
-msgstr ""
-"보안을 위해 이전 암호를 입력 한 다음, 올바르게 입력했는지 확인할 수 있도록 "
-"새 암호를 두 번 입력하십시오."
-
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
-msgid "Change my password"
-msgstr "비밀번호 변경"
-
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "비밀번호 재설정 완료"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "비밀번호가 설정되었습니다. 지금 바로 로그인 하실 수 있습니다."
-
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "로그인"
-
-#: web/templates/registration/password_reset_confirm.html:11
-#, fuzzy
-msgid "Password reset confirmation"
-msgstr "비밀번호 재설정 확인"
-
-#: web/templates/registration/password_reset_confirm.html:17
-msgid ""
-"Please enter your new password twice so we can verify you typed it in "
-"correctly."
-msgstr "올바르게 입력했는지 확인하기 위해 새 암호를 두 번 입력해 주십시오."
-
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "새 비밀번호:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "비밀번호 확인:"
-
-#: web/templates/registration/password_reset_confirm.html:37
-#, fuzzy
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"암호 재설정 링크가 유효하지 않습니다. 이미 사용된 링크일 수 있으니 새 비밀번"
-"호 재설정을 요청하십시오."
-
-#: web/templates/registration/password_reset_done.html:11
-msgid "Password reset link sent"
-msgstr "비밀번호 변경 링크가 전송됨"
-
-#: web/templates/registration/password_reset_done.html:15
-msgid ""
-"If an account exists with the email you entered, we've emailed instructions "
-"for resetting your password and you should receive them shortly."
-msgstr ""
-"귀하께서 입력해주신 이메일에 연결된 계정이 있다면, 곧 귀하의 이메일 주소로 비"
-"밀번호 재설정 안내문이 도착할 것입니다."
-
-#: web/templates/registration/password_reset_done.html:17
-msgid ""
-"If you don't receive an email, please check your spam folder and make sure "
-"you've entered the address you registered with. (You won't get an email "
-"unless there's already an account for that email address!)"
-msgstr ""
-"이메일을 받으시지 못하셨다면, 귀하의 스팸 폴더를 확인해주시고 귀하께서 등록하"
-"신 이메일 주소를 정확하게 입력하셨는지 확인해주시기 바랍니다. (귀하께서 이미 "
-"등록된 이메일 주소가 있으셔야만 안내문 이메일을 받으실 수 있습니다)."
-
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
-msgid ""
-"You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
-msgstr ""
-"이 이메일은 %(site_name)s에서 사용자 계정에 대한 비밀번호 재설정을 요청하셨"
-"기 때문에 발송되었습니다."
-
-#: web/templates/registration/password_reset_email.html:4
-msgid "Please go to the following page and choose a new password:"
-msgstr "다음 페이지로 이동하여 새 비밀번호를 만드십시오:"
-
-#: web/templates/registration/password_reset_email.html:8
-#, fuzzy
-msgid "Your username, in case you've forgotten:"
-msgstr "사용자 이름, 잊어 버린 경우:"
-
-#: web/templates/registration/password_reset_email.html:10
-msgid "Thanks for using our site!"
-msgstr "저희 사이트를 이용해 주셔서 감사합니다!"
-
-#: web/templates/registration/password_reset_email.html:12
-#, python-format
-msgid "The %(site_name)s team"
-msgstr "%(site_name)s 팀"
-
-#: web/templates/registration/password_reset_form.html:11
-msgid "Password reset"
-msgstr "비밀번호 재설정하기"
-
-#: web/templates/registration/password_reset_form.html:15
-msgid ""
-"Forgotten your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"비밀번호를 잊으셨습니까? 아래에 이메일 주소를 입력하시면 새 비밀번호 설정에 "
-"대한 지침을 이메일로 보내드립니다."
-
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "이메일 주소:"
-
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "비밀번호 재설정"
-
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "연구자"
-
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "연구들"
-
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "자주 묻는 질문들"
-
-#: web/templates/web/_navigation.html:35
-#, fuzzy
-msgid "The Scientists"
-msgstr "연구자들"
-
-#: web/templates/web/_navigation.html:36
-#, fuzzy
-msgid "Resources"
-msgstr "참고 자료실"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "안녕하십니까"
-
-#: web/templates/web/_navigation.html:47
-msgid "Logout"
-msgstr "로그아웃"
-
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "회원가입"
-
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
-#, fuzzy
-msgid "Child"
-msgstr "자녀"
-
-#: web/templates/web/child-update.html:26
-msgid "Back to Children List"
-msgstr "자녀 목록으로 돌아가기"
-
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "업데이트(최신정보)"
-
-#: web/templates/web/child-update.html:41
-msgid "Delete"
-msgstr "삭제"
-
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "취소"
-
-#: web/templates/web/children-list.html:40
-#, fuzzy
-msgid "Empty birthday"
-msgstr "생일 정보 없음"
-
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " 일"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " 일"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " 개월"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " 개월"
-
-#: web/templates/web/children-list.html:51
-#, fuzzy
-msgid " year"
-msgstr " 년"
-
-#: web/templates/web/children-list.html:51
-#, fuzzy
-msgid " years"
-msgstr " 년 (살)"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "자녀 정보 입력"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "양식 숨기기"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "이름"
-
-#: web/templates/web/children-list.html:121
-#, fuzzy
-msgid "Update child"
-msgstr "자녀 정보 업데이트"
-
-#: web/templates/web/children-list.html:128
-msgid "No child profiles registered!"
-msgstr "등록된 자녀 정보가 없습니다!"
-
-#: web/templates/web/demographic-data-update.html:4
-msgid "Update demographics"
-msgstr "인구 통계 정보 업데이트"
-
-#: web/templates/web/demographic-data-update.html:89
-#, fuzzy
-msgid ""
-"One reason we are developing Internet-based experiments is to represent a "
-"more diverse group of families in our research. Your answers to these "
-"questions will help us understand what audience we reach, as well as how "
-"factors like speaking multiple languages or having older siblings affect "
-"children's learning."
-msgstr ""
-"저희가 인터넷 기반의 연구들을 개발하는 이유들 중 하나는, 저희 연구에 더 다양"
-"한 가족 집단을 대표하기 위해서입니다. 아래 질문들에 대한 귀하의 대답은 저희"
-"가 맞닿을 수 있는 대중과, 다국어 사용 및 형제 자매 등의 요인들이 어떻게 아이"
-"의 학습에 영향을 주는지를 이해하는 데에 도움이 될 것입니다."
-
-#: web/templates/web/demographic-data-update.html:90
-msgid ""
-"Even if you allow your study videos to be published for scientific or "
-"publicity purposes, your demographic information is never published in "
-"conjunction with your video."
-msgstr ""
-"귀하께서 참여 연구 동영상을 과학 또는 홍보 목적으로 게시하도록 허용하더라도 "
-"귀하의 인구 통계 정보는 절대로 영상과 접목되어 게시되지 않습니다."
-
-#: web/templates/web/participant-email-preferences.html:27
-msgid "I would like to be contacted when:"
-msgstr "다음의 경우에 연락을 받고 싶습니다:"
-
-#: web/templates/web/participant-signup.html:18
-msgid "Create Participant Account"
-msgstr "연구 참여자 계정 만들기"
-
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
-msgstr ""
-"Lookit 연구 참여를 시작하기 위해 가족 계정 만들기 (Lookit 연구에 참여하기 위"
-"해 가족 계정 만들기)"
-
-#: web/templates/web/participant-signup.html:31
-msgid ""
-"By clicking 'Create Account', I agree that I have read and accepted the "
-msgstr "'계정 만들기'를 클릭하여 다음 내용을 읽고 수락하는 것에 동의합니다. "
-
-#: web/templates/web/participant-signup.html:31
-msgid "Privacy Statement"
-msgstr "개인 정보 보호 정책"
-
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "계정 만들기"
-
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "지난 연구들"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
-msgstr ""
-"귀하의 계정으로 이 페이지에 액세스 할 수 없습니다. 계속하려면 액세스 권한이 "
-"있는 계정으로 로그인하십시오."
-
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "이 페이지를 보려면 로그인하십시오."
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
+#: web/templates/web/studies-history.html:15
 #, fuzzy
-msgid "Current studies"
-msgstr "현재 진행중인 연구들"
+#| msgid "Video"
+msgid "Next Video"
+msgstr "동영상"
 
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "귀하의 지난 연구들"
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr "여기에서 귀화의 연구들과 연구자가 남긴 의견을 볼 수 있습니다."
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "연구 미리보기"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "자격:"
 
-#: web/templates/web/studies-history.html:80
+#: web/templates/web/studies-history.html:59
 #, fuzzy
-msgid "Contact:"
+msgid "Contact"
 msgstr "문의:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "아직 데이터를 수집하고 계십니까?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "네"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "아니요"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "보상: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "보상"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "연구 응답"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "동영상"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "날짜"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "동의 상태"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "승인됨"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr "귀하의 동의 영상은 연구자가 검토했으며 유효합니다."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "보류 중"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "귀하의 동의 영상은 연구자가 아직 검토하지 않았습니다."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "유효하지 않음"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 #, fuzzy
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
@@ -3321,179 +3988,178 @@ msgstr ""
 "을 보여주지 않았습니다. 이 세션의 귀하의 다른 데이터는 연구자가 보거나 사용하"
 "지 않습니다."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 #, fuzzy
 msgid "No information about consent video review status."
 msgstr "동의 영상 검토 상태에 대한 정보가 없습니다."
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "피드백/후기"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "없음"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "귀하께서는 아직 어떤 연구에도 참여하지 않으셨습니다."
 
-#: web/templates/web/studies-list.html:32
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-msgid "Current Studies"
-msgstr "현재 진행하고 있는 연구"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "귀하께서는 아직 어떤 연구에도 참여하지 않으셨습니다."
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "연구들"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"참여하시려면 Chrome 또는 Firefox를 실행할 수 있는 노트북 또는 데스크톱 컴퓨"
-"터 (휴대 기기가 아님)가 필요합니다."
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "상세보기"
-
-#: web/templates/web/studies-list.html:87
-#, fuzzy
-msgid "We are not running any studies at this time!"
-msgstr "현재 진행하고 있는 연구가 없습니다! "
-
-#: web/templates/web/studies-list.html:93
-#, fuzzy
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"집에서 연구에 기여할 더 많은 방법을 찾고 계십니까? 더 많은 연구를 위해 <a "
-"href=\"https://childrenhelpingscience.com/\" target=\"_blank\" rel="
-"\"noreferrer noopener\">Children Helping Science</a>를 확인하십시요!"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "일수"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " 까지 "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " 언제 "
-
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "연구 개요"
-
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "목록으로 돌아가기"
-
-#: web/templates/web/study-detail.html:112
+#: web/templates/web/studies-list.html:70
 #, fuzzy
-msgid "Eligibility criteria"
-msgstr "자격 기준"
+msgid "Resources"
+msgstr "참고 자료실"
 
-#: web/templates/web/study-detail.html:116
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
+
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr "미리보기"
+
+#: web/templates/web/study-detail.html:18
+msgid "participate"
+msgstr "참여"
+
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "지금 (현재)"
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "미리 볼 수 있는 연구 진행자 만들기"
+
+#: web/templates/web/study-detail.html:21
 #, fuzzy
-msgid "Duration"
-msgstr "지속 기간"
-
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "보상"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "어떻게 진행 되나요?"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "어떤 연구를 하나요?"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "이 연구는  에서 진행합니다."
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "이 연구에 참여하시겠습니까?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
 msgstr "참여하시려면 로그인하십시오."
 
-#: web/templates/web/study-detail.html:142
+#: web/templates/web/study-detail.html:22
 #, fuzzy
 msgid "Add child profile to "
 msgstr " 에 자녀정보를 추가하기"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
-msgid "preview"
-msgstr "미리보기"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
-msgid "participate"
-msgstr "참여"
-
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr " 를 하기 위해 인구 통계 설문지를 작성하기"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "참여하기"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "어떻게 진행 되나요?"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "어떤 연구를 하나요?"
+
+#: web/templates/web/study-detail.html:72
+#, fuzzy
+msgid "Duration"
+msgstr "지속 기간"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "이 연구는  에서 진행합니다."
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "이 연구에 참여하시겠습니까?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "자녀 선택:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "선택되지 않음"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "귀하의 자녀는 이 연구에 권장되는 연령대보다 아직 어립니다. 자녀가 충분한 연령"
 "이 될 때까지 </span> 기다리실 수 있다면 <span id='wait-until'> 수집된 연구정"
 "보를 저희의 연구에 사용할 수 있습니다!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "귀하 자녀의 연령은 이 연구에 권장되는 연령대보다 높습니다. 연구 참여를 하실 "
 "수는 있지만, 수집된 연구정보는 저희의 연구에 사용 되지 않습니다."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "귀하의 자녀는 이 연구 참여를 위한 자격 기준을 충족하지 않습니다. 연구 참여를 "
 "하실 수는 있지만, 수집된 연구정보는 저희의 연구에 사용 되지 없습니다. 연구자"
 "에게 문의하여 주십시오."
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "미리 볼 수 있는 연구 진행자 만들기"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "참여하기"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "지금 (현재)"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -3501,31 +4167,89 @@ msgstr ""
 "귀하의 연구 프로토콜을 업데이트할 때 발생하는 상황을 쉽게 보려면 위의 버튼에"
 "서 전송하는 URL을 즐겨찾기에 추가하십시오."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "회원가입"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"참여하시려면 Chrome 또는 Firefox를 실행할 수 있는 노트북 또는 데스크톱 컴퓨"
+"터 (휴대 기기가 아님)가 필요합니다."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "연구참여자 계정이 생성됨"
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "인구 통계 정보가 저장됨"
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "자녀 정보가 추가됨"
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "자녀 정보가 삭제됨"
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "자녀 정보가 업데이트 됨"
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "이메일 선호 방식이 저장됨"
 
-#: web/views.py:311
+#: web/views.py:699
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "The study {study.name} is not currently collecting data - the study is "
@@ -3540,17 +4264,426 @@ msgstr ""
 "나 임시로 중단되었습니다. 만약 오류가 있다고 판단되신다면, {연구연락정보} 로 "
 "연락을 주십시오."
 
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr "비밀번호는 귀하의 개인정보와 비슷하게 생성할 수 없습니다."
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "비밀번호는 최소 16자이상이 되어야 합니다."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "비밀번호는 자주쓰는 비밀번호가 아니어야 합니다."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "비밀번호는 숫자로만 구성될 수 없습니다."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "귀하의 가족형태는 어떻게 되십니까?"
+
+#, fuzzy
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "숫자 형태로만 입력 - 대략적인 추측도 괜찮습니다!"
+
+#, fuzzy
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "귀하의 가족이 집에서 대화할 때 사용하는 언어(들)은 무엇입니까?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "귀하의 배우자가 수료한 최고학력은 무엇입니까?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "집에 아동도서가 몇 권 정도 있으십니까?"
+
+#, fuzzy
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "귀하의 답변이 공동 양육권 계약 및 방문 규정으로 인해 답변이 다른 경우, 자"
+#~ "녀분이 일반적으로 함께 살고있는 부모/법적 보호자 수를 입력하거나 설명해주"
+#~ "십시오."
+
+#~ msgid "other"
+#~ msgstr "기타"
+
+#, fuzzy
+#~ msgid "3 or more"
+#~ msgstr "3 이상"
+
+#, fuzzy
+#~ msgid "varies"
+#~ msgstr "상황에 따라 다름"
+
+#~ msgid "My Account"
+#~ msgstr "나의 계정"
+
+#~ msgid "Last Active:"
+#~ msgstr "마지막 활동:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "참가자 글로벌 ID:"
+
+#, fuzzy
+#~ msgid "Dashboard"
+#~ msgstr "대시보드(계기판)"
+
+#, fuzzy
+#~ msgid "Argentinian Spanish"
+#~ msgstr "아르헨티나 스페인어"
+
+#~ msgid "Canadian French"
+#~ msgstr "캐나다 프랑스어"
+
+#~ msgid "Norwegian Bokmål"
+#~ msgstr "노르웨이 보크몰"
+
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "브라질 포르투갈어"
+
+#~ msgid "Simplified Chinese"
+#~ msgstr "간체자"
+
+#~ msgid "Yue"
+#~ msgstr "유 중국어 및 광동어(Yue)"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#~ msgid "How can we participate online?"
+#~ msgstr "온라인으로 참여가 가능한가요?"
+
+#~ msgid ""
+#~ "\n"
+#~ "                            <p>If you have a child and would like to "
+#~ "participate, create an account and take a look at what we have available "
+#~ "for your child's age range. You'll need a working webcam to participate.</"
+#~ "p>\n"
+#~ "                                <p>When you select a study, you'll be "
+#~ "asked to read a consent form and record yourself stating that you and "
+#~ "your child agree to participate. Then we'll guide you through what will "
+#~ "happen during the study. Depending on your child's age, your child may "
+#~ "answer questions directly or we may be looking for indirect signs of what "
+#~ "she thinks is going on--like how long she looks at a surprising outcome.</"
+#~ "p>\n"
+#~ "                                <p>Some portions of the study will be "
+#~ "automatically recorded using your webcam and sent securely to the Lookit "
+#~ "platform. Trained researchers will watch the video and record your "
+#~ "child's responses--for instance, which way he pointed, or how long she "
+#~ "looked at each image. We'll put these together with responses from lots "
+#~ "of other children to learn more about how kids think!</p>\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ "<p>자녀가 있으시고 연구에 참여하고 싶으시다면, 계정을 만드시고 자녀의 나이"
+#~ "에 맞는 연구들을 살펴보세요. 참여하시기 위해서는 화상카메라가 필요합니다."
+#~ "</p>\n"
+#~ "                                <p>연구를 고르신 후, 동의서를 읽고 본인과 "
+#~ "자녀가 연구 참여에 동의한다는 것을 녹화 해주시면 됩니다. 이후 연구에 대한 "
+#~ "자세한 설명이 제공됩니다. 자녀분의 연령에 따라, 연구 방식이 달라집니다. 자"
+#~ "녀분께서 질문에 직접 답변할 수도 있고 자녀분의 암묵적인 행동 (예: 시선 움"
+#~ "직임)이 관찰될 수도 있습니다.</p>\n"
+#~ "                                <p>연구의 일부분은 화상카메라를 통해 자동"
+#~ "으로 녹화되며 Lookit 플랫폼에 안전하게 전송됩니다. 숙련된 연구자들이 비디"
+#~ "오를 보며 자녀의 행동을 기록합니다 (예: 어떻게 손짓 했는지, 얼마 동안 그림"
+#~ "을 보았는지). 이러한 아동들의 데이터를 분석하여 인지발달 연구가 진행됩니"
+#~ "다!</p>"
+
+#~ msgid ""
+#~ "Any researcher with questions about how kids learn and grow can propose a "
+#~ "Lookit study! Each institution using Lookit has to sign a contract with "
+#~ "MIT where they agree to the <a href='/termsofuse'>Terms of Use</a> and "
+#~ "certify that their studies will be reviewed and approved by an "
+#~ "institutional review board. Studies are also subject to approval by "
+#~ "Lookit. As of June 2020 we have agreements with 20 universities!"
+#~ msgstr ""
+#~ "아동이 어떻게 배우며 성장하는지에 관한 공부하는 연구자 누구나 Lookit 연구"
+#~ "를 제안할 수 있습니다! Lookit을 사용하는 기관은 매사추세츠 공과대학(MIT)"
+#~ "과 계약해야 하며, <a href='/termsofuse'>이용약관</a> 및 제안된 연구가 기"
+#~ "관 검토위원회(IRB)에서 검토, 승인되는 것에 동의해야 합니다. 모든 연구는 "
+#~ "Lookit의 승인을 거쳐야 합니다. 2020년 6월 기준 Lookit 은 20개의 대학들과 "
+#~ "계약이 체결되었습니다."
+
+#~ msgid ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+#~ msgstr ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+
+#~ msgid ""
+#~ "Traditionally, developmental studies happen in a quiet room in a "
+#~ "university lab. Researchers call or email local parents to see if they'd "
+#~ "like to take part and schedule an appointment for them to come visit the "
+#~ "lab. Why complement these in-lab studies with online ones? We're hoping "
+#~ "to..."
+#~ msgstr ""
+#~ "일반적으로 발달 연구는 대학교 연구실의 조용한 공간에서 이루어집니다. 연구"
+#~ "자들은 부모님께 전화 또는 이메일을 보내 참여하고 싶은지 의사를 물어보고 연"
+#~ "구실을 방문하도록 약속을 잡습니다. 이러한 일반적인 방법과 달리 저희가 온라"
+#~ "인으로 연구를 진행하는 이유는 아래와 같습니다."
+
+#~ msgid "When will we see the results of the study?"
+#~ msgstr "연구 결과는 언제 볼 수 있나요?"
+
+#~ msgid ""
+#~ "The process of publishing a scientific study, from starting data "
+#~ "collection to seeing the paper in a journal, can take several years. You "
+#~ "can check the Lookit home page for updates on papers, or set your "
+#~ "communication preferences to be notified when we have results from "
+#~ "studies you participated in."
+#~ msgstr ""
+#~ "데이터 수집을 시작하고 학술지에서 논문이 출판되기까지 과정은 몇 년이 걸릴 "
+#~ "수 있습니다. Lookit 홈페이지에서 논문 업데이트를 확인하거나 참여한 연구 결"
+#~ "과가있을 때 알림을 받도록 커뮤니케이션 선호도를 설정하실 수 있습니다."
+
+#~ msgid "Can I get my child's results?"
+#~ msgstr "내 자녀의 연구 결과를 받을 수 있습니까?"
+
+#, fuzzy, python-format
+#~| msgid ""
+#~| "\n"
+#~| "                                <p>For some studies, yes! Usually, "
+#~| "developmental researchers only interpret children's abilities and "
+#~| "developmental trends at a group level, and the individual data collected "
+#~| "just isn't very interpretable. But for \"Your baby, the physicist\" and "
+#~| "other longitudinal studies (where you come back for more than one "
+#~| "session), we can sometimes collect enough data to give you a report of "
+#~| "your child's responses after you complete all the sessions.</p>\n"
+#~| "                                <p>Please note that none of the measures "
+#~| "we collect are diagnostic! For instance, while we hope you'll be "
+#~| "interested to learn that your child looked 70%% of the time at videos "
+#~| "where things fell up versus falling down, we won't be able to tell you "
+#~| "whether this means your child is going to be especially good at physics."
+#~| "</p>\n"
+#~| "                                <p>If you're interested in getting "
+#~| "individual results right away, please see our <a "
+#~| "href='resources'>Resources</a> section for fun at-home activities you "
+#~| "can try with your child.</p>\n"
+#~| "                                "
+#~ msgid ""
+#~ "\n"
+#~ "                                <p>For some studies, yes! Usually, "
+#~ "developmental researchers only interpret children's abilities and "
+#~ "developmental trends at a group level, and the individual data collected "
+#~ "just isn't very interpretable. But for \"Your baby, the physicist\" and "
+#~ "other longitudinal studies (where you come back for more than one "
+#~ "session), we can sometimes collect enough data to give you a report of "
+#~ "your child's responses after you complete all the sessions.</p>\n"
+#~ "                                <p>Please note that none of the measures "
+#~ "we collect are diagnostic! For instance, while we hope you'll be "
+#~ "interested to learn that your child looked 70%% of the time at videos "
+#~ "where things fell up versus falling down, we won't be able to tell you "
+#~ "whether this means your child is going to be especially good at physics.</"
+#~ "p>\n"
+#~ "                                <p>If you're interested in getting "
+#~ "individual results right away, please see our <a "
+#~ "href='resources'>Resources</a> section for fun at-home activities you can "
+#~ "try with your child.</p>\n"
+#~ "                                "
+#~ msgstr ""
+#~ "\n"
+#~ "<p>일부 연구의 경우 귀하 자녀의 결과를 받으실 수 있습니다! 일반적으로 발"
+#~ "달 연구자들은 개별 단계가 아닌 집단 단계에서 아동의 능력과 발달 경향성을 "
+#~ "해석합니다. 그러나 '아기, 물리학자\" 및 다른 종적 연구 (여러 세션을 위해 "
+#~ "반복하여 참여하는 연구) 경우 모든 세션을 완료한 후 자녀의 결과에 대한 보고"
+#~ "서를 제공할 수 있습니다.</p>\n"
+#~ "\n"
+#~ "<p>저희가 수집하는 어떤 데이터도 그 어떤 진단에 쓰일 수 없다는 점을 기억해"
+#~ "주세요! 예를 들어, 자녀가 물건이 넘어지거나 떨어지는 비디오를 70% 만큼 봤"
+#~ "다는 사실만으로, 자녀가 물리학에 뛰어날 것이란 걸 예측할 수는 없습니다.</"
+#~ "p>\n"
+#~ "\n"
+#~ "<p>개별 결과를 즉시 얻고 싶으시면, <a href='resources'>참고 자료실</a>창에"
+#~ "서 자녀와 함께 할 수 있는 재미있는 활동들을 참조하십시오.</p>"
+
+#~ msgid "the online child lab"
+#~ msgstr "온라인 아동 연구실 "
+
+#, fuzzy
+#~ msgid "A project of the MIT Early Childhood Cognition Lab"
+#~ msgstr "MIT 유아기 인지 연구실의 프로젝트"
+
+#~ msgid "Bringing science home"
+#~ msgstr "집에서 진행하는 연구"
+
+#~ msgid ""
+#~ "Here at MIT's Early Childhood Cognition Lab, we're trying a new approach "
+#~ "in developmental psychology: bringing the experiments to you."
+#~ msgstr ""
+#~ "MIT에서 진행하는 유아기 인지 연구실입니다, 저희는 여러분들이 연구에 참여하"
+#~ "실 수 있도록 발달 심리학에 대한 새로운 접근을 시도하고 있습니다."
+
+#~ msgid "Help us understand how your child thinks"
+#~ msgstr "귀하의 자녀가 어떻게 생각 하는지에 대한 이해를 돕는데 참여해 주세요"
+
+#~ msgid ""
+#~ "Your family can contribute to research about how children learn by doing "
+#~ "fun activities together, right in your web browser."
+#~ msgstr ""
+#~ "귀하의 가족은 이 웹 브라우저에서 함께 재미있는 활동을 함으로써 아이들이 어"
+#~ "떻게 배우는지에 대한 연구에 기여할 수 있습니다."
+
+#~ msgid "Participate whenever and wherever"
+#~ msgstr "연구에 언제든 어디서든 참여해보십시오."
+
+#~ msgid ""
+#~ "Log in or create an account at the top right to get started! You can "
+#~ "participate with your child from any computer with a webcam."
+#~ msgstr ""
+#~ "우측 상단에서 로그인을 하시거나 계정을 생성하여 시작하십시오! 화상 카메라"
+#~ "가 달린 컴퓨터를 사용하여 아이와 연구에 참여하실 수 있습니다."
+
+#~ msgid "Core Team"
+#~ msgstr "핵심 팀"
+
+#~ msgid ""
+#~ "Rico is Lookit's lead software engineer, working on planning and adding "
+#~ "features for both participants and researchers."
+#~ msgstr ""
+#~ "리코는 참여자와 연구자를 위한 기능을 계획하고 추가하는 Lookit 소프트웨어 "
+#~ "엔지지어의 리더입니다."
+
+#~ msgid ""
+#~ "Laura is the PI of the Early Childhood Cognition Lab. She conducts "
+#~ "research about how children arrive at a common-sense understanding of the "
+#~ "physical and social world through exploration and instruction."
+#~ msgstr ""
+#~ "로라는 유아기 인지 연구실의 연구책임자입니다. 그녀는 아이들이 어떻게 탐구 "
+#~ "및 교육을 통해 신체적, 사회적 세계에 대한 상식적인 이해에 도달하는지에 대"
+#~ "한 연구합니다."
+
+#~ msgid ""
+#~ "Kim started Lookit as a graduate student, and now runs the project as a "
+#~ "research scientist in the Early Childhood Cognition Lab. Her three "
+#~ "children frequently provide feedback on studies."
+#~ msgstr ""
+#~ "킴은 대학생으로서 Lookit을 시작하였고, 지금은 유아기 인지 연구실에서 연구"
+#~ "자로서 프로젝트를 진행하고 있습니다."
+
+#~ msgid ""
+#~ "Mark organizes the Lookit Working Groups, which are groups of researchers "
+#~ "working to improve Lookit in a variety of ways."
+#~ msgstr ""
+#~ "마크는 다양한 방식으로 Lookit을 개선하기 위해 일하는 연구원이 모인 Lookit "
+#~ "워킹 그룹을 조직하였습니다."
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "귀하의 정보로 로그인에 실패했습니다. 다시 시도해 주십시오."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Lookit에 처음이십니까?"
+
+#~ msgid "New password:"
+#~ msgstr "새 비밀번호:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "비밀번호 확인:"
+
+#, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "%(site_name)s 팀"
+
+#~ msgid "Email address:"
+#~ msgstr "이메일 주소:"
+
+#~ msgid "FAQ"
+#~ msgstr "자주 묻는 질문들"
+
+#~ msgid "Hi"
+#~ msgstr "안녕하십니까"
+
+#, fuzzy
+#~ msgid "Empty birthday"
+#~ msgstr "생일 정보 없음"
+
+#~ msgid " day"
+#~ msgstr " 일"
+
+#~ msgid " days"
+#~ msgstr " 일"
+
+#~ msgid " month"
+#~ msgstr " 개월"
+
+#~ msgid " months"
+#~ msgstr " 개월"
+
+#, fuzzy
+#~ msgid " year"
+#~ msgstr " 년"
+
+#, fuzzy
+#~ msgid " years"
+#~ msgstr " 년 (살)"
+
+#~ msgid "Hide Form"
+#~ msgstr "양식 숨기기"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr ""
+#~ "Lookit 연구 참여를 시작하기 위해 가족 계정 만들기 (Lookit 연구에 참여하기 "
+#~ "위해 가족 계정 만들기)"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "귀하의 계정으로 이 페이지에 액세스 할 수 없습니다. 계속하려면 액세스 권한"
+#~ "이 있는 계정으로 로그인하십시오."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "이 페이지를 보려면 로그인하십시오."
+
+#~ msgid "Compensation: "
+#~ msgstr "보상: "
+
+#~ msgid "None"
+#~ msgstr "없음"
+
+#, fuzzy
+#~ msgid "Current Studies"
+#~ msgstr "현재 진행하고 있는 연구"
+
+#~ msgid "See details"
+#~ msgstr "상세보기"
+
+#, fuzzy
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "현재 진행하고 있는 연구가 없습니다! "
+
+#, fuzzy
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "집에서 연구에 기여할 더 많은 방법을 찾고 계십니까? 더 많은 연구를 위해 <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a>를 확인하십시요!"
+
+#~ msgid "days"
+#~ msgstr "일수"
+
+#~ msgid " until "
+#~ msgstr " 까지 "
+
+#~ msgid " when "
+#~ msgstr " 언제 "
+
+#~ msgid "Study overview"
+#~ msgstr "연구 개요"
+
+#~ msgid "Back to list"
+#~ msgstr "목록으로 돌아가기"
+
+#, fuzzy
+#~ msgid "Eligibility criteria"
+#~ msgstr "자격 기준"
+
 #, fuzzy
 #~ msgid "Alumni &amp; Collaborators"
 #~ msgstr "졸업생 &amp; 협업자들"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "연구자로서 등록하시려면 이것을 사용해주십시오"
-
 #, fuzzy
 #~ msgid "this form"
 #~ msgstr "이 양식"
-
-#, fuzzy
-#~ msgid "instead"
-#~ msgstr "대신"

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -4095,10 +4095,8 @@ msgstr "지속 기간"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "이 연구는  에서 진행합니다."
+msgstr "이 연구는  에서 진행합니다 %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/nb/LC_MESSAGES/django.po
+++ b/locale/nb/LC_MESSAGES/django.po
@@ -3353,9 +3353,8 @@ msgstr "Varighet"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
 msgid "This study is conducted by %(contact)s."
-msgstr "Denne studien utføres av"
+msgstr "Denne studien utføres av %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/nb/LC_MESSAGES/django.po
+++ b/locale/nb/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr "Skriv inn et gyldig 6-sifret engangspassord fra Google Authenticator"
 
@@ -30,42 +30,24 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "Denne kontoen er inaktiv."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr "Passordet ditt kan ikke være for likt personopplysningene dine."
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "Passordet må innholde minst 16 tegn."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "Passordet ditt kan ikke være et passord du bruker ofte."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "Passordet ditt må innholde mer enn bare tall."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "E-postadresse"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Kallenavn"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "Det er på tide med en ny økt av studien vi deltar i."
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "En ny studie er tilgjengelig for et av barna mine"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -73,7 +55,7 @@ msgstr ""
 "En studie vi har deltatt i har blitt oppdatert (for eksempel, resultater har "
 "blitt publisert)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -81,100 +63,91 @@ msgstr ""
 "En forsker har spørsmål om et av svarene jeg har gitt (for eksempel hvis jeg "
 "har rapportert tekniske problemer under studien)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "Hvilken kategori(er) identifiserer familien din seg som?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Land"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Fyll inn en liste separert av kommaer: YYYY-MM-DD, YYYY-MM-DD, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Bare fyll inn numeriske svar, det går greit med gjetting!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "Hvilket land bor du i?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "Hvilket fylke bor du i?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Hvordan ville du beskrevet området du bor i?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Hvilket språk snakker familien din hjemme?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Hvor mange barn har du?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Vennligst fyll inn fødselsdatoen for hvert barn"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Hvor mange foreldre/foresatte bor barna dine med?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Hvor gammel er du?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Hva er ditt kjønn?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Hva er ditt kjønn?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Hva er den høyeste formen for utdanning du har fullført?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Hva er den høyeste formen for utdanning partneren din har fullført?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Hva er din families årlige inntekt ca. (i Norske kroner)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Ca. hvor mange barnebøker har dere hjemme?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Er det noe annet du vil at vi skal vite?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Hvordan hørte du om Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Hvis svaret varierer på grunn av delt omsorg eller reise, ønsker vi at du "
-"forteller hvor mange foreldre eller foresatte barnet ditt vanligvis bor med "
-"eller forklar situasjonen."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Fødselsdato"
+#: accounts/forms.py:357
+#, fuzzy
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Annen rase, etnisitet eller opprinnelse"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -184,33 +157,36 @@ msgstr ""
 "Vi publiserer aldri barnets fødselsdato eller informasjon som lar andre å "
 "regne ut barnets fødselsdato."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Fødselsdag kan ikke være i fremtiden"
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Fornavn"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Fødselsdato"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Kjønn"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Svangerskapsalder ved fødsel"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Er det noen tilleggsinformasjon du vil at vi skal vite?"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Egenskaper og tilstander"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -218,7 +194,7 @@ msgstr ""
 "Språk barnet ditt eksponeres for hjemme, på skolen eller med andre "
 "forsørgere."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -231,531 +207,616 @@ msgstr ""
 "en ny studie tilgjengelig for Molly!\" men vi vil aldri publisere navn eller "
 "bruke dem i studier."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "For eksempel, diagnotisert med utviklingsforstyrrelse, eller syns- eller "
 "hørselsvansker"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Vennligst rund av til nærmeste uke av fullført svangerskap"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Studier"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+msgid "Scheduled studies"
+msgstr "Studier nå"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Dine tidligere studier"
+
+#: accounts/forms.py:517
+#, fuzzy
+msgid "External studies"
+msgstr "Studier nå"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Ikke sikker, eller foretrekker å ikke svare"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Under 24 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 eller flere uker"
 
-#: accounts/models.py:80
+#: accounts/models.py:45
+msgid "male"
+msgstr "Mann"
+
+#: accounts/models.py:46
+msgid "female"
+msgstr "Kvinne"
+
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
+
+#: accounts/models.py:48 accounts/models.py:510
+msgid "prefer not to answer"
+msgstr "Ønsker ikke å svare"
+
+#: accounts/models.py:87
 msgid "Can View Organization"
 msgstr "Kan se Organisasjon"
 
-#: accounts/models.py:81
+#: accounts/models.py:88
 msgid "Can Edit Organization"
 msgstr "Kan redigere Organisasjon"
 
-#: accounts/models.py:82
+#: accounts/models.py:89
 msgid "Can Create Organization"
 msgstr "Kan lage Organisasjon"
 
-#: accounts/models.py:83
+#: accounts/models.py:90
 msgid "Can Remove Organization"
 msgstr "Kan fjerne Organisasjon"
 
-#: accounts/models.py:84
+#: accounts/models.py:91
 #, fuzzy
 msgid "Can View Experimenter"
 msgstr "Kan se Experimenter"
 
-#: accounts/models.py:85
+#: accounts/models.py:92
 #, fuzzy
 msgid "Can View Analytics"
 msgstr "Kan se Analyseverktøy"
 
-#: accounts/models.py:280
+#: accounts/models.py:324
 msgid "Can Create User"
 msgstr "Kan lage bruker"
 
-#: accounts/models.py:281
+#: accounts/models.py:325
 msgid "Can View User"
 msgstr "Kan se bruker"
 
-#: accounts/models.py:282
+#: accounts/models.py:326
 msgid "Can Edit User"
 msgstr "Kan redigere bruker"
 
-#: accounts/models.py:283
+#: accounts/models.py:327
 msgid "Can Remove User"
 msgstr "Kan fjerne bruker"
 
-#: accounts/models.py:284
+#: accounts/models.py:328
 #, fuzzy
 msgid "Can View User Permissions"
 msgstr "Kan se brukertillatelser"
 
-#: accounts/models.py:285
+#: accounts/models.py:329
 #, fuzzy
 msgid "Can Edit User Permissions"
 msgstr "Kan redigere brukertillatelse"
 
-#: accounts/models.py:286
+#: accounts/models.py:330
 msgid "Can Read All User Data"
 msgstr "Kan lese all brukerdata"
 
-#: accounts/models.py:287
+#: accounts/models.py:331
 msgid "Can Read User Usernames"
 msgstr "Kan lese alle brukernavn"
 
-#: accounts/models.py:294 accounts/models.py:397
-msgid "male"
-msgstr "Mann"
-
-#: accounts/models.py:295 accounts/models.py:398
-msgid "female"
-msgstr "Kvinne"
-
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "Annet"
-
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
-msgid "prefer not to answer"
-msgstr "Ønsker ikke å svare"
-
-#: accounts/models.py:387
+#: accounts/models.py:425
 msgid "White"
 msgstr "Hvit"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Latinamerikansk, eller Spansk opprinnelse"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 #, fuzzy
 msgid "Black or African American"
 msgstr "Afrikansk"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 #, fuzzy
 msgid "Asian"
 msgstr "Asiatisk"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 #, fuzzy
 msgid "American Indian or Alaska Native"
 msgstr "Samisk"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Fra Midtøsten eller Nord Afrika"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 #, fuzzy
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr ""
 "Nasjonal minoritet (Jøder, kvener/norskfinner, romanifolk/tatere, skogfinner "
 "og rom)"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 #, fuzzy
 msgid "Another race, ethnicity, or origin"
 msgstr "Annen rase, etnisitet eller opprinnelse"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 #, fuzzy
 msgid "some or attending high school"
 msgstr "Har delvis gått på eller går på videregående skole"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "Fullført videregående skole eller tilsvarende"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 #, fuzzy
 msgid "some or attending college"
 msgstr "Har delvis gått på eller går på universitet eller høyskole"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "Bachelorgrad"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "Mastergrad"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 #, fuzzy
 msgid "some or attending graduate or professional school"
 msgstr ""
 "Har delvis gått på eller går på master-, doktor- eller profesjonsstudie"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 #, fuzzy
 msgid "graduate or professional degree"
 msgstr "Master grad, Phd, eller Profesjonsgrad"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "Ikke aktuelt - ingen ektefelle eller partner"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Mer enn 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "Under 18"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "8-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 eller over"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 eller mer"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "Varierer"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "over 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "Urbant"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 #, fuzzy
 msgid "suburban"
 msgstr "Boligområde, utenfor tettstrøk"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 #, fuzzy
 msgid "rural"
 msgstr "Ute på landet"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Velg Fylke"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "Gan"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Brukerinformasjon"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "Endre påloggingsinformasjon og / eller kallenavn."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 #, fuzzy
 msgid "Demographic Survey"
 msgstr "Demografisk undersøkelse"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Fortell oss mer om deg selv"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informasjon om barn"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 #, fuzzy
 msgid "Add or edit participant information."
 msgstr "Legg til eller rediger deltagerinformasjon"
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "E-post preferanser"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Rediger når du kan bli kontaktet"
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Min konto"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Brukerinformasjon"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Lagre"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Bytt passordet ditt"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "Administrer tofaktorautentisering"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -763,11 +824,18 @@ msgstr ""
 "Hvis du vil, kan du slå av tofaktorautentisering her. Bare skriv inn "
 "engangspassordet ditt her, trykk på send, så blir det slettet for deg!"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "Sett opp to-faktor autentisering"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Alle deltagere"
 
@@ -775,132 +843,65 @@ msgstr "Alle deltagere"
 msgid "Participant ID"
 msgstr "Deltager ID"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Sist aktiv"
-
-#: accounts/templates/accounts/participant_detail.html:25
-#, fuzzy
-msgid "Participant global ID:"
-msgstr "Global deltager ID"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Barn"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Alder"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Tilleggsinformasjon"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Ingen barneprofiler er registrert"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 #, fuzzy
 msgid "Latest Demographic Data"
 msgstr "Siste demografisk data"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Land"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Fylke"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Beskrivelse av område"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Språket som snakkes hjemme"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Antall barn"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 #, fuzzy
 msgid "Children current ages"
 msgstr "Alderen til barna nå"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+msgid "No Response"
+msgstr "Svar fra studien"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Antall foresatte"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Beskrivelse av foresatte"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 #, fuzzy
 msgid "Race"
 msgstr "Etnisitet"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Dashbord"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "Tysk"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "Engelsk"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "Spansk"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "Fransk"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "Italiensk"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "Japansk"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "Koreansk"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "Polsk"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "Portugisisk"
-
-#: project/settings.py:241
-#, fuzzy
-#| msgid "Portuguese"
-msgid "Brazilian Portuguese"
-msgstr "Portugisisk"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "Rumensk"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "Russisk"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "Tyrkisk"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "Nederlandsk"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -955,6 +956,10 @@ msgstr "Septuplett (syv barn født samtidig)"
 msgid "Octuplet"
 msgstr "Octuplet (åtte barn født samtidig)"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "Engelsk"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "Amharisk"
@@ -979,13 +984,25 @@ msgstr "Cebuano"
 msgid "Chhattisgarhi"
 msgstr "Chhattisgarhi"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "Nederlandsk"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "Egyptisk Muntlig Arabisk"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "Fransk"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "Gan"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "Tysk"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -1000,164 +1017,206 @@ msgid "Hausa"
 msgstr "Hausa"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "Hindi"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "Igbo"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "Indonesisk"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "Iransk persisk"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "Italiensk"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "Japansk"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "Javanesisk"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "Jinyu"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "Kannada"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "Khmer"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "Koreansk"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "Magahi"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "Maithili"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "Malaysisk"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "Mandarin"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "Marathi"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "Min Nan"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "Marokkansk talt arabisk"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "Northern Pashto"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "Nord-usbekisk"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "Odia"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "Polsk"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "Portugisisk"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "Rumensk"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "Russisk"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "Saraiki"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "Somalisk"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "Spansk"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "Sunda"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "Tamil"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "Telugu"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "Thai"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "Tyrkisk"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "Ukrainsk"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "Urdu"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "Vietnamesisk"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "Vestlige Punjabi"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "Wu"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "Xiang kinesisk"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "Yue"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Ikke svart"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Annet"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 #, fuzzy
 msgid "Male"
 msgstr "Gutt"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 #, fuzzy
 msgid "Female"
 msgstr "Jente"
 
-#: studies/models.py:113
+#: studies/models.py:143
 #, fuzzy
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
@@ -1167,174 +1226,70 @@ msgstr ""
 "stand til å lage studier tilknyttet til denne labben og kan legges til "
 "labbens studier."
 
-#: studies/models.py:122
+#: studies/models.py:152
 #, fuzzy
 msgid "The Users who have requested to join this Lab."
 msgstr "Brukerene som har bedt om arbeide i labben"
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-#, fuzzy
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:53
-msgid ""
-"This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
-"findings, and conclusions or recommendations expressed in this material are "
-"those of the authors(s) and do not necessarily reflect the views of the "
-"National Science Foundation."
-msgstr ""
-"Dette materialet er basert på arbeid støttet av National Science Foundation "
-"(NSF) under tilskudd 1429216 og 1823919; Center for Brains, Minds and "
-"Machines (CBMM), finansiert av NSF STC-prisen CCF-1231216, og av et NSF "
-"Graduate Research Fellowship under tilskudd nr. 1122374. Enhver mening, funn "
-"og konklusjoner eller anbefalinger uttrykt i dette materialet tilhører "
-"forfatterne og reflekterer ikke nødvendigvis synspunktene til National "
-"Science Foundation."
-
-#: web/templates/frontpages/default.html:60 web/templates/frontpages/home.html:48
-msgid "Privacy"
-msgstr "Personvern"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-msgid "Contact us"
-msgstr "Kontakt oss"
-
-#: web/templates/frontpages/default.html:63
-msgid "Connect"
-msgstr "Få kontakt"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Delta"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Logg inn for å delta"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Logg inn for å delta"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Hva er ditt kjønn?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Varighet"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-msgid "Why are you running studies online instead of in person?"
-msgstr "Vi holder ikke på med noen studier akkurat nå!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Delta"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Personvernserklæring"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Alle deltagere"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Tilleggsinformasjon"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Du har logget av"
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr "Påloggingsinformasjonen din fungerte ikke. Vennligst prøv igjen."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Logg inn"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Glemt passord?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Ny på Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/login.html:36
+#: web/templates/registration/login.html:28
 msgid "Register your family!"
 msgstr "Registrer familien din!"
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/password_change_done.html:9
 #, fuzzy
 msgid "Password changed"
 msgstr "Passordet er byttet"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Ditt passord har blitt forandret"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Dokumentasjon"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Bytt passord"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Logg ut"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Hjem"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Passordbytte"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Vennligst korriger feilen under"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Vennligst korriger feilene under"
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -1342,30 +1297,30 @@ msgstr ""
 "Vennligst fyll inn ditt gamle passord, for sikkerhets skyld, og fyll inn "
 "ditt nye passord to ganger så vi kan bekrefte at du har skrevet det riktig"
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Bytt passordet mitt"
 
-#: web/templates/registration/password_reset_complete.html:11
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "Logg inn"
+
+#: web/templates/registration/password_reset_complete.html:10
 msgid "Password reset complete"
 msgstr "Passordbytte fullført"
 
-#: web/templates/registration/password_reset_complete.html:15
+#: web/templates/registration/password_reset_complete.html:12
 #, fuzzy
 msgid "Your password has been set.  You may go ahead and log in now."
 msgstr "Passordet ditt har blitt lagret. Du kan nå logge inn."
 
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "Logg inn"
-
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_confirm.html:8
 #, fuzzy
 msgid "Password reset confirmation"
 msgstr "Bekreft tilbakestilling av passord"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1373,15 +1328,7 @@ msgstr ""
 "Vennligst fyll inn ditt nye passord to ganger så vi kan bekrefte at du skrev "
 "det riktig"
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nytt passord:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Bekreft passord:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 #, fuzzy
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
@@ -1391,11 +1338,11 @@ msgstr ""
 "utgått eller blitt brukt før. Vennligst be om å tilbakestille passordet på "
 "nytt"
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 msgid "Password reset link sent"
 msgstr "Lenke for tilbakestilling av passord"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 msgid ""
 "If an account exists with the email you entered, we've emailed instructions "
 "for resetting your password and you should receive them shortly."
@@ -1404,7 +1351,7 @@ msgstr ""
 "instruksjoner for å tilbakestille passordet ditt per e-post, og du vil motta "
 "dem snart."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 msgid ""
 "If you don't receive an email, please check your spam folder and make sure "
 "you've entered the address you registered with. (You won't get an email "
@@ -1414,11 +1361,11 @@ msgstr ""
 "for at du har angitt adressen du registrerte deg med. (Du får ikke en e-post "
 "med mindre det allerede finnes en konto som er tilknyttet e-postadressen!)"
 
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Du har mottatt denne e-posten fordi du ønsket å tilbakestille passordet for "
 "denne brukeren på %(site_name)"
@@ -1432,21 +1379,23 @@ msgstr "Vennligst gå til denne siden og lag et nytt passord:"
 msgid "Your username, in case you've forgotten:"
 msgstr "I tilfelle du har glemt det, er brukernavnet ditt:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Takk for at du bruker siden vår!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "Teamet til %(site_name)"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Tilbakestill passordet mitt"
+
+#: web/templates/registration/password_reset_form.html:8
 msgid "Password reset"
 msgstr "Tilbakestilling av passord"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 #, fuzzy
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
@@ -1455,134 +1404,271 @@ msgstr ""
 "Glemt passord? Skriv e-postadressen din under, så sender vi deg "
 "instruksjoner for å lage et nytt passord."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "E-postadresse: "
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "Lenke for tilbakestilling av passord"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Tilbakestill passordet mitt"
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
+"Dette materialet er basert på arbeid støttet av National Science Foundation "
+"(NSF) under tilskudd 1429216 og 1823919; Center for Brains, Minds and "
+"Machines (CBMM), finansiert av NSF STC-prisen CCF-1231216, og av et NSF "
+"Graduate Research Fellowship under tilskudd nr. 1122374. Enhver mening, funn "
+"og konklusjoner eller anbefalinger uttrykt i dette materialet tilhører "
+"forfatterne og reflekterer ikke nødvendigvis synspunktene til National "
+"Science Foundation."
 
-#: web/templates/web/_navigation.html:22
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr "Personvern"
+
+#: web/templates/web/_footer.html:17
+msgid "Contact us"
+msgstr "Kontakt oss"
+
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr "Få kontakt"
+
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr "Logg ut"
+
+#: web/templates/web/_navigation.html:4
 #, fuzzy
 msgid "Experimenter"
 msgstr "Experimenter"
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Studier"
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "Spørsmål og svar"
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Forskerne:"
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
 
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Ressurser"
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
 
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Hei"
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
 
-#: web/templates/web/_navigation.html:47
-msgid "Logout"
-msgstr "Logg ut"
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Barn"
 
-#: web/templates/web/_navigation.html:49
-#, fuzzy
-msgid "Sign up"
-msgstr "Lag en konto"
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Avbryt"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Legg til barn"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Barn"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 msgid "Back to Children List"
 msgstr "Tilbake til Barnelisten"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Oppdater"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Slett"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Avbryt"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Lagre"
 
-#: web/templates/web/children-list.html:40
-#, fuzzy
-msgid "Empty birthday"
-msgstr "Uten bursdag"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Oppdater"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " dag"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " dager"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " måned"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " måneder"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " år"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " år"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Legg til barn"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#, fuzzy
-msgid "Hide Form"
-msgstr "Skjul skjema"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Navn"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Oppdater barn"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Navn"
+
+#: web/templates/web/children-list.html:64
 #, fuzzy
 msgid "No child profiles registered!"
 msgstr "Ingen barneprofiler registrert!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr ""
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Dokumentasjon"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 #, fuzzy
 msgid "Update demographics"
 msgstr "Oppdater demografi"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 #, fuzzy
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
@@ -1596,7 +1682,7 @@ msgstr ""
 "hjelpe oss å forstå hvilken demografi vi når, og hvilken faktorer, som å "
 "være flerspråklig eller antall søsken, som påvirker barns læring."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 #, fuzzy
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
@@ -1607,137 +1693,1553 @@ msgstr ""
 "vitenskapelige eller publiseringsformål, vil vi aldri  publisere din "
 "demografiske informasjon sammen med videoen din."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Delta"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Dine tidligere studier"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+msgid "Why are you running studies online instead of in person?"
+msgstr "Vi holder ikke på med noen studier akkurat nå!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Logg inn for å delta"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Hva er ditt kjønn?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Varighet"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "Hvilket fylke bor du i?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+msgid "For Researchers"
+msgstr ""
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Hvor gammel er du?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Logg inn for å delta"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Forskerne:"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Delta"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Hjem"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Jeg ønsker å bli kontaktet når:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Logg inn for å delta"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Lag konto"
+
+#: web/templates/web/participant-signup.html:13
 msgid "Create Participant Account"
 msgstr "Opprett deltakerkonto"
 
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
-msgstr "Opprett en familiekonto for å begynne å delta i Lookit-studier!"
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "For å registrere deg som forsker, vennligst bruk"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead"
+msgid "instead."
+msgstr "i stedet"
+
+#: web/templates/web/participant-signup.html:28
 #, fuzzy
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "Ved å trykke \"Lag konto\", er jeg enig om at jeg har akkseptert "
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Personvernserklæring"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Lag konto"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Personvernserklæring"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Alle deltagere"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Tilleggsinformasjon"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Tidligere studier"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
-msgstr ""
-"Din konto har ikke tilgang til denne siden. Vennligst log inn med en konto "
-"som har tilgang for å fortsette, "
-
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Venlligst logg inn for å se siden"
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
+#: web/templates/web/studies-history.html:15
 #, fuzzy
-msgid "Current studies"
-msgstr "Studier nå"
+#| msgid "Video"
+msgid "Next Video"
+msgstr "Video"
 
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Dine tidligere studier"
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr "Her kan du se studiene dine og kommentarer fra forskere"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 #, fuzzy
 msgid "Study Thumbnail"
 msgstr "Miniatyrbilde til studien"
 
-#: web/templates/web/studies-history.html:79
+#: web/templates/web/studies-history.html:55
 #, fuzzy
-msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Krav:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Kontakt:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 #, fuzzy
 msgid "Still collecting data?"
 msgstr "Samles fortsatt data?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Ja"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Nei"
 
-#: web/templates/web/studies-history.html:82
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
 #, fuzzy
-msgid "Compensation: "
-msgstr "Kompensasjon: "
+msgid "Compensation"
+msgstr "Kompensasjon"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 #, fuzzy
 msgid "Study Responses"
 msgstr "Svar fra studien"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "Video"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Dato"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Status på samtykke"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Godkjent"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr "Samtykkevideon har blitt gjennomgått av en forsker og er gyldig "
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 #, fuzzy
 msgid "Pending"
 msgstr "Avventer"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "Din samtykkevideo har fremdeles ikke blitt gjennomgått av en forsker"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Ikke gyldig"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 #, fuzzy
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
@@ -1748,183 +3250,166 @@ msgstr ""
 "deg ikke lese samtykkeerklæringen høyt. Annen data du har oppgitt for denne "
 "økten vil ikke bli gjennomgått eller brukt av forskerne til denne studien."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 #, fuzzy
 msgid "No information about consent video review status."
 msgstr "Ingen informasjon om statusen til gjennomgåingen av samtykkevideon"
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "Tilbakemelding"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "Ingen"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Du har ikke deltatt i noen studier enda"
 
-#: web/templates/web/studies-list.html:32
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-msgid "Current Studies"
-msgstr "Gjeldende studier"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Du har ikke deltatt i noen studier enda"
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studier"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Du trenger en laptop eller stasjonær pc (ikke mobil eller nettbrett) med "
-"Chrome eller Firefox for å delta"
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Se detaljer"
-
-#: web/templates/web/studies-list.html:87
-#, fuzzy
-msgid "We are not running any studies at this time!"
-msgstr "Vi holder ikke på med noen studier akkurat nå!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"Ser du etter flere måter å bidra til forskning hjemmefra? Sjekk ut <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for flere studier!"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "dager"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " til "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " når "
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressurser"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Oversikt over studiet "
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Tilbake til listen"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Kvalifikasjonskriterier"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Varighet"
-
-#: web/templates/web/study-detail.html:121
-#, fuzzy
-msgid "Compensation"
-msgstr "Kompensasjon"
-
-#: web/templates/web/study-detail.html:126
-#, fuzzy
-msgid "What happens"
-msgstr "Hva som skjer"
-
-#: web/templates/web/study-detail.html:130
-#, fuzzy
-msgid "What we're studying"
-msgstr "Hva vi undersøker"
-
-#: web/templates/web/study-detail.html:134
-#, fuzzy
-msgid "This study is conducted by"
-msgstr "Denne studien utføres av"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Ønsker du å delta i denne studien?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Logg inn for å delta"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "Legg barneprofil til "
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "forhåndsvisning"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "Delta"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "nå"
+
+#: web/templates/web/study-detail.html:20
+#, fuzzy
+msgid "Build experiment runner to preview"
+msgstr "Lag \"experiment runner\" for forhåndsvisning"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Logg inn for å delta"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "Legg barneprofil til "
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "Fullfør den demografiske undersøkelsen for å"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Delta"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+msgid "What Happens"
+msgstr "Hva som skjer"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+msgid "What We're Studying"
+msgstr "Hva vi undersøker"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Varighet"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+msgid "This study is conducted by %(contact)s."
+msgstr "Denne studien utføres av"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Ønsker du å delta i denne studien?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Velg barn:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 #, fuzzy
 msgid "None Selected"
 msgstr "Ingen valgt"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
 #, fuzzy
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Ditt barn er fremdeles yngre enn den annbefalte aldren for å delta i denne "
 "studien. Hvis du venter til <span id='wait-until'>until</span>  hun eller "
 "han er gammel nok før dere deltar, vil vi kunne bruke den innsamlede dataen! "
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Ditt barn er eldre enn den anbefalte alderen for å delta i denne studien. Du "
 "kan fremdeles delta, men vi kan dessverre ikke bruke den innsamlede dataen. "
 
-#: web/templates/web/study-detail.html:163
-#, fuzzy
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Barnet ditt fyller ikke kriteriene for å detla i denne studien. Du kan "
 "fremdeles delta, men vi kan dessverre ikke bruke den innsamlede dataen. "
 "Vennligst kontakt forskeren som er ansvarlig for studien."
 
-#: web/templates/web/study-detail.html:165
-#, fuzzy
-msgid "Build experiment runner to preview"
-msgstr "Lag \"experiment runner\" for forhåndsvisning"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Delta"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "nå"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 #, fuzzy
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
@@ -1933,31 +3418,90 @@ msgstr ""
 "For en enklere måte å se hva som skjer når du oppdaterer studieprotokoller, "
 "\"bokmerk\" URLen du får fra knappen over."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+#, fuzzy
+msgid "Sign up"
+msgstr "Lag en konto"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Du trenger en laptop eller stasjonær pc (ikke mobil eller nettbrett) med "
+"Chrome eller Firefox for å delta"
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "Deltager opprettet"
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "Demografisk data lagret."
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "Barn lagt til"
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "Barn slettet"
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "Barn oppdatert"
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "E-postinnstillinger lagret."
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -1968,14 +3512,196 @@ msgstr ""
 "eller midlertidig stoppet. Hvis du tror dette kan være feil, kan du kontakte "
 "{study.contact_info}"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "For å registrere deg som forsker, vennligst bruk"
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr "Passordet ditt kan ikke være for likt personopplysningene dine."
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "Passordet må innholde minst 16 tegn."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "Passordet ditt kan ikke være et passord du bruker ofte."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "Passordet ditt må innholde mer enn bare tall."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "Hvilken kategori(er) identifiserer familien din seg som?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Bare fyll inn numeriske svar, det går greit med gjetting!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Hvilket språk snakker familien din hjemme?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "Hva er den høyeste formen for utdanning partneren din har fullført?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Ca. hvor mange barnebøker har dere hjemme?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Hvis svaret varierer på grunn av delt omsorg eller reise, ønsker vi at du "
+#~ "forteller hvor mange foreldre eller foresatte barnet ditt vanligvis bor "
+#~ "med eller forklar situasjonen."
+
+#~ msgid "other"
+#~ msgstr "Annet"
+
+#~ msgid "3 or more"
+#~ msgstr "3 eller mer"
+
+#~ msgid "varies"
+#~ msgstr "Varierer"
+
+#~ msgid "My Account"
+#~ msgstr "Min konto"
+
+#~ msgid "Last Active:"
+#~ msgstr "Sist aktiv"
+
+#, fuzzy
+#~ msgid "Participant global ID:"
+#~ msgstr "Global deltager ID"
+
+#~ msgid "Dashboard"
+#~ msgstr "Dashbord"
+
+#, fuzzy
+#~| msgid "Portuguese"
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "Portugisisk"
+
+#~ msgid "Yue"
+#~ msgstr "Yue"
+
+#, fuzzy
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Logg inn for å delta"
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "Påloggingsinformasjonen din fungerte ikke. Vennligst prøv igjen."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Ny på Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nytt passord:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Bekreft passord:"
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "Teamet til %(site_name)"
+
+#~ msgid "Email address:"
+#~ msgstr "E-postadresse: "
+
+#~ msgid "FAQ"
+#~ msgstr "Spørsmål og svar"
+
+#~ msgid "Hi"
+#~ msgstr "Hei"
+
+#, fuzzy
+#~ msgid "Empty birthday"
+#~ msgstr "Uten bursdag"
+
+#~ msgid " day"
+#~ msgstr " dag"
+
+#~ msgid " days"
+#~ msgstr " dager"
+
+#~ msgid " month"
+#~ msgstr " måned"
+
+#~ msgid " months"
+#~ msgstr " måneder"
+
+#~ msgid " year"
+#~ msgstr " år"
+
+#~ msgid " years"
+#~ msgstr " år"
+
+#, fuzzy
+#~ msgid "Hide Form"
+#~ msgstr "Skjul skjema"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr "Opprett en familiekonto for å begynne å delta i Lookit-studier!"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Din konto har ikke tilgang til denne siden. Vennligst log inn med en "
+#~ "konto som har tilgang for å fortsette, "
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Venlligst logg inn for å se siden"
+
+#, fuzzy
+#~ msgid "Compensation: "
+#~ msgstr "Kompensasjon: "
+
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#, fuzzy
+#~ msgid "Current Studies"
+#~ msgstr "Gjeldende studier"
+
+#~ msgid "See details"
+#~ msgstr "Se detaljer"
+
+#, fuzzy
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Vi holder ikke på med noen studier akkurat nå!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Ser du etter flere måter å bidra til forskning hjemmefra? Sjekk ut <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for flere "
+#~ "studier!"
+
+#~ msgid "days"
+#~ msgstr "dager"
+
+#~ msgid " until "
+#~ msgstr " til "
+
+#~ msgid " when "
+#~ msgstr " når "
+
+#~ msgid "Study overview"
+#~ msgstr "Oversikt over studiet "
+
+#~ msgid "Back to list"
+#~ msgstr "Tilbake til listen"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Kvalifikasjonskriterier"
 
 #~ msgid "this form"
 #~ msgstr "dette skjemaet"
-
-#~ msgid "instead"
-#~ msgstr "i stedet"
 
 #~ msgid "Birthday test"
 #~ msgstr "Bursdagstest"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr ""
 "Voer een geldig eenmalig wachtwoord van zes cijfers in van Google "
@@ -37,45 +37,26 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "Dit account is inactief."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr ""
-"Uw wachtwoord mag niet te veel lijken op uw andere persoonlijke gegevens."
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "Uw wachtwoord moet minimaal 16 tekens bevatten."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "Uw wachtwoord mag geen algemeen gebruikt wachtwoord zijn."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "Uw wachtwoord mag niet volledig numeriek zijn."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "E-mailadres"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Bijnaam"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr ""
 "Het is tijd voor een nieuwe sessie van een onderzoek waaraan we momenteel "
 "deelnemen"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Er is een nieuwe studie beschikbaar voor een van mijn kinderen"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -83,7 +64,7 @@ msgstr ""
 "Er is een update over een onderzoek waaraan we hebben deelgenomen (de "
 "resultaten zijn bijvoorbeeld gepubliceerd)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -91,103 +72,93 @@ msgstr ""
 "Een onderzoeker heeft vragen over mijn individuele antwoorden (bijvoorbeeld "
 "als ik tijdens het onderzoek een technisch probleem meld)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "In welke categorie(ën) identificeert uw gezin zich?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Land"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr ""
 "Voer in als een lijst door komma's gescheiden: JJJJ-MM-DD, JJJJ-MM-DD, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Alleen numerieke antwoorden - een ruwe schatting is prima!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "In welk land woont u?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "In welke provincie woont u?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Hoe zou u het gebied waarin u woont omschrijven?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Welke taal / talen spreekt uw gezin thuis?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Hoeveel kinderen heeft u?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Geef voor elk kind zijn of haar geboortedatum op:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Bij hoeveel ouders / verzorgers wonen uw kinderen?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Wat is uw leeftijd?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Wat is uw geslacht?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Wat is uw geslacht?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Wat is de hoogste opleiding die u heeft afgerond?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr ""
-"Wat is de hoogste opleiding die uw echtgenoot/echtgenote/partner heeft "
-"afgerond?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Wat is uw geschatte jaarlijkse gezinsinkomen (in euro's)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Hoeveel kinderboeken zijn er ongeveer in uw huis?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Is er nog iets anders waarvan u wilt dat wij het weten?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Hoe heeft u over Lookit gehoord?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Als het antwoord varieert vanwege regelingen voor gedeeld gezag of reizen, "
-"voer dan het aantal ouders / verzorgers in waar uw kinderen gewoonlijk mee "
-"samenwonen of leg de situatie uit."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Geboortedatum"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Een andere etniciteit of afkomst"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -197,33 +168,36 @@ msgstr ""
 "een studie. We publiceren nooit geboortegegevens van kinderen of informatie "
 "waarmee een lezer de geboortedatum kan berekenen."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "De geboortedatum kan niet in de toekomst liggen."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Voornaam"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Geboortedatum"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Geslacht"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Zwangerschapsduur bij de geboorte"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Eventuele aanvullende informatie waarvan u wilt dat wij het weten"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Kenmerken en voorwaarden"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -231,7 +205,7 @@ msgstr ""
 "Talen waaraan dit kind thuis, op school of bij een andere verzorger wordt "
 "blootgesteld."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -244,511 +218,598 @@ msgstr ""
 "beschikbaar voor Julia!\"), maar we zullen nooit namen publiceren of ze "
 "gebruiken in ons onderzoek."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Bijvoorbeeld gediagnosticeerde ontwikkelingsstoornissen of zicht- of "
 "gehoorproblemen"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Rond af naar de dichtstbijzijnde volledige zwangerschapsweek"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Studies"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Huidige studies"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Je eerdere studies"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Huidige studies"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Weet niet zeker of beantwoord liever niet"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Minder dan 24 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 weken"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 weken of meer"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Kan organisatie bekijken"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Kan organisatie bewerken"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Kan een organisatie creëren"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Kan organisatie verwijderen"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Kan onderzoeker bekijken"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Kan analytics bekijken"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Kan een gebruiker aanmaken"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Kan gebruiker bekijken"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Kan gebruiker bewerken"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Kan gebruiker verwijderen"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Kan gebruikersrechten bekijken"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Kan gebruikersrechten bewerken"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Kan alle gebruikersgegevens lezen"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Kan gebruikersnamen lezen"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "man"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "vrouw"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "andere"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "beantwoord liever niet"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Kan organisatie bekijken"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Kan organisatie bewerken"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Kan een organisatie creëren"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Kan organisatie verwijderen"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Kan onderzoeker bekijken"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Kan analytics bekijken"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Kan een gebruiker aanmaken"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Kan gebruiker bekijken"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Kan gebruiker bewerken"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Kan gebruiker verwijderen"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Kan gebruikersrechten bekijken"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Kan gebruikersrechten bewerken"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Kan alle gebruikersgegevens lezen"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Kan gebruikersnamen lezen"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Wit"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Van Latijns-Amerikaanse, Latino of Spaanse afkomst"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Zwart of Afro-Amerikaans"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Aziatisch"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Amerikaanse Indiaan of Alaska Native"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Midden-Oosters of Noord-Afrikaans"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Inheemse Hawaiiaan of andere Pacific Islander"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Een andere etniciteit of afkomst"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "enige tijd of nog steeds naar de middelbare school"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "middelbare schooldiploma of equivalent"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "enige tijd of nog steeds naar de universiteit"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "HBO of WO bachelor"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "HBO of WO master"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "enige tijd of nog steeds naar een graduate of professionele school"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "PhD of equivalente professionele graad"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "niet van toepassing - geen echtgenoot/echtgenote of partner"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Meer dan 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "onder de 18"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 of meer"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 of meer"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "varieert"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "meer dan 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "stedelijk"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "buitenwijk"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "landelijk"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Selecteer een provincie"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "Gan"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Accountinformatie"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "Wijzig uw inloggegevens en / of bijnaam."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Demografisch onderzoek"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Vertel ons meer over uzelf."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informatie over kinderen"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Deelnemersgegevens toevoegen of bewerken."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "E-mailvoorkeuren"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Bewerk wanneer u gecontacteerd kunt worden."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Mijn account"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Accountinformatie"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Opslaan"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Wijzig uw wachtwoord"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "Beheer tweefactorauthenticatie"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -757,11 +818,18 @@ msgstr ""
 "gewoon uw eenmalige wachtwoord in, druk op verzenden en het wordt voor u "
 "verwijderd!"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "Stel tweefactorauthenticatie in"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Alle deelnemers"
 
@@ -769,128 +837,63 @@ msgstr "Alle deelnemers"
 msgid "Participant ID"
 msgstr "Deelnemer-ID"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Laatst actief:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "Globale ID deelnemer:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Kinderen"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Leeftijd"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Extra informatie"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Geen kinderprofielen geregistreerd!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Laatste demografische gegevens"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Land"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Provincie"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Gebiedsbeschrijving"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Talen die thuis worden gesproken"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Aantal kinderen"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Huidige leeftijden kinderen"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Onderzoeksreacties"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Aantal ouders of voogden"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Uitleg voor voogden:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Ras"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Dashboard"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "Duits"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "Engels"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "Spaans"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "Frans"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "Italiaans"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "Japans"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "Koreaans"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "Pools"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "Portugees"
-
-#: project/settings.py:241
-#, fuzzy
-#| msgid "Portuguese"
-msgid "Brazilian Portuguese"
-msgstr "Portugees"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "Roemeens"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "Russisch"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "Turks"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "Nederlands"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -940,6 +943,10 @@ msgstr "Zevenling"
 msgid "Octuplet"
 msgstr "Achtling"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "Engels"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "Amhaars"
@@ -964,13 +971,25 @@ msgstr "Cebuano"
 msgid "Chhattisgarhi"
 msgstr "Chhattisgarhi"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "Nederlands"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "Egyptisch gesproken Arabisch"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "Frans"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "Gan"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "Duits"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -985,162 +1004,204 @@ msgid "Hausa"
 msgstr "Hausa"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "Hindi"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "Igbo"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "Indonesisch"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "Iraanse Perzisch"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "Italiaans"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "Japans"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "Javaans"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "Jinyu"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "Kannada"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "Khmer"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "Koreaans"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "Magahi"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "Maithili"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "Maleis"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "Mandarijn"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "Marathi"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "Min Nan"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "Marokkaans gesproken Arabisch"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "Noord-Pasjtoe"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "Noord-Oezbeeks"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "Odia"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "Pools"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "Portugees"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "Roemeens"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "Russisch"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "Saraiki"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "Somalisch"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "Spaans"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "Sunda"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "Tamil"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "Telugu"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "Thais"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "Turks"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "Oekraïens"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "Urdu"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "Vietnamees"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "West-Punjabi"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "Wu"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "Xiang Chinees"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "Ja"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Niet geantwoord"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Andere"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Man"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Vrouw"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -1149,172 +1210,68 @@ msgstr ""
 "onderzoeken creëren die aan dit Lab zijn gekoppeld en kan aan de onderzoeken "
 "van dit Lab worden toegevoegd."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "De gebruikers die hebben verzocht om lid te worden van dit Lab."
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:53
-msgid ""
-"This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
-"findings, and conclusions or recommendations expressed in this material are "
-"those of the authors(s) and do not necessarily reflect the views of the "
-"National Science Foundation."
-msgstr ""
-"Dit materiaal is gebaseerd op werk dat wordt ondersteund door de National "
-"Science Foundation (NSF) in het kader van subsidies 1429216 en 1823919; het "
-"Center for Brains, Minds and Machines (CBMM), gefinancierd door NSF STC "
-"award CCF-1231216, en door een NSF Graduate Research Fellowship onder Grant "
-"nr. 1122374. Alle meningen, bevindingen en conclusies of aanbevelingen in "
-"dit materiaal zijn die van de auteur(s) en geven niet noodzakelijk de mening "
-"van de National Science Foundation weer."
-
-#: web/templates/frontpages/default.html:60 web/templates/frontpages/home.html:48
-msgid "Privacy"
-msgstr "Privacy"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-msgid "Contact us"
-msgstr "Neem contact met ons op"
-
-#: web/templates/frontpages/default.html:63
-msgid "Connect"
-msgstr "Verbind"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Deelnemen"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Log in om mee te doen"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Log in om mee te doen"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Wat is uw geslacht?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Duur"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "We voeren op dit moment geen studies uit!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Deelnemen"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Privacyverklaring"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Alle deelnemers"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Extra informatie"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "U bent succesvol uitgelogd."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr "Uw inloggegevens werkten niet. Probeer het opnieuw."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Log in"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Wachtwoord vergeten?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Nieuw bij Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/login.html:36
+#: web/templates/registration/login.html:28
 msgid "Register your family!"
 msgstr "Registreer uw gezin!"
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Wachtwoord is veranderd"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Uw wachtwoord is veranderd."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Documentatie"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Wijzig wachtwoord"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Uitloggen"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Thuis"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Wachtwoord verandering"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Corrigeer de onderstaande fout."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Gelieve de onderstaande fouten corrigeren."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -1323,28 +1280,28 @@ msgstr ""
 "wachtwoord twee keer in, zodat we kunnen verifiëren dat u het correct hebt "
 "ingevoerd."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Verander mijn wachtwoord"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Wachtwoord opnieuw instellen voltooid"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Uw wachtwoord is ingesteld. U kunt nu doorgaan en inloggen."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 msgid "Log in"
 msgstr "Log in"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Wachtwoord opnieuw instellen voltooid"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Uw wachtwoord is ingesteld. U kunt nu doorgaan en inloggen."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Bevestiging wachtwoord opnieuw instellen"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1352,15 +1309,7 @@ msgstr ""
 "Voer uw nieuwe wachtwoord twee keer in, zodat we kunnen verifiëren dat u het "
 "correct heeft ingevoerd."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nieuw wachtwoord:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Bevestig wachtwoord:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1368,11 +1317,11 @@ msgstr ""
 "De link voor het opnieuw instellen van het wachtwoord was ongeldig, mogelijk "
 "omdat deze al is gebruikt. Vraag opnieuw een nieuw wachtwoord aan."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 msgid "Password reset link sent"
 msgstr "Link voor het opnieuw instellen van het wachtwoord verzonden"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 msgid ""
 "If an account exists with the email you entered, we've emailed instructions "
 "for resetting your password and you should receive them shortly."
@@ -1381,7 +1330,7 @@ msgstr ""
 "we instructies per e-mail gestuurd om uw wachtwoord opnieuw in te stellen. U "
 "ontvangt deze binnenkort."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 msgid ""
 "If you don't receive an email, please check your spam folder and make sure "
 "you've entered the address you registered with. (You won't get an email "
@@ -1391,14 +1340,14 @@ msgstr ""
 "het adres hebt ingevoerd waarmee u zich heeft geregistreerd (U ontvangt geen "
 "e-mail tenzij er al een account voor dat e-mailadres is!)."
 
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
 #| msgid ""
 #| "You're receiving this email because you requested a password reset for "
 #| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "U ontvangt deze e-mail omdat u een verzoek hebt ingediend om het wachtwoord "
 "opnieuw in te stellen voor uw gebruikersaccount op% (site_name) s."
@@ -1411,21 +1360,23 @@ msgstr "Ga naar de volgende pagina en kies een nieuw wachtwoord:"
 msgid "Your username, in case you've forgotten:"
 msgstr "Uw gebruikersnaam, voor het geval u het bent vergeten:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Bedankt voor het gebruiken van onze site!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "Het % (site_name) s team"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Reset mijn wachtwoord"
+
+#: web/templates/registration/password_reset_form.html:8
 msgid "Password reset"
 msgstr "Wachtwoord reset"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1433,127 +1384,267 @@ msgstr ""
 "Je wachtwoord vergeten? Voer hieronder uw e-mailadres in en we e-mailen u "
 "instructies voor het instellen van een nieuw wachtwoord."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "E-mailadres:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "Link voor het opnieuw instellen van het wachtwoord verzonden"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Reset mijn wachtwoord"
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
+"Dit materiaal is gebaseerd op werk dat wordt ondersteund door de National "
+"Science Foundation (NSF) in het kader van subsidies 1429216 en 1823919; het "
+"Center for Brains, Minds and Machines (CBMM), gefinancierd door NSF STC "
+"award CCF-1231216, en door een NSF Graduate Research Fellowship onder Grant "
+"nr. 1122374. Alle meningen, bevindingen en conclusies of aanbevelingen in "
+"dit materiaal zijn die van de auteur(s) en geven niet noodzakelijk de mening "
+"van de National Science Foundation weer."
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Onderzoeker"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr "Privacy"
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Studies"
+#: web/templates/web/_footer.html:17
+msgid "Contact us"
+msgstr "Neem contact met ons op"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "FAQ"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr "Verbind"
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "De wetenschappers"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Middelen"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Hallo"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Uitloggen"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "Aanmelden"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Onderzoeker"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
-msgid "Child"
-msgstr "Kind"
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
 
-#: web/templates/web/child-update.html:26
-msgid "Back to Children List"
-msgstr "Terug naar kinderlijst"
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Bijwerken"
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
 
-#: web/templates/web/child-update.html:41
-msgid "Delete"
-msgstr "Verwijderen"
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Kinderen"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Lege verjaardag"
-
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " dag"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " dagen"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " maand"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " maanden"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " jaar"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " jaren"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
 msgid "Add Child"
 msgstr "Kind toevoegen"
 
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Verberg formulier"
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr "Kind"
 
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Naam"
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr "Terug naar kinderlijst"
 
-#: web/templates/web/children-list.html:121
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr "Verwijderen"
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Opslaan"
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Bijwerken"
+
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Update kind"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Naam"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Geen kinderprofielen geregistreerd!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr ""
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Documentatie"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Update demografische gegevens"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1567,7 +1658,7 @@ msgstr ""
 "en hoe factoren zoals het spreken van meerdere talen of het hebben van "
 "oudere broers en zussen het leren van kinderen beïnvloeden."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1577,129 +1668,1549 @@ msgstr ""
 "of publiciteits doeleinden, wordt uw demografische informatie nooit samen "
 "met uw video gepubliceerd."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Deelnemen"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Je eerdere studies"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "We voeren op dit moment geen studies uit!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Log in om mee te doen"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Wat is uw geslacht?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Duur"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "In welke provincie woont u?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+msgid "For Researchers"
+msgstr ""
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Wat is uw leeftijd?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Log in om mee te doen"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "De wetenschappers"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Deelnemen"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Thuis"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Ik wil dat er met mij contact wordt opgenomen als:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Log in om mee te doen"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Maak een account aan"
+
+#: web/templates/web/participant-signup.html:13
 msgid "Create Participant Account"
 msgstr "Maak een deelnemersaccount aan"
 
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
-msgstr "Maak een gezinsaccount aan om deel te nemen aan Lookit-onderzoeken!"
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "Gebruik om u als onderzoeker te registreren"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead"
+msgid "instead."
+msgstr "in plaats daarvan"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "Door op 'Account aanmaken' te klikken, ga ik ermee akkoord dat ik het "
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Privacyverklaring"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Maak een account aan"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Privacyverklaring"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Alle deelnemers"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Extra informatie"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Eerdere studies"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
+#: web/templates/web/studies-history.html:15
+#, fuzzy
+#| msgid "Video"
+msgid "Next Video"
+msgstr "Video"
+
+#: web/templates/web/studies-history.html:31
 msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
 msgstr ""
-"Uw account heeft geen toegang tot deze pagina. Log in met een account dat "
-"toegang heeft om door te gaan."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Log in om deze pagina te zien."
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Huidige studies"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Je eerdere studies"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr "Hier kunt u uw studies bekijken en opmerkingen van onderzoekers zien:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Bestudeer Thumbnail"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Geschiktheid:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contact:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Verzamelt u nog steeds gegevens?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Ja"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Nee"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Vergoeding: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Vergoeding"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Onderzoeksreacties"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "Video"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Datum"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Toestemmingsstatus"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Goedgekeurd"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr "Uw toestemmingsvideo is beoordeeld door een onderzoeker en is geldig."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "In afwachting"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "Uw toestemmingsvideo is nog niet beoordeeld door een onderzoeker."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Ongeldig"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1709,176 +3220,178 @@ msgstr ""
 "toestemmingsverklaring niet hardop gelezen. Uw andere gegevens van deze "
 "sessie worden niet bekeken of gebruikt door de studieonderzoekers."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr ""
 "Geen informatie over de status van toestemming voor het beoordelen van "
 "video's."
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "Feedback"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "Geen"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "U hebt nog geen studies gedaan."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Huidige studies"
+#: web/templates/web/studies-history.html:147
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "U hebt nog geen studies gedaan."
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studies"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Houd er rekening mee dat u een laptop of desktopcomputer (geen mobiele "
-"telefoon) met Chrome of Firefox nodig heeft om deel te nemen."
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Zie de details"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "We voeren op dit moment geen studies uit!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"Op zoek naar meer manieren om bij te dragen aan onderzoek vanuit huis? "
-"Bekijk <a href=\"https://childrenhelpingscience.com/\" target=\"_blank\" rel="
-"\"noreferrer noopener\"> Children Helping Science </a> voor nog meer studies!"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "dagen"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " tot "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " wanneer "
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Middelen"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Studieoverzicht"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Terug naar lijst"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Geschiktheidscriteria"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Duur"
-
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Vergoeding"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Wat gebeurt er"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Wat we bestuderen"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Dit onderzoek wordt uitgevoerd door"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Wilt u deelnemen aan dit onderzoek?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Log in om mee te doen"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "Voeg kindprofiel toe aan "
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "voorbeeld"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "deelnemen"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "nu"
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Bouw een experimentrunner om een voorbeeld te bekijken"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Log in om mee te doen"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "Voeg kindprofiel toe aan "
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "Vul de demografische enquête in om "
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Deelnemen"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Wat gebeurt er"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Wat we bestuderen"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Duur"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Dit onderzoek wordt uitgevoerd door"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Wilt u deelnemen aan dit onderzoek?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Selecteer een kind:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Geen geselecteerd"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Uw kind is jonger dan de aanbevolen leeftijdscategorie voor dit onderzoek. "
 "Als u kunt wachten <span id = 'wait-till'> tot </span> hij of zij oud genoeg "
 "is, kunnen we dan de verzamelde data gebruiken in ons onderzoek!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Uw kind is ouder dan de aanbevolen leeftijdscategorie voor dit onderzoek. U "
 "bent sowieso welkom om het onderzoek te proberen, maar we kunnen de "
 "verzamelde data niet gebruiken in ons onderzoek."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Uw kind voldoet niet aan de criteria om in aanmerking te komen voor dit "
 "onderzoek. U bent sowieso welkom om het onderzoek te proberen, maar we "
 "kunnen de verzamelde data niet gebruiken in ons onderzoek. Neem dan contact "
 "op met de studieonderzoekers"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Bouw een experimentrunner om een voorbeeld te bekijken"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Deelnemen"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "nu"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1887,31 +3400,89 @@ msgstr ""
 "studieprotocol bijwerkt, kunt u een bladwijzer maken voor de URL waar de "
 "bovenstaande knop u naartoe stuurt."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Aanmelden"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Houd er rekening mee dat u een laptop of desktopcomputer (geen mobiele "
+"telefoon) met Chrome of Firefox nodig heeft om deel te nemen."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "Deelnemer gemaakt."
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "Demografische gegevens opgeslagen."
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "Kind toegevoegd."
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "Kind verwijderd."
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "Kind geüpdatet."
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "E-mailvoorkeuren opgeslagen."
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -1922,14 +3493,192 @@ msgstr ""
 "is voltooid of onderbroken. Als u denkt dat dit een fout is, neem dan "
 "contact op met {study.contact_info}"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "Gebruik om u als onderzoeker te registreren"
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr ""
+#~ "Uw wachtwoord mag niet te veel lijken op uw andere persoonlijke gegevens."
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "Uw wachtwoord moet minimaal 16 tekens bevatten."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "Uw wachtwoord mag geen algemeen gebruikt wachtwoord zijn."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "Uw wachtwoord mag niet volledig numeriek zijn."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "In welke categorie(ën) identificeert uw gezin zich?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Alleen numerieke antwoorden - een ruwe schatting is prima!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Welke taal / talen spreekt uw gezin thuis?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr ""
+#~ "Wat is de hoogste opleiding die uw echtgenoot/echtgenote/partner heeft "
+#~ "afgerond?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Hoeveel kinderboeken zijn er ongeveer in uw huis?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Als het antwoord varieert vanwege regelingen voor gedeeld gezag of "
+#~ "reizen, voer dan het aantal ouders / verzorgers in waar uw kinderen "
+#~ "gewoonlijk mee samenwonen of leg de situatie uit."
+
+#~ msgid "other"
+#~ msgstr "andere"
+
+#~ msgid "3 or more"
+#~ msgstr "3 of meer"
+
+#~ msgid "varies"
+#~ msgstr "varieert"
+
+#~ msgid "My Account"
+#~ msgstr "Mijn account"
+
+#~ msgid "Last Active:"
+#~ msgstr "Laatst actief:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "Globale ID deelnemer:"
+
+#~ msgid "Dashboard"
+#~ msgstr "Dashboard"
+
+#, fuzzy
+#~| msgid "Portuguese"
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "Portugees"
+
+#~ msgid "Yue"
+#~ msgstr "Ja"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Log in om mee te doen"
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "Uw inloggegevens werkten niet. Probeer het opnieuw."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Nieuw bij Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nieuw wachtwoord:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Bevestig wachtwoord:"
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "Het % (site_name) s team"
+
+#~ msgid "Email address:"
+#~ msgstr "E-mailadres:"
+
+#~ msgid "FAQ"
+#~ msgstr "FAQ"
+
+#~ msgid "Hi"
+#~ msgstr "Hallo"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Lege verjaardag"
+
+#~ msgid " day"
+#~ msgstr " dag"
+
+#~ msgid " days"
+#~ msgstr " dagen"
+
+#~ msgid " month"
+#~ msgstr " maand"
+
+#~ msgid " months"
+#~ msgstr " maanden"
+
+#~ msgid " year"
+#~ msgstr " jaar"
+
+#~ msgid " years"
+#~ msgstr " jaren"
+
+#~ msgid "Hide Form"
+#~ msgstr "Verberg formulier"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr "Maak een gezinsaccount aan om deel te nemen aan Lookit-onderzoeken!"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Uw account heeft geen toegang tot deze pagina. Log in met een account dat "
+#~ "toegang heeft om door te gaan."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Log in om deze pagina te zien."
+
+#~ msgid "Compensation: "
+#~ msgstr "Vergoeding: "
+
+#~ msgid "None"
+#~ msgstr "Geen"
+
+#~ msgid "Current Studies"
+#~ msgstr "Huidige studies"
+
+#~ msgid "See details"
+#~ msgstr "Zie de details"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "We voeren op dit moment geen studies uit!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Op zoek naar meer manieren om bij te dragen aan onderzoek vanuit huis? "
+#~ "Bekijk <a href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\"> Children Helping Science </a> voor nog meer "
+#~ "studies!"
+
+#~ msgid "days"
+#~ msgstr "dagen"
+
+#~ msgid " until "
+#~ msgstr " tot "
+
+#~ msgid " when "
+#~ msgstr " wanneer "
+
+#~ msgid "Study overview"
+#~ msgstr "Studieoverzicht"
+
+#~ msgid "Back to list"
+#~ msgstr "Terug naar lijst"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Geschiktheidscriteria"
 
 #~ msgid "this form"
 #~ msgstr "dit formulier"
-
-#~ msgid "instead"
-#~ msgstr "in plaats daarvan"
 
 #~ msgid "Birthday test"
 #~ msgstr "Verjaardagstest"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -3325,10 +3325,8 @@ msgstr "Duur"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Dit onderzoek wordt uitgevoerd door"
+msgstr "Dit onderzoek wordt uitgevoerd door %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -3353,9 +3353,8 @@ msgstr "Varighet"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
 msgid "This study is conducted by %(contact)s."
-msgstr "Denne studien utføres av"
+msgstr "Denne studien utføres av %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr "Skriv inn et gyldig 6-sifret engangspassord fra Google Authenticator"
 
@@ -30,42 +30,24 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "Denne kontoen er inaktiv."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr "Passordet ditt kan ikke være for likt personopplysningene dine."
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "Passordet må innholde minst 16 tegn."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "Passordet ditt kan ikke være et passord du bruker ofte."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "Passordet ditt må innholde mer enn bare tall."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "E-postadresse"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Kallenavn"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "Det er på tide med en ny økt av studien vi deltar i."
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "En ny studie er tilgjengelig for et av barna mine"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -73,7 +55,7 @@ msgstr ""
 "En studie vi har deltatt i har blitt oppdatert (for eksempel, resultater har "
 "blitt publisert)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -81,100 +63,91 @@ msgstr ""
 "En forsker har spørsmål om et av svarene jeg har gitt (for eksempel hvis jeg "
 "har rapportert tekniske problemer under studien)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "Hvilken kategori(er) identifiserer familien din seg som?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Land"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Fyll inn en liste separert av kommaer: YYYY-MM-DD, YYYY-MM-DD, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Bare fyll inn numeriske svar, det går greit med gjetting!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "Hvilket land bor du i?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "Hvilket fylke bor du i?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Hvordan ville du beskrevet området du bor i?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Hvilket språk snakker familien din hjemme?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Hvor mange barn har du?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Vennligst fyll inn fødselsdatoen for hvert barn"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Hvor mange foreldre/foresatte bor barna dine med?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Hvor gammel er du?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Hva er ditt kjønn?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Hva er ditt kjønn?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Hva er den høyeste formen for utdanning du har fullført?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Hva er den høyeste formen for utdanning partneren din har fullført?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Hva er din families årlige inntekt ca. (i Norske kroner)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Ca. hvor mange barnebøker har dere hjemme?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Er det noe annet du vil at vi skal vite?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Hvordan hørte du om Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Hvis svaret varierer på grunn av delt omsorg eller reise, ønsker vi at du "
-"forteller hvor mange foreldre eller foresatte barnet ditt vanligvis bor med "
-"eller forklar situasjonen."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Fødselsdato"
+#: accounts/forms.py:357
+#, fuzzy
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Annen rase, etnisitet eller opprinnelse"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -184,33 +157,36 @@ msgstr ""
 "Vi publiserer aldri barnets fødselsdato eller informasjon som lar andre å "
 "regne ut barnets fødselsdato."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Fødselsdag kan ikke være i fremtiden"
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Fornavn"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Fødselsdato"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Kjønn"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Svangerskapsalder ved fødsel"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Er det noen tilleggsinformasjon du vil at vi skal vite?"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Egenskaper og tilstander"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -218,7 +194,7 @@ msgstr ""
 "Språk barnet ditt eksponeres for hjemme, på skolen eller med andre "
 "forsørgere."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -231,531 +207,616 @@ msgstr ""
 "en ny studie tilgjengelig for Molly!\" men vi vil aldri publisere navn eller "
 "bruke dem i studier."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "For eksempel, diagnotisert med utviklingsforstyrrelse, eller syns- eller "
 "hørselsvansker"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Vennligst rund av til nærmeste uke av fullført svangerskap"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Studier"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+msgid "Scheduled studies"
+msgstr "Studier nå"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Dine tidligere studier"
+
+#: accounts/forms.py:517
+#, fuzzy
+msgid "External studies"
+msgstr "Studier nå"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Ikke sikker, eller foretrekker å ikke svare"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Under 24 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 uker"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 eller flere uker"
 
-#: accounts/models.py:80
+#: accounts/models.py:45
+msgid "male"
+msgstr "Mann"
+
+#: accounts/models.py:46
+msgid "female"
+msgstr "Kvinne"
+
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
+
+#: accounts/models.py:48 accounts/models.py:510
+msgid "prefer not to answer"
+msgstr "Ønsker ikke å svare"
+
+#: accounts/models.py:87
 msgid "Can View Organization"
 msgstr "Kan se Organisasjon"
 
-#: accounts/models.py:81
+#: accounts/models.py:88
 msgid "Can Edit Organization"
 msgstr "Kan redigere Organisasjon"
 
-#: accounts/models.py:82
+#: accounts/models.py:89
 msgid "Can Create Organization"
 msgstr "Kan lage Organisasjon"
 
-#: accounts/models.py:83
+#: accounts/models.py:90
 msgid "Can Remove Organization"
 msgstr "Kan fjerne Organisasjon"
 
-#: accounts/models.py:84
+#: accounts/models.py:91
 #, fuzzy
 msgid "Can View Experimenter"
 msgstr "Kan se Experimenter"
 
-#: accounts/models.py:85
+#: accounts/models.py:92
 #, fuzzy
 msgid "Can View Analytics"
 msgstr "Kan se Analyseverktøy"
 
-#: accounts/models.py:280
+#: accounts/models.py:324
 msgid "Can Create User"
 msgstr "Kan lage bruker"
 
-#: accounts/models.py:281
+#: accounts/models.py:325
 msgid "Can View User"
 msgstr "Kan se bruker"
 
-#: accounts/models.py:282
+#: accounts/models.py:326
 msgid "Can Edit User"
 msgstr "Kan redigere bruker"
 
-#: accounts/models.py:283
+#: accounts/models.py:327
 msgid "Can Remove User"
 msgstr "Kan fjerne bruker"
 
-#: accounts/models.py:284
+#: accounts/models.py:328
 #, fuzzy
 msgid "Can View User Permissions"
 msgstr "Kan se brukertillatelser"
 
-#: accounts/models.py:285
+#: accounts/models.py:329
 #, fuzzy
 msgid "Can Edit User Permissions"
 msgstr "Kan redigere brukertillatelse"
 
-#: accounts/models.py:286
+#: accounts/models.py:330
 msgid "Can Read All User Data"
 msgstr "Kan lese all brukerdata"
 
-#: accounts/models.py:287
+#: accounts/models.py:331
 msgid "Can Read User Usernames"
 msgstr "Kan lese alle brukernavn"
 
-#: accounts/models.py:294 accounts/models.py:397
-msgid "male"
-msgstr "Mann"
-
-#: accounts/models.py:295 accounts/models.py:398
-msgid "female"
-msgstr "Kvinne"
-
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "Annet"
-
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
-msgid "prefer not to answer"
-msgstr "Ønsker ikke å svare"
-
-#: accounts/models.py:387
+#: accounts/models.py:425
 msgid "White"
 msgstr "Hvit"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Latinamerikansk, eller Spansk opprinnelse"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 #, fuzzy
 msgid "Black or African American"
 msgstr "Afrikansk"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 #, fuzzy
 msgid "Asian"
 msgstr "Asiatisk"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 #, fuzzy
 msgid "American Indian or Alaska Native"
 msgstr "Samisk"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Fra Midtøsten eller Nord Afrika"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 #, fuzzy
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr ""
 "Nasjonal minoritet (Jøder, kvener/norskfinner, romanifolk/tatere, skogfinner "
 "og rom)"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 #, fuzzy
 msgid "Another race, ethnicity, or origin"
 msgstr "Annen rase, etnisitet eller opprinnelse"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 #, fuzzy
 msgid "some or attending high school"
 msgstr "Har delvis gått på eller går på videregående skole"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "Fullført videregående skole eller tilsvarende"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 #, fuzzy
 msgid "some or attending college"
 msgstr "Har delvis gått på eller går på universitet eller høyskole"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "Bachelorgrad"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "Mastergrad"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 #, fuzzy
 msgid "some or attending graduate or professional school"
 msgstr ""
 "Har delvis gått på eller går på master-, doktor- eller profesjonsstudie"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 #, fuzzy
 msgid "graduate or professional degree"
 msgstr "Master grad, Phd, eller Profesjonsgrad"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "Ikke aktuelt - ingen ektefelle eller partner"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Mer enn 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "Under 18"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "8-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 eller over"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 eller mer"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "Varierer"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "over 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "Urbant"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 #, fuzzy
 msgid "suburban"
 msgstr "Boligområde, utenfor tettstrøk"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 #, fuzzy
 msgid "rural"
 msgstr "Ute på landet"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Velg Fylke"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "Gan"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Brukerinformasjon"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "Endre påloggingsinformasjon og / eller kallenavn."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 #, fuzzy
 msgid "Demographic Survey"
 msgstr "Demografisk undersøkelse"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Fortell oss mer om deg selv"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informasjon om barn"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 #, fuzzy
 msgid "Add or edit participant information."
 msgstr "Legg til eller rediger deltagerinformasjon"
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "E-post preferanser"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Rediger når du kan bli kontaktet"
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Min konto"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Brukerinformasjon"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Lagre"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Bytt passordet ditt"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "Administrer tofaktorautentisering"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -763,11 +824,18 @@ msgstr ""
 "Hvis du vil, kan du slå av tofaktorautentisering her. Bare skriv inn "
 "engangspassordet ditt her, trykk på send, så blir det slettet for deg!"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "Sett opp to-faktor autentisering"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Alle deltagere"
 
@@ -775,132 +843,65 @@ msgstr "Alle deltagere"
 msgid "Participant ID"
 msgstr "Deltager ID"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Sist aktiv"
-
-#: accounts/templates/accounts/participant_detail.html:25
-#, fuzzy
-msgid "Participant global ID:"
-msgstr "Global deltager ID"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Barn"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Alder"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Tilleggsinformasjon"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Ingen barneprofiler er registrert"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 #, fuzzy
 msgid "Latest Demographic Data"
 msgstr "Siste demografisk data"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Land"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Fylke"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Beskrivelse av område"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Språket som snakkes hjemme"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Antall barn"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 #, fuzzy
 msgid "Children current ages"
 msgstr "Alderen til barna nå"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+msgid "No Response"
+msgstr "Svar fra studien"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Antall foresatte"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Beskrivelse av foresatte"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 #, fuzzy
 msgid "Race"
 msgstr "Etnisitet"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Dashbord"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "Tysk"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "Engelsk"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "Spansk"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "Fransk"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "Italiensk"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "Japansk"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "Koreansk"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "Polsk"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "Portugisisk"
-
-#: project/settings.py:241
-#, fuzzy
-#| msgid "Portuguese"
-msgid "Brazilian Portuguese"
-msgstr "Portugisisk"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "Rumensk"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "Russisk"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "Tyrkisk"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "Nederlandsk"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -955,6 +956,10 @@ msgstr "Septuplett (syv barn født samtidig)"
 msgid "Octuplet"
 msgstr "Octuplet (åtte barn født samtidig)"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "Engelsk"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "Amharisk"
@@ -979,13 +984,25 @@ msgstr "Cebuano"
 msgid "Chhattisgarhi"
 msgstr "Chhattisgarhi"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "Nederlandsk"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "Egyptisk Muntlig Arabisk"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "Fransk"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "Gan"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "Tysk"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -1000,164 +1017,206 @@ msgid "Hausa"
 msgstr "Hausa"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "Hindi"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "Igbo"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "Indonesisk"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "Iransk persisk"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "Italiensk"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "Japansk"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "Javanesisk"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "Jinyu"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "Kannada"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "Khmer"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "Koreansk"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "Magahi"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "Maithili"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "Malaysisk"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "Mandarin"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "Marathi"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "Min Nan"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "Marokkansk talt arabisk"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "Northern Pashto"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "Nord-usbekisk"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "Odia"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "Polsk"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "Portugisisk"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "Rumensk"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "Russisk"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "Saraiki"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "Sindhi"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "Somalisk"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "Spansk"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "Sunda"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "Tamil"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "Telugu"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "Thai"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "Tyrkisk"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "Ukrainsk"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "Urdu"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "Vietnamesisk"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "Vestlige Punjabi"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "Wu"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "Xiang kinesisk"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "Yue"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Ikke svart"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Annet"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 #, fuzzy
 msgid "Male"
 msgstr "Gutt"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 #, fuzzy
 msgid "Female"
 msgstr "Jente"
 
-#: studies/models.py:113
+#: studies/models.py:143
 #, fuzzy
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
@@ -1167,174 +1226,70 @@ msgstr ""
 "stand til å lage studier tilknyttet til denne labben og kan legges til "
 "labbens studier."
 
-#: studies/models.py:122
+#: studies/models.py:152
 #, fuzzy
 msgid "The Users who have requested to join this Lab."
 msgstr "Brukerene som har bedt om arbeide i labben"
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-#, fuzzy
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:53
-msgid ""
-"This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
-"findings, and conclusions or recommendations expressed in this material are "
-"those of the authors(s) and do not necessarily reflect the views of the "
-"National Science Foundation."
-msgstr ""
-"Dette materialet er basert på arbeid støttet av National Science Foundation "
-"(NSF) under tilskudd 1429216 og 1823919; Center for Brains, Minds and "
-"Machines (CBMM), finansiert av NSF STC-prisen CCF-1231216, og av et NSF "
-"Graduate Research Fellowship under tilskudd nr. 1122374. Enhver mening, funn "
-"og konklusjoner eller anbefalinger uttrykt i dette materialet tilhører "
-"forfatterne og reflekterer ikke nødvendigvis synspunktene til National "
-"Science Foundation."
-
-#: web/templates/frontpages/default.html:60 web/templates/frontpages/home.html:48
-msgid "Privacy"
-msgstr "Personvern"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-msgid "Contact us"
-msgstr "Kontakt oss"
-
-#: web/templates/frontpages/default.html:63
-msgid "Connect"
-msgstr "Få kontakt"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Delta"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Logg inn for å delta"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Logg inn for å delta"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Hva er ditt kjønn?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Varighet"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-msgid "Why are you running studies online instead of in person?"
-msgstr "Vi holder ikke på med noen studier akkurat nå!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Delta"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Personvernserklæring"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Alle deltagere"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Tilleggsinformasjon"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Du har logget av"
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr "Påloggingsinformasjonen din fungerte ikke. Vennligst prøv igjen."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Logg inn"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Glemt passord?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Ny på Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/login.html:36
+#: web/templates/registration/login.html:28
 msgid "Register your family!"
 msgstr "Registrer familien din!"
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/password_change_done.html:9
 #, fuzzy
 msgid "Password changed"
 msgstr "Passordet er byttet"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Ditt passord har blitt forandret"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Dokumentasjon"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Bytt passord"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Logg ut"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Hjem"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Passordbytte"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Vennligst korriger feilen under"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Vennligst korriger feilene under"
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -1342,30 +1297,30 @@ msgstr ""
 "Vennligst fyll inn ditt gamle passord, for sikkerhets skyld, og fyll inn "
 "ditt nye passord to ganger så vi kan bekrefte at du har skrevet det riktig"
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Bytt passordet mitt"
 
-#: web/templates/registration/password_reset_complete.html:11
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "Logg inn"
+
+#: web/templates/registration/password_reset_complete.html:10
 msgid "Password reset complete"
 msgstr "Passordbytte fullført"
 
-#: web/templates/registration/password_reset_complete.html:15
+#: web/templates/registration/password_reset_complete.html:12
 #, fuzzy
 msgid "Your password has been set.  You may go ahead and log in now."
 msgstr "Passordet ditt har blitt lagret. Du kan nå logge inn."
 
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "Logg inn"
-
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_confirm.html:8
 #, fuzzy
 msgid "Password reset confirmation"
 msgstr "Bekreft tilbakestilling av passord"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1373,15 +1328,7 @@ msgstr ""
 "Vennligst fyll inn ditt nye passord to ganger så vi kan bekrefte at du skrev "
 "det riktig"
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nytt passord:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Bekreft passord:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 #, fuzzy
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
@@ -1391,11 +1338,11 @@ msgstr ""
 "utgått eller blitt brukt før. Vennligst be om å tilbakestille passordet på "
 "nytt"
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 msgid "Password reset link sent"
 msgstr "Lenke for tilbakestilling av passord"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 msgid ""
 "If an account exists with the email you entered, we've emailed instructions "
 "for resetting your password and you should receive them shortly."
@@ -1404,7 +1351,7 @@ msgstr ""
 "instruksjoner for å tilbakestille passordet ditt per e-post, og du vil motta "
 "dem snart."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 msgid ""
 "If you don't receive an email, please check your spam folder and make sure "
 "you've entered the address you registered with. (You won't get an email "
@@ -1414,11 +1361,11 @@ msgstr ""
 "for at du har angitt adressen du registrerte deg med. (Du får ikke en e-post "
 "med mindre det allerede finnes en konto som er tilknyttet e-postadressen!)"
 
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Du har mottatt denne e-posten fordi du ønsket å tilbakestille passordet for "
 "denne brukeren på %(site_name)"
@@ -1432,21 +1379,23 @@ msgstr "Vennligst gå til denne siden og lag et nytt passord:"
 msgid "Your username, in case you've forgotten:"
 msgstr "I tilfelle du har glemt det, er brukernavnet ditt:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Takk for at du bruker siden vår!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "Teamet til %(site_name)"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Tilbakestill passordet mitt"
+
+#: web/templates/registration/password_reset_form.html:8
 msgid "Password reset"
 msgstr "Tilbakestilling av passord"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 #, fuzzy
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
@@ -1455,134 +1404,271 @@ msgstr ""
 "Glemt passord? Skriv e-postadressen din under, så sender vi deg "
 "instruksjoner for å lage et nytt passord."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "E-postadresse: "
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "Lenke for tilbakestilling av passord"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Tilbakestill passordet mitt"
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
+"Dette materialet er basert på arbeid støttet av National Science Foundation "
+"(NSF) under tilskudd 1429216 og 1823919; Center for Brains, Minds and "
+"Machines (CBMM), finansiert av NSF STC-prisen CCF-1231216, og av et NSF "
+"Graduate Research Fellowship under tilskudd nr. 1122374. Enhver mening, funn "
+"og konklusjoner eller anbefalinger uttrykt i dette materialet tilhører "
+"forfatterne og reflekterer ikke nødvendigvis synspunktene til National "
+"Science Foundation."
 
-#: web/templates/web/_navigation.html:22
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr "Personvern"
+
+#: web/templates/web/_footer.html:17
+msgid "Contact us"
+msgstr "Kontakt oss"
+
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr "Få kontakt"
+
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr "Logg ut"
+
+#: web/templates/web/_navigation.html:4
 #, fuzzy
 msgid "Experimenter"
 msgstr "Experimenter"
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Studier"
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "Spørsmål og svar"
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Forskerne:"
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
 
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Ressurser"
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
 
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Hei"
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
 
-#: web/templates/web/_navigation.html:47
-msgid "Logout"
-msgstr "Logg ut"
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Barn"
 
-#: web/templates/web/_navigation.html:49
-#, fuzzy
-msgid "Sign up"
-msgstr "Lag en konto"
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Avbryt"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Legg til barn"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Barn"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 msgid "Back to Children List"
 msgstr "Tilbake til Barnelisten"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Oppdater"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Slett"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Avbryt"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Lagre"
 
-#: web/templates/web/children-list.html:40
-#, fuzzy
-msgid "Empty birthday"
-msgstr "Uten bursdag"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Oppdater"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " dag"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " dager"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " måned"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " måneder"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " år"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " år"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Legg til barn"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#, fuzzy
-msgid "Hide Form"
-msgstr "Skjul skjema"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Navn"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Oppdater barn"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Navn"
+
+#: web/templates/web/children-list.html:64
 #, fuzzy
 msgid "No child profiles registered!"
 msgstr "Ingen barneprofiler registrert!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr ""
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Dokumentasjon"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 #, fuzzy
 msgid "Update demographics"
 msgstr "Oppdater demografi"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 #, fuzzy
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
@@ -1596,7 +1682,7 @@ msgstr ""
 "hjelpe oss å forstå hvilken demografi vi når, og hvilken faktorer, som å "
 "være flerspråklig eller antall søsken, som påvirker barns læring."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 #, fuzzy
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
@@ -1607,137 +1693,1553 @@ msgstr ""
 "vitenskapelige eller publiseringsformål, vil vi aldri  publisere din "
 "demografiske informasjon sammen med videoen din."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Delta"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Dine tidligere studier"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+msgid "Why are you running studies online instead of in person?"
+msgstr "Vi holder ikke på med noen studier akkurat nå!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Logg inn for å delta"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Hva er ditt kjønn?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Varighet"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "Hvilket fylke bor du i?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+msgid "For Researchers"
+msgstr ""
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Hvor gammel er du?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Logg inn for å delta"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Forskerne:"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Delta"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Hjem"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Jeg ønsker å bli kontaktet når:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Logg inn for å delta"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Lag konto"
+
+#: web/templates/web/participant-signup.html:13
 msgid "Create Participant Account"
 msgstr "Opprett deltakerkonto"
 
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
-msgstr "Opprett en familiekonto for å begynne å delta i Lookit-studier!"
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "For å registrere deg som forsker, vennligst bruk"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead"
+msgid "instead."
+msgstr "i stedet"
+
+#: web/templates/web/participant-signup.html:28
 #, fuzzy
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "Ved å trykke \"Lag konto\", er jeg enig om at jeg har akkseptert "
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Personvernserklæring"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Lag konto"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Personvernserklæring"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Alle deltagere"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Tilleggsinformasjon"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Tidligere studier"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
-msgstr ""
-"Din konto har ikke tilgang til denne siden. Vennligst log inn med en konto "
-"som har tilgang for å fortsette, "
-
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Venlligst logg inn for å se siden"
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
+#: web/templates/web/studies-history.html:15
 #, fuzzy
-msgid "Current studies"
-msgstr "Studier nå"
+#| msgid "Video"
+msgid "Next Video"
+msgstr "Video"
 
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Dine tidligere studier"
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr "Her kan du se studiene dine og kommentarer fra forskere"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 #, fuzzy
 msgid "Study Thumbnail"
 msgstr "Miniatyrbilde til studien"
 
-#: web/templates/web/studies-history.html:79
+#: web/templates/web/studies-history.html:55
 #, fuzzy
-msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Krav:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Kontakt:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 #, fuzzy
 msgid "Still collecting data?"
 msgstr "Samles fortsatt data?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Ja"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Nei"
 
-#: web/templates/web/studies-history.html:82
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
 #, fuzzy
-msgid "Compensation: "
-msgstr "Kompensasjon: "
+msgid "Compensation"
+msgstr "Kompensasjon"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 #, fuzzy
 msgid "Study Responses"
 msgstr "Svar fra studien"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "Video"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Dato"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Status på samtykke"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Godkjent"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr "Samtykkevideon har blitt gjennomgått av en forsker og er gyldig "
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 #, fuzzy
 msgid "Pending"
 msgstr "Avventer"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "Din samtykkevideo har fremdeles ikke blitt gjennomgått av en forsker"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Ikke gyldig"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 #, fuzzy
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
@@ -1748,183 +3250,166 @@ msgstr ""
 "deg ikke lese samtykkeerklæringen høyt. Annen data du har oppgitt for denne "
 "økten vil ikke bli gjennomgått eller brukt av forskerne til denne studien."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 #, fuzzy
 msgid "No information about consent video review status."
 msgstr "Ingen informasjon om statusen til gjennomgåingen av samtykkevideon"
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "Tilbakemelding"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "Ingen"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Du har ikke deltatt i noen studier enda"
 
-#: web/templates/web/studies-list.html:32
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-msgid "Current Studies"
-msgstr "Gjeldende studier"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Du har ikke deltatt i noen studier enda"
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studier"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Du trenger en laptop eller stasjonær pc (ikke mobil eller nettbrett) med "
-"Chrome eller Firefox for å delta"
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Se detaljer"
-
-#: web/templates/web/studies-list.html:87
-#, fuzzy
-msgid "We are not running any studies at this time!"
-msgstr "Vi holder ikke på med noen studier akkurat nå!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"Ser du etter flere måter å bidra til forskning hjemmefra? Sjekk ut <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for flere studier!"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "dager"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " til "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " når "
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressurser"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Oversikt over studiet "
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Tilbake til listen"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Kvalifikasjonskriterier"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Varighet"
-
-#: web/templates/web/study-detail.html:121
-#, fuzzy
-msgid "Compensation"
-msgstr "Kompensasjon"
-
-#: web/templates/web/study-detail.html:126
-#, fuzzy
-msgid "What happens"
-msgstr "Hva som skjer"
-
-#: web/templates/web/study-detail.html:130
-#, fuzzy
-msgid "What we're studying"
-msgstr "Hva vi undersøker"
-
-#: web/templates/web/study-detail.html:134
-#, fuzzy
-msgid "This study is conducted by"
-msgstr "Denne studien utføres av"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Ønsker du å delta i denne studien?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Logg inn for å delta"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "Legg barneprofil til "
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "forhåndsvisning"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "Delta"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "nå"
+
+#: web/templates/web/study-detail.html:20
+#, fuzzy
+msgid "Build experiment runner to preview"
+msgstr "Lag \"experiment runner\" for forhåndsvisning"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Logg inn for å delta"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "Legg barneprofil til "
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "Fullfør den demografiske undersøkelsen for å"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Delta"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+msgid "What Happens"
+msgstr "Hva som skjer"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+msgid "What We're Studying"
+msgstr "Hva vi undersøker"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Varighet"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+msgid "This study is conducted by %(contact)s."
+msgstr "Denne studien utføres av"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Ønsker du å delta i denne studien?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Velg barn:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 #, fuzzy
 msgid "None Selected"
 msgstr "Ingen valgt"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
 #, fuzzy
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Ditt barn er fremdeles yngre enn den annbefalte aldren for å delta i denne "
 "studien. Hvis du venter til <span id='wait-until'>until</span>  hun eller "
 "han er gammel nok før dere deltar, vil vi kunne bruke den innsamlede dataen! "
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Ditt barn er eldre enn den anbefalte alderen for å delta i denne studien. Du "
 "kan fremdeles delta, men vi kan dessverre ikke bruke den innsamlede dataen. "
 
-#: web/templates/web/study-detail.html:163
-#, fuzzy
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Barnet ditt fyller ikke kriteriene for å detla i denne studien. Du kan "
 "fremdeles delta, men vi kan dessverre ikke bruke den innsamlede dataen. "
 "Vennligst kontakt forskeren som er ansvarlig for studien."
 
-#: web/templates/web/study-detail.html:165
-#, fuzzy
-msgid "Build experiment runner to preview"
-msgstr "Lag \"experiment runner\" for forhåndsvisning"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Delta"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "nå"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 #, fuzzy
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
@@ -1933,31 +3418,90 @@ msgstr ""
 "For en enklere måte å se hva som skjer når du oppdaterer studieprotokoller, "
 "\"bokmerk\" URLen du får fra knappen over."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+#, fuzzy
+msgid "Sign up"
+msgstr "Lag en konto"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Du trenger en laptop eller stasjonær pc (ikke mobil eller nettbrett) med "
+"Chrome eller Firefox for å delta"
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "Deltager opprettet"
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "Demografisk data lagret."
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "Barn lagt til"
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "Barn slettet"
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "Barn oppdatert"
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "E-postinnstillinger lagret."
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -1968,14 +3512,196 @@ msgstr ""
 "eller midlertidig stoppet. Hvis du tror dette kan være feil, kan du kontakte "
 "{study.contact_info}"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "For å registrere deg som forsker, vennligst bruk"
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr "Passordet ditt kan ikke være for likt personopplysningene dine."
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "Passordet må innholde minst 16 tegn."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "Passordet ditt kan ikke være et passord du bruker ofte."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "Passordet ditt må innholde mer enn bare tall."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "Hvilken kategori(er) identifiserer familien din seg som?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Bare fyll inn numeriske svar, det går greit med gjetting!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Hvilket språk snakker familien din hjemme?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "Hva er den høyeste formen for utdanning partneren din har fullført?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Ca. hvor mange barnebøker har dere hjemme?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Hvis svaret varierer på grunn av delt omsorg eller reise, ønsker vi at du "
+#~ "forteller hvor mange foreldre eller foresatte barnet ditt vanligvis bor "
+#~ "med eller forklar situasjonen."
+
+#~ msgid "other"
+#~ msgstr "Annet"
+
+#~ msgid "3 or more"
+#~ msgstr "3 eller mer"
+
+#~ msgid "varies"
+#~ msgstr "Varierer"
+
+#~ msgid "My Account"
+#~ msgstr "Min konto"
+
+#~ msgid "Last Active:"
+#~ msgstr "Sist aktiv"
+
+#, fuzzy
+#~ msgid "Participant global ID:"
+#~ msgstr "Global deltager ID"
+
+#~ msgid "Dashboard"
+#~ msgstr "Dashbord"
+
+#, fuzzy
+#~| msgid "Portuguese"
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "Portugisisk"
+
+#~ msgid "Yue"
+#~ msgstr "Yue"
+
+#, fuzzy
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Logg inn for å delta"
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "Påloggingsinformasjonen din fungerte ikke. Vennligst prøv igjen."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Ny på Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nytt passord:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Bekreft passord:"
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "Teamet til %(site_name)"
+
+#~ msgid "Email address:"
+#~ msgstr "E-postadresse: "
+
+#~ msgid "FAQ"
+#~ msgstr "Spørsmål og svar"
+
+#~ msgid "Hi"
+#~ msgstr "Hei"
+
+#, fuzzy
+#~ msgid "Empty birthday"
+#~ msgstr "Uten bursdag"
+
+#~ msgid " day"
+#~ msgstr " dag"
+
+#~ msgid " days"
+#~ msgstr " dager"
+
+#~ msgid " month"
+#~ msgstr " måned"
+
+#~ msgid " months"
+#~ msgstr " måneder"
+
+#~ msgid " year"
+#~ msgstr " år"
+
+#~ msgid " years"
+#~ msgstr " år"
+
+#, fuzzy
+#~ msgid "Hide Form"
+#~ msgstr "Skjul skjema"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr "Opprett en familiekonto for å begynne å delta i Lookit-studier!"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Din konto har ikke tilgang til denne siden. Vennligst log inn med en "
+#~ "konto som har tilgang for å fortsette, "
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Venlligst logg inn for å se siden"
+
+#, fuzzy
+#~ msgid "Compensation: "
+#~ msgstr "Kompensasjon: "
+
+#~ msgid "None"
+#~ msgstr "Ingen"
+
+#, fuzzy
+#~ msgid "Current Studies"
+#~ msgstr "Gjeldende studier"
+
+#~ msgid "See details"
+#~ msgstr "Se detaljer"
+
+#, fuzzy
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Vi holder ikke på med noen studier akkurat nå!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Ser du etter flere måter å bidra til forskning hjemmefra? Sjekk ut <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for flere "
+#~ "studier!"
+
+#~ msgid "days"
+#~ msgstr "dager"
+
+#~ msgid " until "
+#~ msgstr " til "
+
+#~ msgid " when "
+#~ msgstr " når "
+
+#~ msgid "Study overview"
+#~ msgstr "Oversikt over studiet "
+
+#~ msgid "Back to list"
+#~ msgstr "Tilbake til listen"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Kvalifikasjonskriterier"
 
 #~ msgid "this form"
 #~ msgstr "dette skjemaet"
-
-#~ msgid "instead"
-#~ msgstr "i stedet"
 
 #~ msgid "Birthday test"
 #~ msgstr "Bursdagstest"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -2,33 +2,48 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Adres e-mail"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Pseudonim"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "Czas na kolejną sesję badania, w którym obecnie uczestniczymy"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Nowe badanie jest dostępne dla jednego z moich dzieci."
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -36,7 +51,7 @@ msgstr ""
 "Istnieje aktualizacja dotycząca badania, w którym braliśmy udział (na "
 "przykład, wyniki są opublikowane)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -44,105 +59,94 @@ msgstr ""
 "Badacz(ka) ma pytania dotyczące moich poszczególnych odpowiedzi (na "
 "przykład, jeśli zgłoszę problem techniczny podczas badania)."
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr ""
-"Z którą (lub z którymi) z tych kategorii utożsamia się państwa rodzina?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Państwo"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Wpisz jako listę oddzieloną przecinkami: YYYY-MM-DD, YYYYY-MM-DD, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Tylko odpowiedzi wyrażone w liczbach - można mniej więcej oszacować. "
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "W jakim kraju Państwo mieszkają?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "W jakim województwie Państwo mieszkają?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Jak opisaliby Państwo okolicę, w której Państwo mieszkają?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Jakim językiem (językami) posługuje się państwa rodzina w domu?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Ile mają Państwo dzieci?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Dla każdego dziecka, proszę podać ich datę urodzenia:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Z iloma rodzicami/opiekunami mieszkają państwa dzieci?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Jaki jest państwa wiek?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Jaka jest państwa płeć?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Jaka jest państwa płeć?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Jaki jest najwyższy poziom edukacji, który Państwo ukończyli?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr ""
-"Jaki jest najwyższy poziom wykształcenia, które ukończył/a państwa "
-"współmałżonek/współmałżonka?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr ""
 "Jaki jest  przybliżony roczny dochód państwa rodziny (w dolarach "
 "amerykańskich)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Około ile książek dla dzieci jest obecnych w państwa domu?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Czy jest coś więcej, o czym Państwo chcieliby nas poinformować?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Skąd się Państwo dowiedzieli o Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Jeśli odpowiedź różni się w zależności od ustaleń dotyczących wspólnej "
-"opieki nad dzieckiem lub podróży, proszę podać liczbę rodziców/opiekunów, z "
-"którymi zazwyczaj mieszkają państwa dzieci lub wyjaśnić."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Urodziny"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Inna rasa lub pochodzenie etniczne"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -152,40 +156,43 @@ msgstr ""
 "badaniach. Nigdy nie publikujemy dat urodzin dzieci ani informacji, które "
 "pozwoliłyby czytelnikowi na obliczenie daty urodzenia."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Urodziny nie mogą być w przyszłości."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Imię"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Urodziny"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Płeć"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Wiek ciążowy przy porodzie"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Wszelkie dodatkowe informacje, które chcieliby Państwo nam przekazać"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Charakterystyka i warunki"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
 msgstr ""
 "Języki, z którymi dziecko ma kontakt w domu, w szkole lub u innego opiekuna."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -198,504 +205,612 @@ msgstr ""
 "\"), ale nigdy nie opublikujemy imienia, ani nie użyjemy go w naszych "
 "badaniach."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Na przykład zdiagnozowane zaburzenia rozwojowe lub problemy ze wzrokiem lub "
 "słuchem"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr ""
 "Proszę zaokrąglić w dół do najbliższego, ukończonego, pełnego tygodnia ciąży"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Badania"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Aktualne badania"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Twoje zeszłe badania"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Aktualne badania"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Nie jestem pewien/pewna lub wolę nie odpowiadać"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Poniżej 24 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 tygodnie"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 tygodnie"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 tygodnie"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 tygodnie"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 tygodni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 lub więcej tygodni"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Możliwość podglądu organizacji"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Możliwość edycji organizacji"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Możliwość stworzenia organizacji"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Możliwość usunięcia organizacji"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Możliwość podglądu badacza/badaczki"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Możliwość podglądu analizy"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Możliwość utworzenia użytkownika"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Możliwość podglądu użytkownika"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Możliwość edycji użytkownika"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Możliwość usunięcia użytkownika"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Możliwość podglądu uprawnień użytkowników"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Możliwość edycji uprawnień użytkowników"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Możliwość podglądu wszystkich danych użytkownika"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Możliwość podglądu nazw użytkowników"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "męska"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "żeńska"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "inny/inna"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "wolę nie odpowiadać"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Możliwość podglądu organizacji"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Możliwość edycji organizacji"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Możliwość stworzenia organizacji"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Możliwość usunięcia organizacji"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Możliwość podglądu badacza/badaczki"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Możliwość podglądu analizy"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Możliwość utworzenia użytkownika"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Możliwość podglądu użytkownika"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Możliwość edycji użytkownika"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Możliwość usunięcia użytkownika"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Możliwość podglądu uprawnień użytkowników"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Możliwość edycji uprawnień użytkowników"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Możliwość podglądu wszystkich danych użytkownika"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Możliwość podglądu nazw użytkowników"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Biała"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Hiszpańskie, latynoskie lub hiszpańskie pochodzenie"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Czarna lub afroamerykańska"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Azjatycka"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Rdzenny/a Amerykanin/ka lub Alaskanin/ka"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Bliski Wschód lub Afryka Północna"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Rdzenny/a Hawajczyk/Hawajka lub inny wyspiarz/wyspiarka z Pacyfiku"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Inna rasa lub pochodzenie etniczne"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "niektóre lub uczęszczanie do szkoły średniej"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "świadectwo ukończenia szkoły średniej lub zawodowej"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "niektóre lub uczęszczanie na uniwersytet"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "3-letnie wykształcenie wyższe (np. licencjat)"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "5-letnie wykształcenie wyższe (np. magisterium)"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "niektóre lub uczęszczanie do szkoły wyższej lub zawodowej"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "absolwent lub stopień zawodowy"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "nie dotyczy - brak współmałżonka/i lub partnera/partnerki"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Więcej niż 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "poniżej 18 roku życia"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 lub więcej"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 lub więcej"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "różnie"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "ponad 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "miejski"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "podmiejski"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "wiejski"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Wybierz województwo"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Informacje o koncie"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Ankieta demograficzna"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Opowiedz nam więcej o sobie."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informacje o dzieciach"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Dodaj lub edytuj informacje uczestnika/uczestniczki."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Preferencje dotyczące e-maili"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Edytuj, kiedy można się z państwem skontaktować."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Moje konto"
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr "Aktualizacja informacji o koncie"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Zapisz"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Zmień swoje hasło"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Wszyscy uczestnicy"
 
@@ -703,76 +818,83 @@ msgstr "Wszyscy uczestnicy"
 msgid "Participant ID"
 msgstr "Identyfikator uczestnika"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Ostatnio aktywny/a:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "Globalny identyfikator uczestnika:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Dzieci"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Wiek"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Dodatkowe informacje"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Nie zarejestrowano żadnych profili dzieci!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Najnowsze dane demograficzne"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Państwo"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Województwo"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Opis okolicy"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Języki używane w domu"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Liczba dzieci"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Obecny wiek dzieci"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Odpowiedzi na badanie"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Liczba opiekunów"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Wyjaśnienie dla opiekunów:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Rasa/pochodzenie etniczne"
 
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Pulpit"
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
 
-#: project/settings.py:243 studies/fields.py:97
-#, fuzzy
-#| msgid "Asian"
-msgid "Russian"
-msgstr "Azjatycka"
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
 
 #: studies/fields.py:45
 msgid "Twin"
@@ -802,35 +924,269 @@ msgstr "Siedmioraczek"
 msgid "Octuplet"
 msgstr "Ośmioraczek"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
 #: studies/fields.py:69
 #, fuzzy
 #| msgid "Duration"
 msgid "Gujarati"
 msgstr "Czas trwania"
 
-#: studies/fields.py:115
-#, fuzzy
-#| msgid "Yes"
-msgid "Yue"
-msgstr "Tak"
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+#, fuzzy
+#| msgid "Duration"
+msgid "Marathi"
+msgstr "Czas trwania"
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+#, fuzzy
+#| msgid "Asian"
+msgid "Russian"
+msgstr "Azjatycka"
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Nie udzielono odpowiedzi"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Inne"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Męska"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Żeńska"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -839,155 +1195,68 @@ msgstr ""
 "laboratorium będzie mógł tworzyć badania związane z tym laboratorium i może "
 "być dodawany do badań tego laboratorium."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Użytkownicy, którzy zgłosili chęć przystąpienia do tego laboratorium."
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-#, fuzzy
-#| msgid "researcher login"
-msgid "For researchers"
-msgstr "login badacza"
-
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-#, fuzzy
-#| msgid "Contact:"
-msgid "Contact us"
-msgstr "Kontakt:"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Weź udział w projekcie"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Zaloguj się, aby wziąć udział"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Zaloguj się, aby wziąć udział"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Jaka jest państwa płeć?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Czas trwania"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "W tej chwili nie prowadzimy żadnych badań!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Weź udział w projekcie"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Oświadczenie o ochronie prywatności"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Wszyscy uczestnicy"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Dodatkowe informacje"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Udało ci się wylogować."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-#, fuzzy
-#| msgid "Your username and password didn't match. Please try again."
-msgid "Your login credentials didn't work. Please try again."
-msgstr ""
-"Twoja nazwa użytkownika i hasło nie zgadzają się. Proszę spróbować jeszcze "
-"raz."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Login"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Zapomniałeś/zapomniałaś hasła?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Pierwszy raz w Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Hasło zmienione"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Twoje hasło zostało zmienione."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Dokumentacja"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Zmiana hasła"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Wyloguj się"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Strona główna"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Zmiana hasła"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Prosimy o poprawienie poniższego błędu."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Proszę poprawić poniższe błędy."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -996,28 +1265,28 @@ msgstr ""
 "dwukrotnie wprowadzić nowe hasło, abyśmy mogli zweryfikować, czy zostało "
 "wpisane poprawnie."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Zmień moje hasło"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Reset hasła zakończony"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Twoje hasło zostało ustawione.  Możesz się teraz zalogować."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 msgid "Log in"
 msgstr "Zaloguj się"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Reset hasła zakończony"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Twoje hasło zostało ustawione.  Możesz się teraz zalogować."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Potwierdzenie zresetowania hasła"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1025,15 +1294,7 @@ msgstr ""
 "Prosimy o dwukrotne wprowadzenie nowego hasła, abyśmy mogli zweryfikować, "
 "czy zostało ono wpisane poprawnie."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nowe hasło:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Potwierdź hasło:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1041,13 +1302,13 @@ msgstr ""
 "Link do zresetowania hasła był nieprawidłowy, prawdopodobnie dlatego, że "
 "został już raz użyty.  Proszę poprosić o nowy link do zresetowania hasła."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset link sent"
 msgstr "Reset hasła zakończony"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 #, fuzzy
 #| msgid ""
 #| "We've emailed you instructions for setting your password, if an account "
@@ -1059,7 +1320,7 @@ msgstr ""
 "Wysłaliśmy do Ciebie instrukcje dotyczące ustawienia hasła, jeśli konto "
 "istnieje na podany adres e-mail. Powinni Państwo niedługo je otrzymać."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 #, fuzzy
 #| msgid ""
 #| "If you don't receive an email, please make sure you've entered the "
@@ -1072,11 +1333,14 @@ msgstr ""
 "Jeśli nie otrzymali Państwo e-maila, należy upewnić się, że podany jest "
 "adres na który dokonali Państwo rejestracji, i sprawdzić folder ze spamem."
 
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Otrzymują Państwo ten e-mail, ponieważ poprosili Państwo o zresetowanie "
 "hasła dla swojego konta użytkownika w %(site_name)s."
@@ -1089,23 +1353,25 @@ msgstr "Proszę przejść do następnej strony i wybrać nowe hasło:"
 msgid "Your username, in case you've forgotten:"
 msgstr "Państwa nazwa użytkownika, na wypadek w którym Państwo zapomnieli:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Dziękujemy za skorzystanie z naszej strony!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "Grupa %(site_name)"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Zresetuj moje hasło"
+
+#: web/templates/registration/password_reset_form.html:8
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset"
 msgstr "Reset hasła zakończony"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1113,129 +1379,257 @@ msgstr ""
 "Zapomnieli Państwo swojego hasła? Proszę wpisać poniżej swój adres e-mail, a "
 "my wyślemy instrukcje dotyczące ustawienia nowego hasła."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Adres e-mail:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset complete"
+msgid "Password reset on Children Helping Science"
+msgstr "Reset hasła zakończony"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Zresetuj moje hasło"
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Badacz(ka)"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Badania"
+#: web/templates/web/_footer.html:17
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact us"
+msgstr "Kontakt:"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "FAQ"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Badacze"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Zasoby"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Dzień dobry"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Wyloguj się"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "Zarejestruj się"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Badacz(ka)"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Dzieci"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Dodaj dziecko"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Dziecko"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 #| msgid "Back to list"
 msgid "Back to Children List"
 msgstr "Powrót do listy"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Aktualizuj"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Usuń"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Anuluj"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Zapisz"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Puste pole: urodziny"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Aktualizuj"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " dzień"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " dni"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " miesiąc"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " miesiące"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " rok"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " lata"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Dodaj dziecko"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Ukryj formularz"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nazwa"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Aktualizacja danych dziecka"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nazwa"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Nie zarejestrowano żadnych profili dziecięcych!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+#, fuzzy
+#| msgid "researcher login"
+msgid "For researchers"
+msgstr "login badacza"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Dokumentacja"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Aktualizuj dane demograficzne"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1249,7 +1643,7 @@ msgstr ""
 "docieramy, a także jak czynniki takie jak mówienie wieloma językami czy "
 "posiadanie starszego rodzeństwa wpływają na naukę dzieci."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1259,129 +1653,1555 @@ msgstr ""
 "celach naukowych lub w promocji naszych badań, Państwa dane demograficzne "
 "nigdy nie są publikowane w połączeniu z materiałem wideo."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Weź udział w projekcie"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Twoje zeszłe badania"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "W tej chwili nie prowadzimy żadnych badań!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Zaloguj się, aby wziąć udział"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Jaka jest państwa płeć?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Czas trwania"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "W jakim województwie Państwo mieszkają?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "researcher login"
+msgid "For Researchers"
+msgstr "login badacza"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Jaki jest państwa wiek?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Zaloguj się, aby wziąć udział"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Badacze"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Weź udział w projekcie"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Strona główna"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Chciałbym/chciałabym, żeby skontaktowano się ze mną kiedy:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Zaloguj się, aby wziąć udział"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Utwórz konto"
+
+#: web/templates/web/participant-signup.html:13
 #, fuzzy
 #| msgid "Participant account"
 msgid "Create Participant Account"
 msgstr "Konto uczestnika/uczestniczki"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead?"
+msgid "instead."
+msgstr "Zamiast tego?"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr ""
 "Klikając w \"Utwórz konto\", zgadzam się, że przeczytałem/am i "
 "zaakceptowałem/am"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Oświadczenie o ochronie prywatności"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Utwórz konto"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Oświadczenie o ochronie prywatności"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Wszyscy uczestnicy"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Dodatkowe informacje"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Zeszłe badania"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
 msgstr ""
-"Twoje konto nie ma dostępu do tej strony. Aby przejść dalej, proszę zaloguj "
-"się na konto, które ma dostęp."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Proszę się zalogować, aby zobaczyć tę stronę."
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Aktualne badania"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Twoje zeszłe badania"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Tutaj mogą Państwo obejrzeć swoje badania i zobaczyć komentarze pozostawione "
 "przez badaczy i badaczki:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Miniaturka badania"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Kwalifikacja:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Kontakt:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Nadal zbierasz dane?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Tak"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Nie"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Rekompensata: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Rekompensata"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Odpowiedzi na badanie"
 
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Data"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Status zgody"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Zatwierdzone"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Państwa film ze zgodą został pozytywnie zweryfikowany przez badacza/badaczkę."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "W toku"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr ""
 "Twoje nagranie wideo za zgodą nie zostało jeszcze przejrzane przez badacza."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Nieważne"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1392,157 +3212,182 @@ msgstr ""
 "zgodzie. Pozostałe Państwa dane z tej sesji nie będą oglądane ani "
 "wykorzystywane przez badaczy lub badaczki."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr "Brak informacji o statusie weryfikacji wideo za zgodą."
 
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Nie brali Państwo jeszcze udziału w żadnych badaniach."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Bieżące badania"
-
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
-msgstr ""
-"Pamiętaj, że do udziału w badaniu potrzebny jest laptop lub komputer "
-"stacjonarny (nie urządzenie przenośne) z systemem Chrome lub Firefox."
-
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Zobacz szczegóły"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "W tej chwili nie prowadzimy żadnych badań!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
-msgstr ""
-"Szukasz więcej sposobów, aby pomóc w badaniach z domu? Odwiedź <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> po jeszcze więcej badań!"
-
-#: web/templates/web/study-detail.html:53
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-#| msgid " days"
-msgid "days"
-msgstr " dni"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Nie brali Państwo jeszcze udziału w żadnych badaniach."
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Przegląd badań"
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Badania"
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Powrót do listy"
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Kryteria kwalifikujące"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
 
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Czas trwania"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Rekompensata"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Co się dzieje?"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Zasoby"
 
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Co badamy?"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "To badanie jest przeprowadzane przez:"
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
 
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Czy chcieliby Państwo wziąć udział w tym badaniu?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Zaloguj się, aby wziąć udział"
-
-#: web/templates/web/study-detail.html:142
-#, fuzzy
-#| msgid "No child profiles registered!"
-msgid "Add child profile to "
-msgstr "Nie zarejestrowano żadnych profili dziecięcych!"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 #, fuzzy
 #| msgid "Participate"
 msgid "participate"
 msgstr "Weź udział w projekcie"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Utwórz przeprowadzacz eksperymentu do podglądu"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Zaloguj się, aby wziąć udział"
+
+#: web/templates/web/study-detail.html:22
+#, fuzzy
+#| msgid "No child profiles registered!"
+msgid "Add child profile to "
+msgstr "Nie zarejestrowano żadnych profili dziecięcych!"
+
+#: web/templates/web/study-detail.html:23
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Complete demographic survey to "
 msgstr "Ankieta demograficzna"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Weź udział w projekcie"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Co się dzieje?"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Co badamy?"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Czas trwania"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "To badanie jest przeprowadzane przez:"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Czy chcieliby Państwo wziąć udział w tym badaniu?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Wybierz dziecko:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Brak wybranych"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Państwa dziecko jest młodsze niż zalecany przedział wiekowy dla tego "
 "badania. Jeśli mogą Państwo poczekać <span id='wait-until'>aż</span> Państwa "
 "dziecko jest w odpowiednim wieku, będziemy mogli wykorzystać zebrane dane w "
 "naszych badaniach!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Państwa dziecko jest starsze niż zalecany przedział wiekowy dla tego "
 "badania. Zapraszamy do wypróbowania badania, ale nie będziemy w stanie "
 "wykorzystać zebranych danych w naszych badaniach."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Twoje dziecko nie spełnia kryteriów kwalifikacyjnych do tego badania. "
 "Zapraszamy do wypróbowania badania, ale nie będziemy w stanie wykorzystać "
 "zebranych danych. Prosimy o kontakt z badaczami badania"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Utwórz przeprowadzacz eksperymentu do podglądu"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Weź udział w projekcie"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1550,34 +3395,270 @@ msgstr ""
 "Aby łatwo zobaczyć, co się dzieje podczas aktualizacji protokołu badania, "
 "dodaj do zakładki adres URL na który wysyła Cię powyższy przycisk."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Zarejestruj się"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Pamiętaj, że do udziału w badaniu potrzebny jest laptop lub komputer "
+"stacjonarny (nie urządzenie przenośne) z systemem Chrome lub Firefox."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 #, fuzzy
 #| msgid "Participant account"
 msgid "Participant created."
 msgstr "Konto uczestnika/uczestniczki"
 
-#: web/views.py:88
+#: web/views.py:157
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Demographic data saved."
 msgstr "Ankieta demograficzna"
 
-#: web/views.py:156
+#: web/views.py:223
 #, fuzzy
 #| msgid "Children"
 msgid "Child added."
 msgstr "Dzieci"
 
-#: web/views.py:217
+#: web/views.py:264
+#, fuzzy
+#| msgid "Children"
+msgid "Child deleted."
+msgstr "Dzieci"
+
+#: web/views.py:266
+#, fuzzy
+#| msgid "Children"
+msgid "Child updated."
+msgstr "Dzieci"
+
+#: web/views.py:294
 #, fuzzy
 #| msgid "Email Preferences"
 msgid "Email preferences saved."
 msgstr "Preferencje dotyczące e-maili"
 
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr ""
+#~ "Z którą (lub z którymi) z tych kategorii utożsamia się państwa rodzina?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr ""
+#~ "Tylko odpowiedzi wyrażone w liczbach - można mniej więcej oszacować. "
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Jakim językiem (językami) posługuje się państwa rodzina w domu?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr ""
+#~ "Jaki jest najwyższy poziom wykształcenia, które ukończył/a państwa "
+#~ "współmałżonek/współmałżonka?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Około ile książek dla dzieci jest obecnych w państwa domu?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Jeśli odpowiedź różni się w zależności od ustaleń dotyczących wspólnej "
+#~ "opieki nad dzieckiem lub podróży, proszę podać liczbę rodziców/opiekunów, "
+#~ "z którymi zazwyczaj mieszkają państwa dzieci lub wyjaśnić."
+
+#~ msgid "other"
+#~ msgstr "inny/inna"
+
+#~ msgid "3 or more"
+#~ msgstr "3 lub więcej"
+
+#~ msgid "varies"
+#~ msgstr "różnie"
+
+#~ msgid "My Account"
+#~ msgstr "Moje konto"
+
+#~ msgid "Last Active:"
+#~ msgstr "Ostatnio aktywny/a:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "Globalny identyfikator uczestnika:"
+
+#~ msgid "Dashboard"
+#~ msgstr "Pulpit"
+
 #, fuzzy
-#~| msgid "instead?"
-#~ msgid "instead"
-#~ msgstr "Zamiast tego?"
+#~| msgid "Yes"
+#~ msgid "Yue"
+#~ msgstr "Tak"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Zaloguj się, aby wziąć udział"
+
+#, fuzzy
+#~| msgid "Your username and password didn't match. Please try again."
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr ""
+#~ "Twoja nazwa użytkownika i hasło nie zgadzają się. Proszę spróbować "
+#~ "jeszcze raz."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Pierwszy raz w Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nowe hasło:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Potwierdź hasło:"
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "Grupa %(site_name)"
+
+#~ msgid "Email address:"
+#~ msgstr "Adres e-mail:"
+
+#~ msgid "FAQ"
+#~ msgstr "FAQ"
+
+#~ msgid "Hi"
+#~ msgstr "Dzień dobry"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Puste pole: urodziny"
+
+#~ msgid " day"
+#~ msgstr " dzień"
+
+#~ msgid " days"
+#~ msgstr " dni"
+
+#~ msgid " month"
+#~ msgstr " miesiąc"
+
+#~ msgid " months"
+#~ msgstr " miesiące"
+
+#~ msgid " year"
+#~ msgstr " rok"
+
+#~ msgid " years"
+#~ msgstr " lata"
+
+#~ msgid "Hide Form"
+#~ msgstr "Ukryj formularz"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Twoje konto nie ma dostępu do tej strony. Aby przejść dalej, proszę "
+#~ "zaloguj się na konto, które ma dostęp."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Proszę się zalogować, aby zobaczyć tę stronę."
+
+#~ msgid "Compensation: "
+#~ msgstr "Rekompensata: "
+
+#~ msgid "Current Studies"
+#~ msgstr "Bieżące badania"
+
+#~ msgid "See details"
+#~ msgstr "Zobacz szczegóły"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "W tej chwili nie prowadzimy żadnych badań!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Szukasz więcej sposobów, aby pomóc w badaniach z domu? Odwiedź <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> po jeszcze "
+#~ "więcej badań!"
+
+#, fuzzy
+#~| msgid " days"
+#~ msgid "days"
+#~ msgstr " dni"
+
+#~ msgid "Study overview"
+#~ msgstr "Przegląd badań"
+
+#~ msgid "Back to list"
+#~ msgstr "Powrót do listy"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Kryteria kwalifikujące"
 
 #, fuzzy
 #~| msgid "Birthday"
@@ -1662,6 +3743,3 @@ msgstr "Preferencje dotyczące e-maili"
 
 #~ msgid "Signup"
 #~ msgstr "Zapisy"
-
-#~ msgid "Update account information"
-#~ msgstr "Aktualizacja informacji o koncie"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -3321,10 +3321,8 @@ msgstr "Czas trwania"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "To badanie jest przeprowadzane przez:"
+msgstr "To badanie jest przeprowadzane przez %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -3323,10 +3323,8 @@ msgstr "Duração"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Este estudo é realizado por"
+msgstr "Este estudo é realizado por %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: pt-br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr "Insira a senha de uso único de 6 dígitos do Google Authenticator "
 
@@ -35,43 +35,24 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "A conta está inativa."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr ""
-"Sua senha não pode ser tão semelhante às suas outras informações pessoais."
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "A sua senha deve conter no mínimo 16 caracteres."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "A sua senha não pode ser comumente utilizada."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "A sua senha não pode conter apenas números."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Endereço de e-mail"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Apelido"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "É hora de outra sessão de um estudo em que estamos participando"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Um novo estudo está disponível para um dos meus filhos"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -79,7 +60,7 @@ msgstr ""
 "Há uma atualização sobre um estudo em que participamos (por exemplo, os "
 "resultados foram publicados)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -87,101 +68,93 @@ msgstr ""
 "Um pesquisador tem perguntas sobre minhas respostas (por exemplo, se eu "
 "relatei um problema técnico durante o estudo)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "Com quais categoria(s) sua família se identifica?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "País"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Digite separando com vírgulas: AAAA-MM-DD, AAAA-MM-DD, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Apenas respostas numéricas - pode chutar!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "Em qual país você mora?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "Em qual estado você mora?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Como você descreveria a área onde você mora?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Qual(is) idioma(s) sua família fala em casa?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Quantos filhos você tem?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Digite a data de nascimento de cada criança/filho(a):"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Seus filhos moram com quantos pais ou maiores responsáveis?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Qual é a sua idade?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Qual é o seu sexo?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Qual é o seu sexo?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Qual é o seu nível mais alto de educação?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Qual é o nível mais alto de educação do seu cônjuge?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr ""
 "Qual é a renda anual aproximada da sua família (em dólares americanos)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Aproximadamente quantos livros infantis você tem em sua casa?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Mais alguma coisa que você gostaria que soubéssemos?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Como você ficou sabendo sobre o Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Se a resposta variar devido a acordos de custódia / guarda compartilhada ou "
-"viagem, digite o número de pais / responsáveis com os quais seus filhos(as) "
-"geralmente moram ou explique a situação."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Data de nascimento"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Outra raça, etnia, ou origem"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -191,33 +164,36 @@ msgstr ""
 "momento em que ele/ela participa de um estudo. Nós NUNCA publicamos datas de "
 "nascimento ou informações que permitam o calculo data de nascimento."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Aniversários não podem acontecer no futuro."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Primeiro nome"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Data de nascimento"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Gênero"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Idade gestacional no nascimento"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Qualquer informação adicional que você gostaria que soubéssemos"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Características e condições"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -225,7 +201,7 @@ msgstr ""
 "Idiomas aos quais essa criança é exposta em casa, na escola, ou com outro "
 "cuidador / responsável."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -238,511 +214,598 @@ msgstr ""
 "(por exemplo, \"Há um novo estudo disponível para Maria!\"), Mas NUNCA "
 "publicaremos nomes ou os usaremos em nossa pesquisa."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Por exemplo, diagnósticos de distúrbios do desenvolvimento ou problemas de "
 "visão ou audição"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Arredonde para a ultima semana completa de gestação"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Estudos"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Estudos atuais"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Seus estudos anteriores"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Estudos atuais"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Não tenho certeza ou prefiro não responder"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Menos de 24 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 semanas ou mais"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Pode exibir a organização"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Pode editar a organização"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Pode criar organização"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Pode remover a organização"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Pode visualizar o Pesquisador"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Pode visualizar as Estatísticas"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Pode criar um usuário"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Pode Ver o Usuário"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Pode editar o usuário"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Pode remover o usuário"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Pode visualizar as permissões do usuário"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Pode editar as permissões do usuário"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Pode ler todos os dados do usuário"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Pode ler nomes de usuário"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "masculino"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "feminino"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "outro"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "Prefiro não responder"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Pode exibir a organização"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Pode editar a organização"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Pode criar organização"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Pode remover a organização"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Pode visualizar o Pesquisador"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Pode visualizar as Estatísticas"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Pode criar um usuário"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Pode Ver o Usuário"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Pode editar o usuário"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Pode remover o usuário"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Pode visualizar as permissões do usuário"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Pode editar as permissões do usuário"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Pode ler todos os dados do usuário"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Pode ler nomes de usuário"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Branco"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Origem hispânica, latina, ou espanhola"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Afro-descendente"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asiático"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Índio americano ou nativo do Alasca"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Oriente Médio ou Norte da África"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Nativo do Havaí ou de outras ilhas do Pacífico"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Outra raça, etnia, ou origem"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "ensino fundamental completo ou ensino médio em andamento"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "ensino médio completo ou supletivo completo"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "ensino superior em andamento"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "ensino superior completo (3 ou 4 anos de curso)"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "ensino superior completo (5 anos de curso)"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "pós-graduação em andamento"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "ensino técnico completo"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "não aplicável - sem cônjuge ou companheiro"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Mais do que 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "menores de 18 anos"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 anos ou mais"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 ou mais"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "varia"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "500000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "1000000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "1500000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "2000000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "3000000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "4000000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "5000000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "mais de 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "urbana"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "suburbana"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "rural"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Selecione um Estado"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "Gan"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Informação da conta"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "Redefina as suas credenciais de login e/ou apelido."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Pesquisa Demográfica"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Conte-nos mais sobre você."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informações sobre as crianças"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Adicione ou edite as informações do participante."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Preferências de Email"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Edite suas preferências de notificações."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Minha conta"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Informação da conta"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Salvar"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Redefinir senha"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "Gerenciar autenticação de dois fatores"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -751,11 +814,18 @@ msgstr ""
 "inserir sua senha de uso único, clicar em enviar e ela será excluída para "
 "você!"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "Configurar autenticação de dois fatores"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Todos os participantes"
 
@@ -763,128 +833,63 @@ msgstr "Todos os participantes"
 msgid "Participant ID"
 msgstr "ID do participante"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Ativo pela última vez:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "ID global do participante:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Crianças"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Idade"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Informação adicional"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Nenhum perfil de participante/criança registrado!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Dados demográficos mais recentes"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "País"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Estado"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Descrição da área"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Idiomas falados em casa"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Número de Filhos"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Idade atual dos filhos"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Respostas do Estudo"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Número de guardiões legais"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Explicação para os guardiões legais:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Raça"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "painel de controle"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "alemão"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "Inglês"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "espanhol"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "francês"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "italiano"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "japonês"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "Coreano"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "Polonês"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "Português"
-
-#: project/settings.py:241
-#, fuzzy
-#| msgid "Portuguese"
-msgid "Brazilian Portuguese"
-msgstr "Português"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "Romeno"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "Russo"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "Turco"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "holandês"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -934,6 +939,10 @@ msgstr "Sétuplo"
 msgid "Octuplet"
 msgstr "Óctuplo"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "Inglês"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "Amárico"
@@ -958,13 +967,25 @@ msgstr "Cebuano"
 msgid "Chhattisgarhi"
 msgstr "Chhattisgarhi"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "holandês"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "Árabe egípcio falado"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "francês"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "Gan"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "alemão"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -979,162 +1000,204 @@ msgid "Hausa"
 msgstr "Hausa"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "hindi"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "Igbo"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "indonésio"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "Persa iraniano"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "italiano"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "japonês"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "Javanês"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "Jinyu"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "Canarim"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "Khmer"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "Coreano"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "Magahi"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "Maithili"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "Malaio"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "Malayalam"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "Mandarim"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "Marati"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "Min Nan"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "Árabe Marroquino Falado"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "Pashto do norte"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "Uzbeque do Norte"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "Odia"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "Polonês"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "Português"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "Romeno"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "Russo"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "Saraiki"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "Sindi"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "Somali"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "espanhol"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "Sunda"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "Tagalo"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "tâmil"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "Telugu"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "tailandês"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "Turco"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "urdu"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "vietnamita"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "Punjabi Ocidental"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "Wu"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "Chinês xiang"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "Ioruba"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "Yue"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Não respondido"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Outro(s)"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Masculino"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Feminino"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -1143,217 +1206,68 @@ msgstr ""
 "poderá criar estudos associados a este laboratório e poderá ser adicionado "
 "aos estudos deste laboratório."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Os usuários que solicitaram ingressar neste laboratório."
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:53
-msgid ""
-"This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
-"findings, and conclusions or recommendations expressed in this material are "
-"those of the authors(s) and do not necessarily reflect the views of the "
-"National Science Foundation."
-msgstr ""
-"Este material é baseado no trabalho apoiado pela National Science Foundation "
-"(NSF) pelo financiamento número 1429216 e 1823919; o pelo Center for Brains, "
-"Minds and Machines (CBMM), financiamento número NSF STC CCF-1231216, e por "
-"uma bolsa de pesquisa de pós-graduação da NSF sob o subsídio nº 1122374. "
-"Qualquer opinião, descobertas e conclusões ou recomendações expressas neste "
-"material são aquelas dos autores e não refletem necessariamente as opiniões "
-"da National Science Foundation."
-
-#: web/templates/frontpages/default.html:60 web/templates/frontpages/home.html:48
-msgid "Privacy"
-msgstr "Privacidade"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-msgid "Contact us"
-msgstr "Entre em contato"
-
-#: web/templates/frontpages/default.html:63
-msgid "Connect"
-msgstr "Conecte-se"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Participar"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Faça login para participar"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Faça login para participar"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Qual é o seu sexo?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Duração"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "No momento, não estamos realizando estudos!"
-
-#: web/templates/frontpages/home.html:11
-msgid "the online child lab"
-msgstr "O laboratório online para crianças"
-
-#: web/templates/frontpages/home.html:12
-msgid "A project of the MIT Early Childhood Cognition Lab"
-msgstr "Um projeto do Laboratório de Cognição Infantil do MIT"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Participar"
-
-#: web/templates/frontpages/home.html:22
-msgid "Bringing science home"
-msgstr "Trazendo ciência aos lares"
-
-#: web/templates/frontpages/home.html:23
-msgid ""
-"Here at MIT's Early Childhood Cognition Lab, we're trying a new approach in "
-"developmental psychology: bringing the experiments to you."
-msgstr ""
-"Aqui no Laboratório de Cognição Infantil do MIT, nós estamos testando uma "
-"nova abordagem em psicologia do desenvolvimento: trazer os experimentos até "
-"você."
-
-#: web/templates/frontpages/home.html:29
-msgid "Help us understand how your child thinks"
-msgstr "Ajude-nos a entender como a sua criança pensa"
-
-#: web/templates/frontpages/home.html:30
-msgid ""
-"Your family can contribute to research about how children learn by doing fun "
-"activities together, right in your web browser."
-msgstr ""
-"Sua família pode contribuir para pesquisas sobre como crianças aprendem "
-"fazendo atividades divertidas juntos, no seu navegador de internet"
-
-#: web/templates/frontpages/home.html:36
-msgid "Participate whenever and wherever"
-msgstr "Participe a qualquer momento, de qualquer lugar"
-
-#: web/templates/frontpages/home.html:37
-msgid ""
-"Log in or create an account at the top right to get started! You can "
-"participate with your child from any computer with a webcam."
-msgstr ""
-"Faça o login ou crie uma conta no topo direito para começar! Você pode "
-"participar com sua criança de qualquer computador com webcam."
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Declaração de privacidade"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Todos os participantes"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Informação adicional"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Você efetuou logout com sucesso."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr "Suas credenciais são inválidas. Por favor, tente novamente."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Login"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Esqueceu a senha?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Novo no Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/login.html:36
+#: web/templates/registration/login.html:28
 msgid "Register your family!"
 msgstr "Registre a sua família!"
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Senha alterada"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Sua senha foi alterada."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Documentação"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Mudar senha"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Sair"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Tela Inicial"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Mudança de senha"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Corrija o erro abaixo."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Por favor corrija os erros abaixo."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -1362,28 +1276,28 @@ msgstr ""
 "nova senha duas vezes para que possamos verificar se você a digitou "
 "corretamente."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Mudar minha senha"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Redefinição de senha concluída"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Sua senha foi definida. Você pode ir em frente e entrar."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 msgid "Log in"
 msgstr "Log in"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Redefinição de senha concluída"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Sua senha foi definida. Você pode ir em frente e entrar."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Confirmação de redefinição de senha"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1391,15 +1305,7 @@ msgstr ""
 "Digite sua nova senha duas vezes para que possamos verificar se você a "
 "digitou corretamente."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nova senha:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Confirme a Senha:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1407,11 +1313,11 @@ msgstr ""
 "O link de redefinição de senha era inválido, possivelmente porque já foi "
 "usado. Solicite uma nova redefinição de senha."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 msgid "Password reset link sent"
 msgstr "Link para redefinição de senha enviado."
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 msgid ""
 "If an account exists with the email you entered, we've emailed instructions "
 "for resetting your password and you should receive them shortly."
@@ -1419,7 +1325,7 @@ msgstr ""
 "Se houver uma conta com o e-mail que você inseriu, enviamos instruções para "
 "redefinir sua senha e você deve recebê-las em breve."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 msgid ""
 "If you don't receive an email, please check your spam folder and make sure "
 "you've entered the address you registered with. (You won't get an email "
@@ -1429,14 +1335,14 @@ msgstr ""
 "de inserir o endereço com o qual se registrou. (Você não receberá um e-mail "
 "a menos que já exista uma conta com esse endereço de e-mail!)"
 
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
 #| msgid ""
 #| "You're receiving this email because you requested a password reset for "
 #| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Você recebeu este e-mail porque solicitou uma redefinição de senha para sua "
 "conta de usuário em% (site_name) s."
@@ -1449,21 +1355,23 @@ msgstr "Vá para a seguinte página e escolha uma nova senha:"
 msgid "Your username, in case you've forgotten:"
 msgstr "Seu nome de usuário, caso você tenha esquecido:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Obrigado por usar o nosso site!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "A equipe% (site_name) s"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Redefinir minha senha"
+
+#: web/templates/registration/password_reset_form.html:8
 msgid "Password reset"
 msgstr "Redefinição de senha"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1471,127 +1379,267 @@ msgstr ""
 "Esqueceu sua senha? Digite seu endereço de e-mail abaixo e enviaremos "
 "instruções por e-mail para definir uma nova senha."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Endereço de e-mail:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "Link para redefinição de senha enviado."
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Redefinir minha senha"
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
+"Este material é baseado no trabalho apoiado pela National Science Foundation "
+"(NSF) pelo financiamento número 1429216 e 1823919; o pelo Center for Brains, "
+"Minds and Machines (CBMM), financiamento número NSF STC CCF-1231216, e por "
+"uma bolsa de pesquisa de pós-graduação da NSF sob o subsídio nº 1122374. "
+"Qualquer opinião, descobertas e conclusões ou recomendações expressas neste "
+"material são aquelas dos autores e não refletem necessariamente as opiniões "
+"da National Science Foundation."
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Pesquisador"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr "Privacidade"
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Estudos"
+#: web/templates/web/_footer.html:17
+msgid "Contact us"
+msgstr "Entre em contato"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "Perguntas frequentes"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr "Conecte-se"
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Os cientistas"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Recursos"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Oi"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Sair"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "inscrever-se"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Pesquisador"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
-msgid "Child"
-msgstr "Criança"
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
 
-#: web/templates/web/child-update.html:26
-msgid "Back to Children List"
-msgstr "Retorne à lista de filhos(as)"
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Atualizar"
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
 
-#: web/templates/web/child-update.html:41
-msgid "Delete"
-msgstr "Excluir"
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Crianças"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Aniversário vazio"
-
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " dia"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " dias"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " mês"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " meses"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " ano"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " anos"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
 msgid "Add Child"
 msgstr "Adicionar filho"
 
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Ocultar formulário"
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr "Criança"
 
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nome"
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr "Retorne à lista de filhos(as)"
 
-#: web/templates/web/children-list.html:121
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr "Excluir"
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Salvar"
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Atualizar"
+
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Atualizar filho"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nome"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Nenhuma criança foi registrada!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr ""
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Documentação"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Atualizar dados demográficos"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1605,7 +1653,7 @@ msgstr ""
 "fatores como: falar vários idiomas ou ter irmãos mais velhos influenciam a "
 "aprendizagem das crianças."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1615,133 +1663,1552 @@ msgstr ""
 "com seu vídeo. Isso continua valendo mesmo se você permitir que os vídeos "
 "dos estudos sejam publicados para fins científicos ou de publicidade."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Participar"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Seus estudos anteriores"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "No momento, não estamos realizando estudos!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Faça login para participar"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Qual é o seu sexo?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Duração"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "Em qual estado você mora?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+msgid "For Researchers"
+msgstr ""
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Qual é a sua idade?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Faça login para participar"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Os cientistas"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Participar"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Tela Inicial"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Gostaria de ser contatado quando:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Faça login para participar"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Criar Conta"
+
+#: web/templates/web/participant-signup.html:13
 msgid "Create Participant Account"
 msgstr "Crie uma conta de Participante"
 
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
 msgstr ""
-"Crie uma conta familiar para começar a participar nos estudos do Lookit!"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "Para se registrar como pesquisador, por favor use"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead"
+msgid "instead."
+msgstr "ao invés"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "Ao clicar em \"Criar conta\", concordo que li e aceitei o "
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Declaração de privacidade"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Criar Conta"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Declaração de privacidade"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Todos os participantes"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Informação adicional"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Estudos anteriores"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
+#: web/templates/web/studies-history.html:15
+#, fuzzy
+#| msgid "Video"
+msgid "Next Video"
+msgstr "Vídeo"
+
+#: web/templates/web/studies-history.html:31
 msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
 msgstr ""
-"Sua conta não tem acesso a esta página. Para continuar, faça login com uma "
-"conta que tenha acesso."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Faça o login para ver esta página."
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Estudos atuais"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Seus estudos anteriores"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Aqui você pode ver seus estudos e ver comentários deixados pelos "
 "pesquisadores:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Miniatura do estudo"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Elegibilidade:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contato:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Ainda está coletando dados?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Sim"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Não"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Compensação: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Compensação"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Respostas do Estudo"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "Vídeo"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Data"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Status de consentimento"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Aprovado"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Seu vídeo de consentimento foi analisado por um pesquisador e é válido."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "Pendente"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "Seu vídeo de consentimento ainda não foi analisado por um pesquisador."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Inválido"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1752,176 +3219,177 @@ msgstr ""
 "dados desta sessão não serão visualizados ou utilizados pelos pesquisadores "
 "do estudo."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr ""
 "Nenhuma informação sobre o status de revisão do vídeo de consentimento."
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "Feedback"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "Nenhum"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Você ainda não participou de nenhum estudo."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Estudos atuais"
+#: web/templates/web/studies-history.html:147
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Você ainda não participou de nenhum estudo."
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Estudos"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Você precisará de um laptop ou de um computador de mesa/desktop executando o "
-"Chrome ou Firefox para participar. Não é possível usar um dispositivo móvel "
-"(tablet, iPad, celular)."
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Veja detalhes"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "No momento, não estamos realizando estudos!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"Procurando mais maneiras de contribuir sem sair de casa? Confira <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\"> Crianças ajudando a ciência </a> para ver mais estudos!"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "dias"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " até "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " quando "
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Recursos"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Resumo do estudo"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "De volta à lista"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Critérios de elegibilidade"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Duração"
-
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Compensação"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "O que acontece"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "O que estamos estudando"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Este estudo é realizado por"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Você gostaria de participar deste estudo?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Faça login para participar"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "Adicionar o perfil do seu filho(a) ao "
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "Pré-visualização"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "participar"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "agora "
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Crie um executador para visualizar o experimento"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Faça login para participar"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "Adicionar o perfil do seu filho(a) ao "
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "Complete a pesquisa demográfica para "
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Participar"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "O que acontece"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "O que estamos estudando"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Duração"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Este estudo é realizado por"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Você gostaria de participar deste estudo?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Selecione uma filha(o):"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Nenhum selecionado"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Seu filho ainda é mais novo que a faixa etária recomendada para este estudo. "
 "Se você esperar <span id = 'wait-till'> até que </span> ele tenha idade "
 "suficiente, poderemos usar os dados coletados em nossa pesquisa!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Seu filho é mais velho que a faixa etária recomendada para este estudo. "
 "Fique a vontade para participar do estudo de qualquer maneira, mas não "
 "poderemos usar os dados coletados em nossa pesquisa."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Seu filho não atende aos critérios de elegibilidade listados para este "
 "estudo. Fique a vontade para participar do estudo de qualquer maneira, mas "
 "não poderemos usar os dados coletados em nossa pesquisa. Entre em contato "
 "com os pesquisadores do estudo"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Crie um executador para visualizar o experimento"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Participar"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "agora "
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1929,31 +3397,90 @@ msgstr ""
 "Para uma maneira fácil de ver o que acontece quando você atualiza seu "
 "protocolo de estudo, adicione aos favoritos o URL contido no botão acima."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "inscrever-se"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Você precisará de um laptop ou de um computador de mesa/desktop executando o "
+"Chrome ou Firefox para participar. Não é possível usar um dispositivo móvel "
+"(tablet, iPad, celular)."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "Participante criado com sucesso."
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "Dados demográficos salvos com sucesso."
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "Filho(a) adicionado(a)."
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "Filho(a) deletado(a)."
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "Filho(a) atualizado(a)."
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "Preferências de e-mail salvas com sucesso."
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -1964,14 +3491,228 @@ msgstr ""
 "pausado. Se você acha que isso é um erro, entre em contato com {study."
 "contact_info}"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "Para se registrar como pesquisador, por favor use"
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr ""
+#~ "Sua senha não pode ser tão semelhante às suas outras informações pessoais."
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "A sua senha deve conter no mínimo 16 caracteres."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "A sua senha não pode ser comumente utilizada."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "A sua senha não pode conter apenas números."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "Com quais categoria(s) sua família se identifica?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Apenas respostas numéricas - pode chutar!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Qual(is) idioma(s) sua família fala em casa?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "Qual é o nível mais alto de educação do seu cônjuge?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Aproximadamente quantos livros infantis você tem em sua casa?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Se a resposta variar devido a acordos de custódia / guarda compartilhada "
+#~ "ou viagem, digite o número de pais / responsáveis com os quais seus "
+#~ "filhos(as) geralmente moram ou explique a situação."
+
+#~ msgid "other"
+#~ msgstr "outro"
+
+#~ msgid "3 or more"
+#~ msgstr "3 ou mais"
+
+#~ msgid "varies"
+#~ msgstr "varia"
+
+#~ msgid "My Account"
+#~ msgstr "Minha conta"
+
+#~ msgid "Last Active:"
+#~ msgstr "Ativo pela última vez:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "ID global do participante:"
+
+#~ msgid "Dashboard"
+#~ msgstr "painel de controle"
+
+#, fuzzy
+#~| msgid "Portuguese"
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "Português"
+
+#~ msgid "Yue"
+#~ msgstr "Yue"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Faça login para participar"
+
+#~ msgid "the online child lab"
+#~ msgstr "O laboratório online para crianças"
+
+#~ msgid "A project of the MIT Early Childhood Cognition Lab"
+#~ msgstr "Um projeto do Laboratório de Cognição Infantil do MIT"
+
+#~ msgid "Bringing science home"
+#~ msgstr "Trazendo ciência aos lares"
+
+#~ msgid ""
+#~ "Here at MIT's Early Childhood Cognition Lab, we're trying a new approach "
+#~ "in developmental psychology: bringing the experiments to you."
+#~ msgstr ""
+#~ "Aqui no Laboratório de Cognição Infantil do MIT, nós estamos testando uma "
+#~ "nova abordagem em psicologia do desenvolvimento: trazer os experimentos "
+#~ "até você."
+
+#~ msgid "Help us understand how your child thinks"
+#~ msgstr "Ajude-nos a entender como a sua criança pensa"
+
+#~ msgid ""
+#~ "Your family can contribute to research about how children learn by doing "
+#~ "fun activities together, right in your web browser."
+#~ msgstr ""
+#~ "Sua família pode contribuir para pesquisas sobre como crianças aprendem "
+#~ "fazendo atividades divertidas juntos, no seu navegador de internet"
+
+#~ msgid "Participate whenever and wherever"
+#~ msgstr "Participe a qualquer momento, de qualquer lugar"
+
+#~ msgid ""
+#~ "Log in or create an account at the top right to get started! You can "
+#~ "participate with your child from any computer with a webcam."
+#~ msgstr ""
+#~ "Faça o login ou crie uma conta no topo direito para começar! Você pode "
+#~ "participar com sua criança de qualquer computador com webcam."
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "Suas credenciais são inválidas. Por favor, tente novamente."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Novo no Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nova senha:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Confirme a Senha:"
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "A equipe% (site_name) s"
+
+#~ msgid "Email address:"
+#~ msgstr "Endereço de e-mail:"
+
+#~ msgid "FAQ"
+#~ msgstr "Perguntas frequentes"
+
+#~ msgid "Hi"
+#~ msgstr "Oi"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Aniversário vazio"
+
+#~ msgid " day"
+#~ msgstr " dia"
+
+#~ msgid " days"
+#~ msgstr " dias"
+
+#~ msgid " month"
+#~ msgstr " mês"
+
+#~ msgid " months"
+#~ msgstr " meses"
+
+#~ msgid " year"
+#~ msgstr " ano"
+
+#~ msgid " years"
+#~ msgstr " anos"
+
+#~ msgid "Hide Form"
+#~ msgstr "Ocultar formulário"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr ""
+#~ "Crie uma conta familiar para começar a participar nos estudos do Lookit!"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Sua conta não tem acesso a esta página. Para continuar, faça login com "
+#~ "uma conta que tenha acesso."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Faça o login para ver esta página."
+
+#~ msgid "Compensation: "
+#~ msgstr "Compensação: "
+
+#~ msgid "None"
+#~ msgstr "Nenhum"
+
+#~ msgid "Current Studies"
+#~ msgstr "Estudos atuais"
+
+#~ msgid "See details"
+#~ msgstr "Veja detalhes"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "No momento, não estamos realizando estudos!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Procurando mais maneiras de contribuir sem sair de casa? Confira <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\"> Crianças ajudando a ciência </a> para ver "
+#~ "mais estudos!"
+
+#~ msgid "days"
+#~ msgstr "dias"
+
+#~ msgid " until "
+#~ msgstr " até "
+
+#~ msgid " when "
+#~ msgstr " quando "
+
+#~ msgid "Study overview"
+#~ msgstr "Resumo do estudo"
+
+#~ msgid "Back to list"
+#~ msgstr "De volta à lista"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Critérios de elegibilidade"
 
 #~ msgid "this form"
 #~ msgstr "esse formulário"
-
-#~ msgid "instead"
-#~ msgstr "ao invés"
 
 #~ msgid "News"
 #~ msgstr "Notícias"

--- a/locale/pt_PT/LC_MESSAGES/django.po
+++ b/locale/pt_PT/LC_MESSAGES/django.po
@@ -2,33 +2,48 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Endereço de e-mail"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Apelido"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "É tempo para outra sessão de um estudo em que estamos a participar"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Um novo estudo está disponível para um dos meus filhos"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -36,7 +51,7 @@ msgstr ""
 "Há uma atualização sobre um estudo em que participámos (por exemplo, os "
 "resultados foram publicados)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -44,102 +59,94 @@ msgstr ""
 "Um investigador tem perguntas sobre as minhas respostas (por exemplo, se eu "
 "reportei um problema técnico durante o estudo)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "Com que categoria(s) se identifica a sua família?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "País"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Introduza separando por vírgulas: AAAA-MM-DD, AAAA-MM-DD, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Apenas respostas numéricas - pode ser uma estimativa!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "Em que país mora?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "Em que estado mora?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Como descreveria a área onde mora?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Que língua(s) a sua família fala em casa?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Quantos filhos tem?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Por favor introduza a data de nascimento de cada criança:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Com quantos responsáveis legais vive a criança (por exemplo, pais)?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Qual é a sua idade?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Qual é o seu género?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Qual é o seu género?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Qual é o nível mais alto de educação que completou?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Qual é o nível mais alto de educação que o seu cônjuge completou ?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr ""
 "Aproximadamente, qual é o seu rendimento familiar anual (em dólares "
 "americanos)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Aproximadamente, quantos livros infantis tem em casa?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Há mais alguma coisa que gostaria que soubéssemos?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Como tomou conhecimento sobre o Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Se a resposta variar devido a acordos de custódia / guarda compartilhada ou "
-"viagem, por favor introduza o número de pais / responsáveis legais com os "
-"quais as crianças habitualmente moram ou explique a situação."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Data de nascimento"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Outra raça, etnia, ou origem"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -149,33 +156,36 @@ msgstr ""
 "NUNCA publicamos datas de nascimento ou informações que permitam o calculo "
 "data de nascimento."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Aniversários não podem acontecer no futuro."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Primeiro nome"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Data de nascimento"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Gênero"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Idade gestacional no nascimento"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Alguma informação adicional que gostaria que soubéssemos"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Características e condições"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
@@ -183,7 +193,7 @@ msgstr ""
 "Línguas às quais esta criança está exposta em casa, na escola, ou com outro "
 "cuidador / responsável."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -196,503 +206,613 @@ msgstr ""
 "estudo disponível para a Maria!\"), mas nunca iremos publicar ou usar os "
 "nomes na nossa investigação."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Por exemplo, diagnósticos de transtornos do desenvolvimento ou problemas de "
 "visão ou audição"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Arredonde para a última semana completa de gestação"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Estudos"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Estudos atuais"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Seus estudos anteriores"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Estudos atuais"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Não tenho certeza ou prefiro não responder"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Menos de 24 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 semanas"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 semanas ou mais"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Pode exibir a organização"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Pode editar a organização"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Pode criar organização"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Pode remover a organização"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Pode visualizar o Pesquisador"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Pode visualizar as Estatísticas"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Pode criar um usuário"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Pode Ver o Usuário"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Pode editar o usuário"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Pode remover o usuário"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Pode visualizar as permissões do usuário"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Pode editar as permissões do usuário"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Pode ler todos os dados do usuário"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Pode ler nomes de usuário"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "masculino"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "feminino"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "outro"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "Prefiro não responder"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Pode exibir a organização"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Pode editar a organização"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Pode criar organização"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Pode remover a organização"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Pode visualizar o Pesquisador"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Pode visualizar as Estatísticas"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Pode criar um usuário"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Pode Ver o Usuário"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Pode editar o usuário"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Pode remover o usuário"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Pode visualizar as permissões do usuário"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Pode editar as permissões do usuário"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Pode ler todos os dados do usuário"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Pode ler nomes de usuário"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Branco"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Origem hispânica, latina, ou espanhola"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Afro-descendente"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asiático"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Índio americano ou nativo do Alasca"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Oriente Médio ou Norte da África"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Nativo do Havaí ou de outras ilhas do Pacífico"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Outra raça, etnia, ou origem"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "ensino fundamental completo ou ensino médio em andamento"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "ensino médio completo ou supletivo completo"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "ensino superior em andamento"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "ensino superior completo (3 ou 4 anos de curso)"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "ensino superior completo (5 anos de curso)"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "pós-graduação em andamento"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "ensino técnico completo"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "não aplicável - sem cônjuge ou companheiro"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Mais do que 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "menores de 18 anos"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 anos ou mais"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 ou mais"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "varia"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "500000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "1000000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "1500000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "2000000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "3000000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "4000000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "5000000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "mais de 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "urbana"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "suburbana"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "rural"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Selecione um Estado"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Informação da conta"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Pesquisa Demográfica"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Conte-nos mais sobre você."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informações sobre as crianças"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Adicione ou edite as informações do participante."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Preferências de Email"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Edite suas preferências de notificações."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Minha conta"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Informação da conta"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Salvar"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Redefinir senha"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Todos os participantes"
 
@@ -700,76 +820,83 @@ msgstr "Todos os participantes"
 msgid "Participant ID"
 msgstr "ID do participante"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Ativo pela última vez:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "ID global do participante:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Crianças"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Idade"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Informação adicional"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Nenhum perfil de participante/criança registrado!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Dados demográficos mais recentes"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "País"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Estado"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Descrição da área"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Idiomas falados em casa"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Número de Filhos"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Idade atual dos filhos"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Respostas do Estudo"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Número de guardiões legais"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Explicação para os guardiões legais:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Raça"
 
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "painel de controle"
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
 
-#: project/settings.py:243 studies/fields.py:97
-#, fuzzy
-#| msgid "Asian"
-msgid "Russian"
-msgstr "Asiático"
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
 
 #: studies/fields.py:45
 msgid "Twin"
@@ -799,35 +926,269 @@ msgstr "Sétuplo"
 msgid "Octuplet"
 msgstr "Óctuplo"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
 #: studies/fields.py:69
 #, fuzzy
 #| msgid "Duration"
 msgid "Gujarati"
 msgstr "Duração"
 
-#: studies/fields.py:115
-#, fuzzy
-#| msgid "Yes"
-msgid "Yue"
-msgstr "Sim"
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+#, fuzzy
+#| msgid "Duration"
+msgid "Marathi"
+msgstr "Duração"
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+#, fuzzy
+#| msgid "Asian"
+msgid "Russian"
+msgstr "Asiático"
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Não respondido"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Outro(s)"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Masculino"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Feminino"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -836,138 +1197,68 @@ msgstr ""
 "poderá criar estudos associados a este laboratório e poderá ser adicionado "
 "aos estudos deste laboratório."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Os usuários que solicitaram ingressar neste laboratório."
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-#, fuzzy
-#| msgid "Contact:"
-msgid "Contact us"
-msgstr "Contato:"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Participar"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Faça login para participar"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Faça login para participar"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Qual é o seu género?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Duração"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "No momento, não estamos realizando estudos!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Participar"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Declaração de privacidade"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Todos os participantes"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Informação adicional"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Você efetuou logout com sucesso."
 
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Login"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Esqueceu a senha?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Novo no Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Senha alterada"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Sua senha foi alterada."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Documentação"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Mudar senha"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Sair"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Tela Inicial"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Mudança de senha"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Corrija o erro abaixo."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Por favor corrija os erros abaixo."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -976,28 +1267,28 @@ msgstr ""
 "nova senha duas vezes para que possamos verificar se você a digitou "
 "corretamente."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Mudar minha senha"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Redefinição de senha concluída"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Sua senha foi definida. Você pode ir em frente e entrar."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 msgid "Log in"
 msgstr "Log in"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Redefinição de senha concluída"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Sua senha foi definida. Você pode ir em frente e entrar."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Confirmação de redefinição de senha"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1005,15 +1296,7 @@ msgstr ""
 "Digite sua nova senha duas vezes para que possamos verificar se você a "
 "digitou corretamente."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Nova senha:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Confirme a Senha:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1021,17 +1304,30 @@ msgstr ""
 "O link de redefinição de senha era inválido, possivelmente porque já foi "
 "usado. Solicite uma nova redefinição de senha."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset link sent"
 msgstr "Redefinição de senha concluída"
 
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
+#: web/templates/registration/password_reset_done.html:9
+msgid ""
+"If an account exists with the email you entered, we've emailed instructions "
+"for resetting your password and you should receive them shortly."
+msgstr ""
+
+#: web/templates/registration/password_reset_done.html:12
+msgid ""
+"If you don't receive an email, please check your spam folder and make sure "
+"you've entered the address you registered with. (You won't get an email "
+"unless there's already an account for that email address!)"
+msgstr ""
+
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Você recebeu este e-mail porque solicitou uma redefinição de senha para sua "
 "conta de usuário em% (site_name) s."
@@ -1044,22 +1340,25 @@ msgstr "Vá para a seguinte página e escolha uma nova senha:"
 msgid "Your username, in case you've forgotten:"
 msgstr "Seu nome de usuário, caso você tenha esquecido:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Obrigado por usar o nosso site!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-msgid "The %(site_name)s team"
-msgstr "A equipe% (site_name) s"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Redefinir minha senha"
+
+#: web/templates/registration/password_reset_form.html:8
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset"
 msgstr "Redefinição de senha concluída"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1067,129 +1366,255 @@ msgstr ""
 "Esqueceu sua senha? Digite seu endereço de e-mail abaixo e enviaremos "
 "instruções por e-mail para definir uma nova senha."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Endereço de e-mail:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset complete"
+msgid "Password reset on Children Helping Science"
+msgstr "Redefinição de senha concluída"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Redefinir minha senha"
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Pesquisador"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Estudos"
+#: web/templates/web/_footer.html:17
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact us"
+msgstr "Contato:"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "Perguntas frequentes"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Os cientistass"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Recursos"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Oi"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Sair"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "inscrever-se"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Pesquisador"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Crianças"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Adicionar filho"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Criança"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 #| msgid "Back to list"
 msgid "Back to Children List"
 msgstr "De volta à lista"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Atualizar"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Excluir"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Cancelar"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Salvar"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Aniversário vazio"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Atualizar"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " dia"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " dias"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " mês"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " meses"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " ano"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " anos"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Adicionar filho"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Ocultar formulário"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nome"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Atualizar filho"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nome"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Nenhuma criança foi registrada!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr ""
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Documentação"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Atualizar dados demográficos"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1203,7 +1628,7 @@ msgstr ""
 "fatores como: falar vários idiomas ou ter irmãos mais velhos influenciam a "
 "aprendizagem das crianças."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1213,126 +1638,1548 @@ msgstr ""
 "com seu vídeo. Isso continua valendo mesmo se você permitir que os vídeos "
 "dos estudos sejam publicados para fins científicos ou de publicidade."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Participar"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Seus estudos anteriores"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "No momento, não estamos realizando estudos!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Faça login para participar"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Qual é o seu género?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Duração"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "Em que estado mora?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+msgid "For Researchers"
+msgstr ""
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Qual é a sua idade?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Faça login para participar"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Os cientistass"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Participar"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Tela Inicial"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Gostaria de ser contatado quando:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Faça login para participar"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Criar Conta"
+
+#: web/templates/web/participant-signup.html:13
 #, fuzzy
 #| msgid "Create Account"
 msgid "Create Participant Account"
 msgstr "Criar Conta"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+msgid "instead."
+msgstr ""
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "Ao clicar em \"Criar conta\", concordo que li e aceitei o "
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Declaração de privacidade"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Criar Conta"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Declaração de privacidade"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Todos os participantes"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Informação adicional"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Estudos anteriores"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
 msgstr ""
-"Sua conta não tem acesso a esta página. Para continuar, faça login com uma "
-"conta que tenha acesso."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Faça o login para ver esta página."
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Estudos atuais"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Seus estudos anteriores"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Aqui você pode ver seus estudos e ver comentários deixados pelos "
 "pesquisadores:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Miniatura do estudo"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Elegibilidade:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contato:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Ainda está coletando dados?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Sim"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Não"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Compensação: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Compensação"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Respostas do Estudo"
 
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Data"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Status de consentimento"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Aprovado"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Seu vídeo de consentimento foi analisado por um pesquisador e é válido."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "Pendente"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "Seu vídeo de consentimento ainda não foi analisado por um pesquisador."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Inválido"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1343,159 +3190,183 @@ msgstr ""
 "dados desta sessão não serão visualizados ou utilizados pelos pesquisadores "
 "do estudo."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr ""
 "Nenhuma informação sobre o status de revisão do vídeo de consentimento."
 
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Você ainda não participou de nenhum estudo."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Estudos atuais"
-
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
-msgstr ""
-"Você precisará de um laptop ou de um computador de mesa/desktop executando o "
-"Chrome ou Firefox para participar. Não é possível usar um dispositivo móvel "
-"(tablet, iPad, celular)."
-
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Veja detalhes"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "No momento, não estamos realizando estudos!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
-msgstr ""
-"Procurando mais maneiras de contribuir sem sair de casa? Confira <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\"> Crianças ajudando a ciência </a> para ver mais estudos!"
-
-#: web/templates/web/study-detail.html:53
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-#| msgid " days"
-msgid "days"
-msgstr " dias"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Você ainda não participou de nenhum estudo."
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Resumo do estudo"
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Estudos"
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "De volta à lista"
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Critérios de elegibilidade"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
 
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Duração"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Compensação"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "O que acontece"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Recursos"
 
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "O que estamos estudando"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Este estudo é realizado por"
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
 
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Você gostaria de participar deste estudo?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Faça login para participar"
-
-#: web/templates/web/study-detail.html:142
-#, fuzzy
-#| msgid "No child profiles registered!"
-msgid "Add child profile to "
-msgstr "Nenhuma criança foi registrada!"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 #, fuzzy
 #| msgid "Participate"
 msgid "participate"
 msgstr "Participar"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Crie um executador para visualizar o experimento"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Faça login para participar"
+
+#: web/templates/web/study-detail.html:22
+#, fuzzy
+#| msgid "No child profiles registered!"
+msgid "Add child profile to "
+msgstr "Nenhuma criança foi registrada!"
+
+#: web/templates/web/study-detail.html:23
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Complete demographic survey to "
 msgstr "Pesquisa Demográfica"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Participar"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "O que acontece"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "O que estamos estudando"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Duração"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Este estudo é realizado por"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Você gostaria de participar deste estudo?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Selecione uma filha(o):"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Nenhum selecionado"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Seu filho ainda é mais novo que a faixa etária recomendada para este estudo. "
 "Se você esperar <span id = 'wait-till'> até que </span> ele tenha idade "
 "suficiente, poderemos usar os dados coletados em nossa pesquisa!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Seu filho é mais velho que a faixa etária recomendada para este estudo. "
 "Fique a vontade para participar do estudo de qualquer maneira, mas não "
 "poderemos usar os dados coletados em nossa pesquisa."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Seu filho não atende aos critérios de elegibilidade listados para este "
 "estudo. Fique a vontade para participar do estudo de qualquer maneira, mas "
 "não poderemos usar os dados coletados em nossa pesquisa. Entre em contato "
 "com os pesquisadores do estudo"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Crie um executador para visualizar o experimento"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Participar"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1503,26 +3374,256 @@ msgstr ""
 "Para uma maneira fácil de ver o que acontece quando você atualiza seu "
 "protocolo de estudo, adicione aos favoritos o URL contido no botão acima."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "inscrever-se"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Você precisará de um laptop ou de um computador de mesa/desktop executando o "
+"Chrome ou Firefox para participar. Não é possível usar um dispositivo móvel "
+"(tablet, iPad, celular)."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 #, fuzzy
 #| msgid "Participate"
 msgid "Participant created."
 msgstr "Participar"
 
-#: web/views.py:88
+#: web/views.py:157
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Demographic data saved."
 msgstr "Pesquisa Demográfica"
 
-#: web/views.py:156
+#: web/views.py:223
 #, fuzzy
 #| msgid "Children"
 msgid "Child added."
 msgstr "Crianças"
 
-#: web/views.py:217
+#: web/views.py:264
+#, fuzzy
+#| msgid "Children"
+msgid "Child deleted."
+msgstr "Crianças"
+
+#: web/views.py:266
+#, fuzzy
+#| msgid "Children"
+msgid "Child updated."
+msgstr "Crianças"
+
+#: web/views.py:294
 #, fuzzy
 #| msgid "Email Preferences"
 msgid "Email preferences saved."
 msgstr "Preferências de Email"
+
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "Com que categoria(s) se identifica a sua família?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Apenas respostas numéricas - pode ser uma estimativa!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Que língua(s) a sua família fala em casa?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "Qual é o nível mais alto de educação que o seu cônjuge completou ?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Aproximadamente, quantos livros infantis tem em casa?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Se a resposta variar devido a acordos de custódia / guarda compartilhada "
+#~ "ou viagem, por favor introduza o número de pais / responsáveis legais com "
+#~ "os quais as crianças habitualmente moram ou explique a situação."
+
+#~ msgid "other"
+#~ msgstr "outro"
+
+#~ msgid "3 or more"
+#~ msgstr "3 ou mais"
+
+#~ msgid "varies"
+#~ msgstr "varia"
+
+#~ msgid "My Account"
+#~ msgstr "Minha conta"
+
+#~ msgid "Last Active:"
+#~ msgstr "Ativo pela última vez:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "ID global do participante:"
+
+#~ msgid "Dashboard"
+#~ msgstr "painel de controle"
+
+#, fuzzy
+#~| msgid "Yes"
+#~ msgid "Yue"
+#~ msgstr "Sim"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Faça login para participar"
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Novo no Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Nova senha:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Confirme a Senha:"
+
+#, fuzzy, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "A equipe% (site_name) s"
+
+#~ msgid "Email address:"
+#~ msgstr "Endereço de e-mail:"
+
+#~ msgid "FAQ"
+#~ msgstr "Perguntas frequentes"
+
+#~ msgid "Hi"
+#~ msgstr "Oi"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Aniversário vazio"
+
+#~ msgid " day"
+#~ msgstr " dia"
+
+#~ msgid " days"
+#~ msgstr " dias"
+
+#~ msgid " month"
+#~ msgstr " mês"
+
+#~ msgid " months"
+#~ msgstr " meses"
+
+#~ msgid " year"
+#~ msgstr " ano"
+
+#~ msgid " years"
+#~ msgstr " anos"
+
+#~ msgid "Hide Form"
+#~ msgstr "Ocultar formulário"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Sua conta não tem acesso a esta página. Para continuar, faça login com "
+#~ "uma conta que tenha acesso."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Faça o login para ver esta página."
+
+#~ msgid "Compensation: "
+#~ msgstr "Compensação: "
+
+#~ msgid "Current Studies"
+#~ msgstr "Estudos atuais"
+
+#~ msgid "See details"
+#~ msgstr "Veja detalhes"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "No momento, não estamos realizando estudos!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Procurando mais maneiras de contribuir sem sair de casa? Confira <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\"> Crianças ajudando a ciência </a> para ver "
+#~ "mais estudos!"
+
+#, fuzzy
+#~| msgid " days"
+#~ msgid "days"
+#~ msgstr " dias"
+
+#~ msgid "Study overview"
+#~ msgstr "Resumo do estudo"
+
+#~ msgid "Back to list"
+#~ msgstr "De volta à lista"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Critérios de elegibilidade"

--- a/locale/pt_PT/LC_MESSAGES/django.po
+++ b/locale/pt_PT/LC_MESSAGES/django.po
@@ -3300,10 +3300,8 @@ msgstr "Duração"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Este estudo é realizado por"
+msgstr "Este estudo é realizado por %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -2,33 +2,48 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Adresă de e-mail"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Poreclă"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "E momentul unei noi sesiuni a studiului la care participați"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Un nou studiu este disponibil pentru unul dintre copiii dvs."
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -36,7 +51,7 @@ msgstr ""
 "Avem noutăți cu privire la un studiu la care ați participat (de exemplu, au "
 "fost publicate rezultatele)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -44,100 +59,92 @@ msgstr ""
 "Un cercetător are întrebări cu privire la răspunsurile dvs. anterioare (de "
 "exemplu, dacă ați semnalat probleme tehnice pe durata studiului)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "Din ce categorie/categorii face parte familia dvs.?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Țară"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Separați cu o virgula: AAAA-LL-ZZ, AAAA-LL-ZZ,..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Doar răspunsuri numerice - răspunsul poate fi aproximativ"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "În ce țară locuiți?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "În ce județ locuiți?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Cum ați descrie zona în care locuiți?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Ce limbă vorbiți acasă?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Câți copii aveți?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Introduceți ziua de naștere a fiecărui copil"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Câți părinți / tutori au copiii dumneavoastră?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Ce vârstă aveți?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Ce gen aveţi?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Ce gen aveţi?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Care e nivelul dvs. de educaţie?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Care e nivelul de educaţie al soţiei / soţului dvs.?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Ce salariu anual aveţi (în RON)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Aproximativ câte cărți pentru copii aveți acasă?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Vreți să mai adaugați ceva ce ați dori să ştim?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Cum ați auzit de Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Dacă răspunsul depinde de aranjamente de custodie comună sau de călătorii, "
-"vă rugăm să introduceți numărul de părinți / tutori cu care locuiesc de "
-"obicei copiii dvs. sau explicați-ne situația dvs."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Data de naștere"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "altă rasă, etnie sau origine"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -148,40 +155,43 @@ msgstr ""
 "copiilor sau informații personale care să permită cititorului să calculeze "
 "data nașterii."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Datele de naștere nu pot fi în viitor"
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Prenume"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Data de naștere"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Gen"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Vârsta gestațională la naștere"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Vreți să mai adaugați ceva ce ați dori să ştim?"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Caracteristici și condiții"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
 msgstr ""
 "Limbile la care e expus acest copil acasă, la școală sau cu alte îngrijitoare"
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -194,504 +204,612 @@ msgstr ""
 "exemplu, „Avem un nou studiu disponibil pentru Ina!”), dar nu vom face "
 "publice niciodată numele și nu le vom folosi în cercetarea noastră."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "De exemplu, tulburări de dezvoltare sau probleme de vedere sau auz "
 "diagnosticate"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr ""
 "Vă rugăm să rotunjiți până la cea mai apropiată săptămână întreagă de sarcină"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Studii"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Studiile curente"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Studiile dvs. precedente"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Studiile curente"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Nu sunt sigur / sigură sau prefer să nu răspund"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Sub 24 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 de săptămâni"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 de săptămâni sau mai mult"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Vizualizare organizație"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Editare organizație"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Creare organizație"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Eliminare organizație"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Vizualizare experimentator"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Vizualizare analitice"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Creare utilizator"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Vizualizare utilizator"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Editare utilizator"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Eliminare utilizator"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Vizualizare permisiuni pentru utilizatori"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Editare permisiuni pentru utilizatori"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Citire date utilizatori"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Citire nume utilizatori"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "masculin"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "feminin"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "alt gen"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "prefer să nu răspund"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Vizualizare organizație"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Editare organizație"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Creare organizație"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Eliminare organizație"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Vizualizare experimentator"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Vizualizare analitice"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Creare utilizator"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Vizualizare utilizator"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Editare utilizator"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Eliminare utilizator"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Vizualizare permisiuni pentru utilizatori"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Editare permisiuni pentru utilizatori"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Citire date utilizatori"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Citire nume utilizatori"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "albă sau europeană"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "origine hispanică, latino sau spaniolă"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "neagră sau afro-americană"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "asiatică"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "indio-americană sau din Alaska"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "din Orientul Mijlociu sau Africa de Nord"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "nativ hawaian sau de pe altă insulă din Pacific"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "altă rasă, etnie sau origine"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "studii liceale în curs"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "studii liceale cu diplomă de bacalaureat"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "studii universitare în curs"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "facultate, studii superioare de bază (3 ani)"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "studii superioare, masterat (4-5 ani)"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "studii profesionale în curs"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "studii liceu profesional fără certificat de calificare"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "Nu se aplică, fără soț / soție sau partener / parteneră"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Mai mult de 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "sub 18 ani"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 sau mai mult"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 sau mai mult"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "depinde"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "peste 200000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "urban"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "suburban"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "rural"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Selectați un județ"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Informații cont"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Sondaj demografic"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Spuneţi-ne mai multe despre dvs."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Informaţii despre copii"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Adăugaţi sau modificaţi informaţiile participantului."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Preferinţe e-mail"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "Editați când puteți fi contactat / contactată."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Contul meu"
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr "Actualizare informații cont"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Salvare"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Schimbare parolă"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Toți participanții"
 
@@ -699,76 +817,83 @@ msgstr "Toți participanții"
 msgid "Participant ID"
 msgstr "Numărul de identificare al participantului"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Ultima accesare"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "Numărul de identificare global al participantului"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Copii"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Vârstă"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Informații suplimentare"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Nu ați înregistrat niciun profil de copil!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Cele mai recente date demografice"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Țară"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Județ"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Descrierea zonei"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Limbi vorbite acasă"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Număr de copii"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Vârstele actuale ale copiilor"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Răspunsurile dvs. la acest studiu"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Număr de tutori"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Explicație tutori"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Etnie"
 
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Tablou de bord"
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
 
-#: project/settings.py:243 studies/fields.py:97
-#, fuzzy
-#| msgid "Asian"
-msgid "Russian"
-msgstr "asiatică"
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
 
 #: studies/fields.py:45
 msgid "Twin"
@@ -798,35 +923,269 @@ msgstr "Septuplet"
 msgid "Octuplet"
 msgstr "Octuplet"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
 #: studies/fields.py:69
 #, fuzzy
 #| msgid "Duration"
 msgid "Gujarati"
 msgstr "Durată"
 
-#: studies/fields.py:115
-#, fuzzy
-#| msgid "Yes"
-msgid "Yue"
-msgstr "Da"
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+#, fuzzy
+#| msgid "Duration"
+msgid "Marathi"
+msgstr "Durată"
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+#, fuzzy
+#| msgid "Asian"
+msgid "Russian"
+msgstr "asiatică"
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Fără răspuns"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Alt răspuns"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Masculin"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Feminin"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -835,155 +1194,68 @@ msgstr ""
 "vor putea crea studii asociate cu acest laborator care pot fi adăugate la "
 "studiile acestui laborator."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Utilizatorii care au solicitat să se alăture acestui laborator."
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-#, fuzzy
-#| msgid "researcher login"
-msgid "For researchers"
-msgstr "conectare cercetător"
-
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-#, fuzzy
-#| msgid "Contact:"
-msgid "Contact us"
-msgstr "Contact"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Participați"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Conectați-vă pentru a participa"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Conectați-vă pentru a participa"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Ce gen aveţi?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Durată"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "Nu derulăm niciun studiu în acest moment!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Participați"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Declarația de confidențialitate"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Toți participanții"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Informații suplimentare"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "V-ați deconectat cu succes."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-#, fuzzy
-#| msgid "Your username and password didn't match. Please try again."
-msgid "Your login credentials didn't work. Please try again."
-msgstr ""
-"Numele dvs. de utilizator și parola nu s-au potrivit. Vă rugăm să încercați "
-"din nou."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 msgid "Login"
 msgstr "Autentificare"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Ați uitat parola dvs.?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Sunteți nou / nouă pe Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Parolă schimbată"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Parola dvs. a fost schimbată."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Documentație"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Schimbați parola"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Deconectare"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Acasă"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Schimbare parolă"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Vă rugăm să corectați eroarea de mai jos."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Vă rugăm să corectați erorile de mai jos."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -992,28 +1264,28 @@ msgstr ""
 "introduceți parolă noua de două ori, să putem verifica dacă ați introdus-o "
 "corect."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Schimbare parolă"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Resetarea parolei a fost finalizată"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Parola dvs. a fost setată. Vă puteți conecta acum."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 msgid "Log in"
 msgstr "Autentificare"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Resetarea parolei a fost finalizată"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Parola dvs. a fost setată. Vă puteți conecta acum."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Confirmare resetare parolă"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1021,15 +1293,7 @@ msgstr ""
 "Vă rugăm să introduceți noua parolă de două ori pentru verifica dacă ați "
 "introdus-o corect."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Noua parolă"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Confirmare parolă"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1037,13 +1301,13 @@ msgstr ""
 "Link-ul de resetare al parolei a fost invalid, posibil pentru că a fost deja "
 "utilizat. Vă rugăm să solicitați o nouă resetare a parolei."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset link sent"
 msgstr "Resetarea parolei a fost finalizată"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 #, fuzzy
 #| msgid ""
 #| "We've emailed you instructions for setting your password, if an account "
@@ -1055,7 +1319,7 @@ msgstr ""
 "V-am trimis instrucțiuni pentru setarea parolei, dacă deja există un cont cu "
 "e-mailul pe care l-ați introdus. Ar trebui să le primiți în scurt timp."
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 #, fuzzy
 #| msgid ""
 #| "If you don't receive an email, please make sure you've entered the "
@@ -1068,11 +1332,14 @@ msgstr ""
 "Dacă nu primiți e-mailul, vă rugăm să vă asigurați că ați introdus adresa cu "
 "care v-ați înregistrat și să verificați dosarul de spam."
 
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Ați primit acest e-mail deoarece ați solicitat o resetare a parolei pentru "
 "contul dvs. de utilizator la %(site_name)s."
@@ -1085,22 +1352,25 @@ msgstr "Vă rugăm să accesați pagina următoare și să vă alegeți o parol�
 msgid "Your username, in case you've forgotten:"
 msgstr "Numele dvs. de utilizator, în cazul în care l-ați uitat:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Vă mulțumim că ați vizitat site-ul nostru!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, python-format
-msgid "The %(site_name)s team"
-msgstr "Echipa %(site_name)s"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Resetare parolă"
+
+#: web/templates/registration/password_reset_form.html:8
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset"
 msgstr "Resetarea parolei a fost finalizată"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1108,129 +1378,257 @@ msgstr ""
 "Ați uitat parola? Introduceți adresa dvs. de e-mail mai jos și vă trimitem "
 "prin e-mail instrucțiuni pentru setarea uneia noi."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Adresă de e-mail"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset complete"
+msgid "Password reset on Children Helping Science"
+msgstr "Resetarea parolei a fost finalizată"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Resetare parolă"
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Experimentator"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Studii"
+#: web/templates/web/_footer.html:17
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact us"
+msgstr "Contact"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "Întrebări frecvente"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Oamenii de știință"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Resurse"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Bună ziua!"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Deconectare"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "Înscriere"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Experimentator"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Copii"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Anulare"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Adăugare copil"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Copil"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 #| msgid "Back to list"
 msgid "Back to Children List"
 msgstr "Înapoi la listă"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Actualizări"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Eliminare"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Anulare"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Salvare"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Lipsește ziua de naștere"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Actualizări"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " zi"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr " zile"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " lună"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr " luni"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " an"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr " ani"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Adăugare copil"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Ascundeți formularul"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Nume"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Actualizare copil"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Nume"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Nu ați înregistrat niciun profil de copil!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+#, fuzzy
+#| msgid "researcher login"
+msgid "For researchers"
+msgstr "conectare cercetător"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Documentație"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Actualizare date demografice"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
 "more diverse group of families in our research. Your answers to these "
@@ -1244,7 +1642,7 @@ msgstr ""
 "ce public ajungem, precum și modul în care vorbirea mai multor limbi sau "
 "prezența fraților mai mari afectează cum învăță copiii."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1254,128 +1652,1554 @@ msgstr ""
 "activități științifice sau publicitare, informațiile dvs. demografice nu "
 "sunt publicate niciodată împreună cu videoclipul dvs."
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Participați"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Studiile dvs. precedente"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "Nu derulăm niciun studiu în acest moment!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Conectați-vă pentru a participa"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Ce gen aveţi?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Durată"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "În ce județ locuiți?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "researcher login"
+msgid "For Researchers"
+msgstr "conectare cercetător"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Ce vârstă aveți?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Conectați-vă pentru a participa"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Oamenii de știință"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Participați"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Acasă"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Aș dori să fiu contactat / contactată când:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Conectați-vă pentru a participa"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Creare cont"
+
+#: web/templates/web/participant-signup.html:13
 #, fuzzy
 #| msgid "Participant account"
 msgid "Create Participant Account"
 msgstr "Contul participantului"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead?"
+msgid "instead."
+msgstr "cumva?"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr "Făcând clic pe „Creare cont”, sunt de acord că am citit și acceptat"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Declarația de confidențialitate"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Creare cont"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Declarația de confidențialitate"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Toți participanții"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Informații suplimentare"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Studiile precedente"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
 msgstr ""
-"Contul dvs. nu are acces la această pagină. Pentru a continua, vă rugăm să "
-"vă autentificați cu un cont care are acces."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Vă rugăm să vă autentificați pentru a putea vedea această pagină."
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Studiile curente"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Studiile dvs. precedente"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Aici puteți vizualiza studiile dvs. și puteți vedea comentariile lăsate de "
 "cercetători:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Miniatură studiu"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Eligibilitate"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Contact"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Încă mai colectați date?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Da"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Nu"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
 msgstr "Recompensă"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Răspunsurile dvs. la acest studiu"
 
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Dată"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Statutul consimțământului"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Aprobat"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Videoclipul dvs. de consimțământ a fost revizuit de un cercetător și este "
 "valid."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "În așteptare"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr ""
 "Videoclipul dvs. de consimțământ încă nu a fost revizuit de un cercetător."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Invalid"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1386,160 +3210,185 @@ msgstr ""
 "dvs. din această sesiune nu vor fi vizualizate sau utilizate de cercetătorii "
 "studiului."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr ""
 "Nu există informații despre statutul de examinare a videoclipurilor de "
 "consimțământ."
 
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Încă nu ați participat la nici un studiu."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Studiile actuale"
-
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
-msgstr ""
-"Vă rugăm să rețineți că pentru a participa aveți nevoie de un laptop sau "
-"calculator (nu un dispozitiv mobil) care rulează Chrome sau Firefox."
-
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Vedeți detalii"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "Nu derulăm niciun studiu în acest moment!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
-msgstr ""
-"Căutați alte modalități de a contribui la cercetare de acasă? Pentru a vedea "
-"mai multe studii, consultați <a href=\"https://childrenhelpingscience.com/\" "
-"target=\"_blank\" rel=\"noreferrer noopener\"> Children Helping Science </a>."
-
-#: web/templates/web/study-detail.html:53
+#: web/templates/web/studies-history.html:147
 #, fuzzy
-#| msgid " days"
-msgid "days"
-msgstr " zile"
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Încă nu ați participat la nici un studiu."
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Prezentarea generală a studiului"
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studii"
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Înapoi la listă"
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Criterii de eligibilitate"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
+msgstr ""
 
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Durată"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Recompensă"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Ce se întâmplă"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Resurse"
 
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Ce studiem"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Acest studiu e condus de"
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
 
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Doriți să participați la acest studiu?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Conectați-vă pentru a participa"
-
-#: web/templates/web/study-detail.html:142
-#, fuzzy
-#| msgid "No child profiles registered!"
-msgid "Add child profile to "
-msgstr "Nu ați înregistrat niciun profil de copil!"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 #, fuzzy
 #| msgid "Participate"
 msgid "participate"
 msgstr "Participați"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Previzualizați experimentul"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Conectați-vă pentru a participa"
+
+#: web/templates/web/study-detail.html:22
+#, fuzzy
+#| msgid "No child profiles registered!"
+msgid "Add child profile to "
+msgstr "Nu ați înregistrat niciun profil de copil!"
+
+#: web/templates/web/study-detail.html:23
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Complete demographic survey to "
 msgstr "Sondaj demografic"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Participați"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Ce se întâmplă"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Ce studiem"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Durată"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Acest studiu e condus de"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Doriți să participați la acest studiu?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Selectați un copil"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Nu ați selectat nimic"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Copilul dvs. este încă mai mic decât intervalul de vârstă recomandat pentru "
 "acest studiu. Dacă puteți aștepta <span id = 'wait-until'> până când </span> "
 "el sau ea are vârsta suficientă, vom putea folosi datele colectate în "
 "cercetarea noastră!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Copilul dvs. este mai mare decât intervalul de vârstă recomandat pentru "
 "acest studiu. Puteți participa la acest studiu oricum, dar nu vom putea "
 "folosi datele dvs. în cercetarea noastră."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Copilul dvs. nu îndeplinește criteriile de selecție pentru acest studiu. "
 "Puteți participa la acest studiu oricum, dar nu vom putea folosi datele dvs. "
 "în cercetarea noastră. Vă rugăm să contactați cercetătorii responsabili "
 "pentru acest studiu."
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Previzualizați experimentul"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Participați"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1548,34 +3397,265 @@ msgstr ""
 "actualizați protocolul de studiu, marcați adresa URL la care vă trimite "
 "butonul de mai sus."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Înscriere"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Vă rugăm să rețineți că pentru a participa aveți nevoie de un laptop sau "
+"calculator (nu un dispozitiv mobil) care rulează Chrome sau Firefox."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 #, fuzzy
 #| msgid "Participant account"
 msgid "Participant created."
 msgstr "Contul participantului"
 
-#: web/views.py:88
+#: web/views.py:157
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Demographic data saved."
 msgstr "Sondaj demografic"
 
-#: web/views.py:156
+#: web/views.py:223
 #, fuzzy
 #| msgid "Children"
 msgid "Child added."
 msgstr "Copii"
 
-#: web/views.py:217
+#: web/views.py:264
+#, fuzzy
+#| msgid "Children"
+msgid "Child deleted."
+msgstr "Copii"
+
+#: web/views.py:266
+#, fuzzy
+#| msgid "Children"
+msgid "Child updated."
+msgstr "Copii"
+
+#: web/views.py:294
 #, fuzzy
 #| msgid "Email Preferences"
 msgid "Email preferences saved."
 msgstr "Preferinţe e-mail"
 
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "Din ce categorie/categorii face parte familia dvs.?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Doar răspunsuri numerice - răspunsul poate fi aproximativ"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Ce limbă vorbiți acasă?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "Care e nivelul de educaţie al soţiei / soţului dvs.?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Aproximativ câte cărți pentru copii aveți acasă?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Dacă răspunsul depinde de aranjamente de custodie comună sau de "
+#~ "călătorii, vă rugăm să introduceți numărul de părinți / tutori cu care "
+#~ "locuiesc de obicei copiii dvs. sau explicați-ne situația dvs."
+
+#~ msgid "other"
+#~ msgstr "alt gen"
+
+#~ msgid "3 or more"
+#~ msgstr "3 sau mai mult"
+
+#~ msgid "varies"
+#~ msgstr "depinde"
+
+#~ msgid "My Account"
+#~ msgstr "Contul meu"
+
+#~ msgid "Last Active:"
+#~ msgstr "Ultima accesare"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "Numărul de identificare global al participantului"
+
+#~ msgid "Dashboard"
+#~ msgstr "Tablou de bord"
+
 #, fuzzy
-#~| msgid "instead?"
-#~ msgid "instead"
-#~ msgstr "cumva?"
+#~| msgid "Yes"
+#~ msgid "Yue"
+#~ msgstr "Da"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Conectați-vă pentru a participa"
+
+#, fuzzy
+#~| msgid "Your username and password didn't match. Please try again."
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr ""
+#~ "Numele dvs. de utilizator și parola nu s-au potrivit. Vă rugăm să "
+#~ "încercați din nou."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Sunteți nou / nouă pe Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Noua parolă"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Confirmare parolă"
+
+#, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "Echipa %(site_name)s"
+
+#~ msgid "Email address:"
+#~ msgstr "Adresă de e-mail"
+
+#~ msgid "FAQ"
+#~ msgstr "Întrebări frecvente"
+
+#~ msgid "Hi"
+#~ msgstr "Bună ziua!"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Lipsește ziua de naștere"
+
+#~ msgid " day"
+#~ msgstr " zi"
+
+#~ msgid " days"
+#~ msgstr " zile"
+
+#~ msgid " month"
+#~ msgstr " lună"
+
+#~ msgid " months"
+#~ msgstr " luni"
+
+#~ msgid " year"
+#~ msgstr " an"
+
+#~ msgid " years"
+#~ msgstr " ani"
+
+#~ msgid "Hide Form"
+#~ msgstr "Ascundeți formularul"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Contul dvs. nu are acces la această pagină. Pentru a continua, vă rugăm "
+#~ "să vă autentificați cu un cont care are acces."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Vă rugăm să vă autentificați pentru a putea vedea această pagină."
+
+#~ msgid "Compensation: "
+#~ msgstr "Recompensă"
+
+#~ msgid "Current Studies"
+#~ msgstr "Studiile actuale"
+
+#~ msgid "See details"
+#~ msgstr "Vedeți detalii"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Nu derulăm niciun studiu în acest moment!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Căutați alte modalități de a contribui la cercetare de acasă? Pentru a "
+#~ "vedea mai multe studii, consultați <a href=\"https://"
+#~ "childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
+#~ "noopener\"> Children Helping Science </a>."
+
+#, fuzzy
+#~| msgid " days"
+#~ msgid "days"
+#~ msgstr " zile"
+
+#~ msgid "Study overview"
+#~ msgstr "Prezentarea generală a studiului"
+
+#~ msgid "Back to list"
+#~ msgstr "Înapoi la listă"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Criterii de eligibilitate"
 
 #, fuzzy
 #~| msgid "Birthday"
@@ -1659,6 +3739,3 @@ msgstr "Preferinţe e-mail"
 
 #~ msgid "Signup"
 #~ msgstr "Înscriere"
-
-#~ msgid "Update account information"
-#~ msgstr "Actualizare informații cont"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -3321,10 +3321,8 @@ msgstr "Durată"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Acest studiu e condus de"
+msgstr "Acest studiu e condus de %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -2,35 +2,50 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:56
+msgid "Enter a valid 6-digit one-time password from Google Authenticator"
+msgstr ""
+
+#: accounts/forms.py:109
+#, python-format
+msgid ""
+"Please enter a correct %(username)s and password. Note that email and "
+"password fields may be case-sensitive. If you have turned on two-factor "
+"authentication, you will need a one-time password (OTP code) from Google "
+"Authenticator as well. "
+msgstr ""
+
+#: accounts/forms.py:114
+msgid "This account is inactive."
+msgstr ""
+
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Адрес электронной почты"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Псевдоним"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr ""
 "Пришло время провести еще одну сессию исследования, в котором мы сейчас "
 "участвуем"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Доступно новое исследование для одного из моих детей"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -38,7 +53,7 @@ msgstr ""
 "Доступна обновленная информация об исследовании, в котором мы участвовали "
 "(например, опубликованы результаты)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -46,103 +61,92 @@ msgstr ""
 "У исследователя есть вопросы по поводу некоторых моих ответов (например, "
 "если я сообщал(-а) о технической проблеме во время исследования)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr ""
-"Как бы Вы охарактеризовали \n"
-"Вашу семью?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Страна"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Перечислите, разделяя запятыми: ГГГГ-ММ-ДД, ГГГГ-ММ-ДД, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Только числовые ответы; Вы можете ответить приблизительно!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "В какой стране Вы живете?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "В каком регионе Вы живете?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Как бы Вы описали район, в котором живете?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "На каком языке (языках) в Вашей семье говорят дома?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Сколько у Вас детей?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Для каждого ребенка укажите дату рождения:"
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Со сколькими родителями / опекунами живут Ваши дети?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Сколько Вам лет?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Какого Вы пола?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Какого Вы пола?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Самый высокий уровень полученного Вами образования?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Самый высокий уровень образования, который получил(-а) Ваш супруг(-а)?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Сколько составляет примерный годовой доход Вашей семьи (в рублях)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Сколько примерно детских книг у Вас дома?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Хотели бы Вы сообщить нам что-то еще?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Как Вы узнали о Lookit?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Если ситуация меняется из-за договоренности о совместной опеке или "
-"длительных поездок одного из родителей/опекунов, укажите количество "
-"родителей/опекунов, с которыми обычно проживают Ваши дети, или поясните "
-"дополнительно."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Дата рождения"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "другая этническая принадлежность или другое происхождение"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -152,39 +156,42 @@ msgstr ""
 "исследовании. Мы никогда не публикуем даты рождения детей или информацию, "
 "которая позволила бы читателю рассчитать дату рождения."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Даты рождения не могут быть в будущем."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "Имя"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Дата рождения"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Пол"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Гестационный возраст при рождении"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Любая дополнительная информация, которую Вы бы хотели нам сообщить"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Характеристики и условия"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
 msgstr "Языки, которые ребенок слышит дома, в школе или от другого опекуна. "
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -196,504 +203,612 @@ msgstr ""
 "электронном письме (например, «Доступно новое исследование для Марины!»), но "
 "никогда не будем публиковать имена или использовать их в наших исследованиях."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Например, диагностированные нарушения развития, нарушения зрения или слуха"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Пожалуйста, округлите до ближайшей полной недели беременности"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Исследования"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Текущие исследования"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+msgid "here on the Lookit platform"
+msgstr ""
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Ваши прошлые исследования"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Текущие исследования"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Не уверен(-а) или предпочитаю не отвечать"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "Менее 24 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 недели"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 неделя"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 недели"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 недели"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 недели"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 недель"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 и более недель"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Может просматривать организацию"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Может редактировать организацию"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Может создать организацию"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Может удалить организацию"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Может видеть экспериментатора"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Может просматривать аналитику"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Может создать пользователя"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Может видеть пользователя"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Может редактировать пользователя"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Может удалить пользователя"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Может просматривать разрешения пользователей"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Может редактировать разрешения пользователей"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Может видеть все данные пользователей"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Может видеть имена пользователей"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "мужской"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "женский"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "другой"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "предпочитаю не отвечать"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Может просматривать организацию"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Может редактировать организацию"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Может создать организацию"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Может удалить организацию"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Может видеть экспериментатора"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Может просматривать аналитику"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Может создать пользователя"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Может видеть пользователя"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Может редактировать пользователя"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Может удалить пользователя"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Может просматривать разрешения пользователей"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Может редактировать разрешения пользователей"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Может видеть все данные пользователей"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Может видеть имена пользователей"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "белый"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "латиноамериканское или испанское происхождение"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "африканское или афроамериканское происхождение"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "азиат"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "коренные народы Америки (в том числе Аляски)"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "ближневосточное или североафриканское происхождение"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "коренное население Гавайев или других тихоокеанских островов"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "другая этническая принадлежность или другое происхождение"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "учитесь в средней школе или учились, но не окончили"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "окончили среднюю школу (или эквивалент)"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "учитесь в колледже или учились, но не окончили"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "среднее профессиональное или неполное высшее образование"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "бакалавриат или специалитет"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "обучаетесь в магистратуре или обучались, но не окончили"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "магистратура или аспирантура "
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "неприменимо: нет супруга или партнера "
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "Более 10"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "менее 18"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18–21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25–29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30–34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35–39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40–44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45–49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50–59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60–69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 и старше"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 и более"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "варьируется"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "400000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "800000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "1200000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "1600000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "2400000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "3200000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "4000000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "4800000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "5600000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "6400000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "7200000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "8000000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "8800000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "9600000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "10400000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "11200000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "12000000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "12800000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "13600000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "14400000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "15200000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "16000000"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "городской"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "пригородный"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "сельский"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Выберите регион"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+msgid "and"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Информация об учетной записи"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:7
+msgid "Change your login credentials and/or nickname."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Демографическая анкета"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Расскажите нам побольше о себе."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Информация о детях"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 #, fuzzy
 msgid "Add or edit participant information."
 msgstr "Добавьте или отредактируйте информацию об участнике."
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Настройки электронной почты"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 #, fuzzy
 msgid "Edit when you can be contacted."
 msgstr "Укажите, когда с вами можно будет связаться."
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Мой аккаунт"
+#: accounts/templates/accounts/account-update.html:6
+msgid "Update account information"
+msgstr "Обновить информацию об учетной записи"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Сохранить"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Измените свой пароль"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/account-update.html:42
+msgid "Manage Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:49
+msgid ""
+"If you'd like, you can turn two-factor authentication off here. Just enter "
+"your one-time password here, hit submit, and it'll get deleted for you!"
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
+msgid "Set up Two-Factor Authentication"
+msgstr ""
+
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Все участники"
 
@@ -701,76 +816,82 @@ msgstr "Все участники"
 msgid "Participant ID"
 msgstr "ID участника"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Последнее посещение:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "Глобальный ID участника:"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Дети"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Возраст"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Дополнительная информация"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Нет зарегестрированных профилей детей!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Актуальные демографические данные"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Страна"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Регион"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Тип местности"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Языки, на которых говорят дома"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Количество детей"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Возраст детей на данный момент"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+msgid "No Response"
+msgstr "Отклик на исследование"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Количество опекунов"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Пояснение для опекунов:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Этническая принадлежность"
 
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Управление"
+#: studies/fields.py:7
+msgid "Autism Spectrum Disorder"
+msgstr ""
 
-#: project/settings.py:243 studies/fields.py:97
-#, fuzzy
-#| msgid "Asian"
-msgid "Russian"
-msgstr "азиат"
+#: studies/fields.py:8
+msgid "Deaf"
+msgstr ""
+
+#: studies/fields.py:9
+msgid "Hard of Hearing"
+msgstr ""
+
+#: studies/fields.py:10
+msgid "Dyslexia"
+msgstr ""
+
+#: studies/fields.py:11
+msgid "Multiple Birth (twin, triplet, or higher order)"
+msgstr ""
 
 #: studies/fields.py:45
 msgid "Twin"
@@ -800,36 +921,270 @@ msgstr "Семерняшка"
 msgid "Octuplet"
 msgstr "Восьмерняшка"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr ""
+
+#: studies/fields.py:58
+msgid "Amharic"
+msgstr ""
+
+#: studies/fields.py:59
+msgid "Bengali"
+msgstr ""
+
+#: studies/fields.py:60
+msgid "Bhojpuri"
+msgstr ""
+
+#: studies/fields.py:61
+msgid "Burmese"
+msgstr ""
+
+#: studies/fields.py:62
+msgid "Cebuano"
+msgstr ""
+
+#: studies/fields.py:63
+msgid "Chhattisgarhi"
+msgstr ""
+
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr ""
+
+#: studies/fields.py:65
+msgid "Egyptian Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:66
+msgid "French"
+msgstr ""
+
+#: studies/fields.py:67
+msgid "Gan"
+msgstr ""
+
+#: studies/fields.py:68
+msgid "German"
+msgstr ""
+
 #: studies/fields.py:69
 #, fuzzy
 #| msgid "Duration"
 msgid "Gujarati"
 msgstr "Продолжительность"
 
-#: studies/fields.py:115
-#, fuzzy
-#| msgid "Yes"
-msgid "Yue"
-msgstr "Да"
+#: studies/fields.py:70
+msgid "Hakka"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:71
+msgid "Hausa"
+msgstr ""
+
+#: studies/fields.py:72
+msgid "Hebrew"
+msgstr ""
+
+#: studies/fields.py:73
+msgid "Hindi"
+msgstr ""
+
+#: studies/fields.py:74
+msgid "Igbo"
+msgstr ""
+
+#: studies/fields.py:75
+msgid "Indonesian"
+msgstr ""
+
+#: studies/fields.py:76
+msgid "Iranian Persian"
+msgstr ""
+
+#: studies/fields.py:77
+msgid "Italian"
+msgstr ""
+
+#: studies/fields.py:78
+msgid "Japanese"
+msgstr ""
+
+#: studies/fields.py:79
+msgid "Javanese"
+msgstr ""
+
+#: studies/fields.py:80
+msgid "Jinyu"
+msgstr ""
+
+#: studies/fields.py:81
+msgid "Kannada"
+msgstr ""
+
+#: studies/fields.py:82
+msgid "Khmer"
+msgstr ""
+
+#: studies/fields.py:83
+msgid "Korean"
+msgstr ""
+
+#: studies/fields.py:84
+msgid "Magahi"
+msgstr ""
+
+#: studies/fields.py:85
+msgid "Maithili"
+msgstr ""
+
+#: studies/fields.py:86
+msgid "Malay"
+msgstr ""
+
+#: studies/fields.py:87
+msgid "Malayalam"
+msgstr ""
+
+#: studies/fields.py:88
+msgid "Chinese (Mandarin)"
+msgstr ""
+
+#: studies/fields.py:89
+#, fuzzy
+#| msgid "Duration"
+msgid "Marathi"
+msgstr "Продолжительность"
+
+#: studies/fields.py:90
+msgid "Min Nan"
+msgstr ""
+
+#: studies/fields.py:91
+msgid "Moroccan Spoken Arabic"
+msgstr ""
+
+#: studies/fields.py:92
+msgid "Northern Pashto"
+msgstr ""
+
+#: studies/fields.py:93
+msgid "Northern Uzbek"
+msgstr ""
+
+#: studies/fields.py:94
+msgid "Odia"
+msgstr ""
+
+#: studies/fields.py:95
+msgid "Polish"
+msgstr ""
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr ""
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr ""
+
+#: studies/fields.py:98
+#, fuzzy
+#| msgid "Asian"
+msgid "Russian"
+msgstr "азиат"
+
+#: studies/fields.py:99
+msgid "Saraiki"
+msgstr ""
+
+#: studies/fields.py:100
+msgid "Sindhi"
+msgstr ""
+
+#: studies/fields.py:101
+msgid "Somali"
+msgstr ""
+
+#: studies/fields.py:102
+msgid "Spanish"
+msgstr ""
+
+#: studies/fields.py:103
+msgid "Sunda"
+msgstr ""
+
+#: studies/fields.py:104
+msgid "Tagalog"
+msgstr ""
+
+#: studies/fields.py:105
+msgid "Tamil"
+msgstr ""
+
+#: studies/fields.py:106
+msgid "Telugu"
+msgstr ""
+
+#: studies/fields.py:107
+msgid "Thai"
+msgstr ""
+
+#: studies/fields.py:108
+msgid "Turkish"
+msgstr ""
+
+#: studies/fields.py:109
+msgid "Ukrainian"
+msgstr ""
+
+#: studies/fields.py:110
+msgid "Urdu"
+msgstr ""
+
+#: studies/fields.py:111
+msgid "Vietnamese"
+msgstr ""
+
+#: studies/fields.py:112
+msgid "Western Punjabi"
+msgstr ""
+
+#: studies/fields.py:113
+msgid "Wu"
+msgstr ""
+
+#: studies/fields.py:114
+msgid "Xiang Chinese"
+msgstr ""
+
+#: studies/fields.py:115
+msgid "Yoruba"
+msgstr ""
+
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
+
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Нет ответа "
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 #, fuzzy
 msgid "Other"
 msgstr "другое"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "мужской"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "женский"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -838,156 +1193,69 @@ msgstr ""
 "пользователь сможет создавать исследования, связанные с данной лабораторией, "
 "и может быть добавлен к исследованиям этой лаборатории."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Пользователи, подавшие запрос на присоединение к этой лаборатории."
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-#, fuzzy
-#| msgid "researcher login"
-msgid "For researchers"
-msgstr "Вход для исследователя"
-
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
-
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
-#, fuzzy
-#| msgid "Contact:"
-msgid "Contact us"
-msgstr "Контакты:"
-
-#: web/templates/frontpages/faq.html:16
-#, fuzzy
-#| msgid "Participate"
-msgid "Participation"
-msgstr "Участвовать"
-
-#: web/templates/frontpages/faq.html:40
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How can we participate online?"
-msgstr "Войдите, чтобы принять участие"
-
-#: web/templates/frontpages/faq.html:69
-#, fuzzy
-#| msgid "Log in to participate"
-msgid "How do we provide consent to participate?"
-msgstr "Войдите, чтобы принять участие"
-
-#: web/templates/frontpages/faq.html:107
-#, fuzzy
-#| msgid "What is your gender?"
-msgid "Who will see our video?"
-msgstr "Какого Вы пола?"
-
-#: web/templates/frontpages/faq.html:150
-#, fuzzy
-#| msgid "Duration"
-msgid "Habituation"
-msgstr "Продолжительность"
-
-#: web/templates/frontpages/faq.html:181
-#, fuzzy
-#| msgid "We are not running any studies at this time!"
-msgid "Why are you running studies online instead of in person?"
-msgstr "Сейчас мы не проводим никаких исследований!"
-
-#: web/templates/frontpages/home.html:12
-#, fuzzy
-#| msgid "Participate"
-msgid "Participate in a Study"
-msgstr "Участвовать"
-
-#: web/templates/frontpages/privacy.html:11
-#, fuzzy
-#| msgid "Privacy Statement"
-msgid "Privacy statement"
-msgstr "Заявление о конфиденциальности"
-
-#: web/templates/frontpages/privacy.html:22
-#, fuzzy
-#| msgid "All Participants"
-msgid "For participants"
-msgstr "Все участники"
-
-#: web/templates/frontpages/privacy.html:214
-#, fuzzy
-#| msgid "Additional Info"
-msgid "Additional Information"
-msgstr "Дополнительная информация"
-
-#: web/templates/registration/logged_out.html:6
+#: web/templates/registration/logged_out.html:5
 msgid "You've successfully logged out."
 msgstr "Вы успешно вышли из системы."
 
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-#, fuzzy
-#| msgid "Your username and password didn't match. Please try again."
-msgid "Your login credentials didn't work. Please try again."
-msgstr ""
-"Ваше имя пользователя и/или пароль введены неверно. Пожалуйста, попробуйте "
-"еще раз."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
 #, fuzzy
 msgid "Login"
 msgstr "Вход"
 
-#: web/templates/registration/login.html:34
+#: web/templates/registration/login.html:25
 msgid "Forgot password?"
 msgstr "Забыли пароль?"
 
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Впервые на Lookit?"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/registration/password_change_done.html:11
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr ""
+
+#: web/templates/registration/password_change_done.html:9
 msgid "Password changed"
 msgstr "Пароль изменен"
 
-#: web/templates/registration/password_change_done.html:15
+#: web/templates/registration/password_change_done.html:12
 msgid "Your password was changed."
 msgstr "Ваш пароль был изменен."
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:12
 msgid "Documentation"
 msgstr "Документация"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Change password"
 msgstr "Изменить пароль"
 
-#: web/templates/registration/password_change_form.html:4
+#: web/templates/registration/password_change_form.html:14
 msgid "Log out"
 msgstr "Выйти"
 
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
+#: web/templates/registration/password_change_form.html:18
 msgid "Home"
 msgstr "Главная страница"
 
-#: web/templates/registration/password_change_form.html:8
+#: web/templates/registration/password_change_form.html:19
 msgid "Password change"
 msgstr "Изменение пароля"
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:36
 msgid "Please correct the error below."
 msgstr "Пожалуйста, исправьте ошибку ниже."
 
-#: web/templates/registration/password_change_form.html:21
+#: web/templates/registration/password_change_form.html:38
 msgid "Please correct the errors below."
 msgstr "Пожалуйста, исправьте ошибки ниже."
 
-#: web/templates/registration/password_change_form.html:26
+#: web/templates/registration/password_change_form.html:43
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -995,29 +1263,29 @@ msgstr ""
 "Пожалуйста, введите свой старый пароль в целях безопасности, а затем дважды "
 "введите новый пароль, чтобы мы могли убедиться, что Вы ввели его правильно."
 
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
 msgid "Change my password"
 msgstr "Изменить пароль"
 
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Пароль сброшен"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Ваш пароль установлен. Сейчас Вы можете продолжить и войти в систему."
-
-#: web/templates/registration/password_reset_complete.html:17
+#: web/templates/registration/password_reset_complete.html:8
 #, fuzzy
 msgid "Log in"
 msgstr "Войти"
 
-#: web/templates/registration/password_reset_confirm.html:11
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Пароль сброшен"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Ваш пароль установлен. Сейчас Вы можете продолжить и войти в систему."
+
+#: web/templates/registration/password_reset_confirm.html:8
 msgid "Password reset confirmation"
 msgstr "Подтверждение сброса пароля"
 
-#: web/templates/registration/password_reset_confirm.html:17
+#: web/templates/registration/password_reset_confirm.html:11
 msgid ""
 "Please enter your new password twice so we can verify you typed it in "
 "correctly."
@@ -1025,15 +1293,7 @@ msgstr ""
 "Пожалуйста, введите свой новый пароль дважды, чтобы мы могли убедиться, что "
 "Вы ввели его правильно."
 
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Новый пароль:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Подтвердить пароль:"
-
-#: web/templates/registration/password_reset_confirm.html:37
+#: web/templates/registration/password_reset_confirm.html:21
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
@@ -1041,13 +1301,13 @@ msgstr ""
 "Ссылка для сброса пароля недействительна. Возможно, она уже использовалась. "
 "Пожалуйста, запросите сброс пароля еще раз."
 
-#: web/templates/registration/password_reset_done.html:11
+#: web/templates/registration/password_reset_done.html:6
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset link sent"
 msgstr "Пароль сброшен"
 
-#: web/templates/registration/password_reset_done.html:15
+#: web/templates/registration/password_reset_done.html:9
 #, fuzzy
 #| msgid ""
 #| "We've emailed you instructions for setting your password, if an account "
@@ -1060,7 +1320,7 @@ msgstr ""
 "если учетная запись с указанным Вами адресом электронной почты существует. "
 "Вы получите письмо в ближайшее время. "
 
-#: web/templates/registration/password_reset_done.html:17
+#: web/templates/registration/password_reset_done.html:12
 #, fuzzy
 #| msgid ""
 #| "If you don't receive an email, please make sure you've entered the "
@@ -1074,14 +1334,14 @@ msgstr ""
 "электронный адрес, который использовали при регистрации. Пожалуйста, "
 "проверьте также папку «Спам»."
 
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
 #| msgid ""
 #| "You're receiving this email because you requested a password reset for "
 #| "your user account at %(site_name)s."
 msgid ""
 "You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
+"user account at Children Helping Science."
 msgstr ""
 "Вы получили это письмо, потому что запросили сброс пароля для своей учетной "
 "записи на% (site_name) s."
@@ -1094,22 +1354,25 @@ msgstr "Перейдите на следующую страницу и созд�
 msgid "Your username, in case you've forgotten:"
 msgstr "Ваше имя пользователя, если Вы забыли:"
 
-#: web/templates/registration/password_reset_email.html:10
+#: web/templates/registration/password_reset_email.html:9
 msgid "Thanks for using our site!"
 msgstr "Спасибо, что используете наш сайт!"
 
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-msgid "The %(site_name)s team"
-msgstr "Команда % (site_name) s"
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
 
-#: web/templates/registration/password_reset_form.html:11
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Сбросить пароль"
+
+#: web/templates/registration/password_reset_form.html:8
 #, fuzzy
 #| msgid "Password reset complete"
 msgid "Password reset"
 msgstr "Пароль сброшен"
 
-#: web/templates/registration/password_reset_form.html:15
+#: web/templates/registration/password_reset_form.html:11
 msgid ""
 "Forgotten your password? Enter your email address below, and we'll email "
 "instructions for setting a new one."
@@ -1117,132 +1380,257 @@ msgstr ""
 "Забыли пароль? Введите ниже свой адрес электронной почты, и мы отправим Вам "
 "инструкцию по установке нового пароля."
 
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Адрес электронной почты:"
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset complete"
+msgid "Password reset on Children Helping Science"
+msgstr "Пароль сброшен"
 
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Сбросить пароль"
+#: web/templates/web/_footer.html:9
+msgid ""
+"This material is based upon work supported by the National Science "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"findings, and conclusions or recommendations expressed in this material are "
+"those of the authors(s) and do not necessarily reflect the views of the "
+"National Science Foundation."
+msgstr ""
 
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "Экспериментатор"
+#: web/templates/web/_footer.html:14
+msgid "Privacy"
+msgstr ""
 
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Исследования"
+#: web/templates/web/_footer.html:17
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact us"
+msgstr "Контакты:"
 
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "FAQ"
+#: web/templates/web/_footer.html:20
+msgid "Connect"
+msgstr ""
 
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "Исследователи"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "Ресурсы"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "Здравствуйте!"
-
-#: web/templates/web/_navigation.html:47
+#: web/templates/web/_navigation.html:3
 msgid "Logout"
 msgstr "Выход"
 
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "Зарегистрироваться"
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Экспериментатор"
 
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Дети"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "Отмена"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Добавить ребенка"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
 msgid "Child"
 msgstr "Ребенок"
 
-#: web/templates/web/child-update.html:26
+#: web/templates/web/child-update.html:14
 #, fuzzy
 #| msgid "Back to list"
 msgid "Back to Children List"
 msgstr "Вернуться к списку"
 
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Обновить"
-
-#: web/templates/web/child-update.html:41
+#: web/templates/web/child-update.html:15
 msgid "Delete"
 msgstr "Удалить"
 
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "Отмена"
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Сохранить"
 
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Не указана дата рождения"
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Обновить"
 
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr " день"
-
-#: web/templates/web/children-list.html:47
-#, fuzzy
-msgid " days"
-msgstr " дней"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr " месяц"
-
-#: web/templates/web/children-list.html:49
-#, fuzzy
-msgid " months"
-msgstr " месяцев"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr " год"
-
-#: web/templates/web/children-list.html:51
-#, fuzzy
-msgid " years"
-msgstr " лет"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Добавить ребенка"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Скрыть форму"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "Имя"
-
-#: web/templates/web/children-list.html:121
+#: web/templates/web/children-list.html:9
 msgid "Update child"
 msgstr "Обновить данные ребенка"
 
-#: web/templates/web/children-list.html:128
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "Имя"
+
+#: web/templates/web/children-list.html:64
 msgid "No child profiles registered!"
 msgstr "Нет зарегистрированых профилей детей!"
 
-#: web/templates/web/demographic-data-update.html:4
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr ""
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr ""
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+#, fuzzy
+#| msgid "researcher login"
+msgid "For researchers"
+msgstr "Вход для исследователя"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Документация"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
 msgid "Update demographics"
 msgstr "Обновить демографические данные"
 
-#: web/templates/web/demographic-data-update.html:89
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
 #, fuzzy
 msgid ""
 "One reason we are developing Internet-based experiments is to represent a "
@@ -1258,7 +1646,7 @@ msgstr ""
 "а также оценить влияние таких факторов, как владение несколькими языками или "
 "наличие старших братьев и/или сестер, влияют на то, как дети учатся."
 
-#: web/templates/web/demographic-data-update.html:90
+#: web/templates/web/demographic-data-update.html:47
 msgid ""
 "Even if you allow your study videos to be published for scientific or "
 "publicity purposes, your demographic information is never published in "
@@ -1268,132 +1656,1555 @@ msgstr ""
 "которые были записаны в ходе исследования, Ваша демографическая информация "
 "никогда не будет опубликована вместе с видео. "
 
-#: web/templates/web/participant-email-preferences.html:27
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: web/templates/web/faq.html:12
+#, fuzzy
+#| msgid "Participate"
+msgid "Participation"
+msgstr "Участвовать"
+
+#: web/templates/web/faq.html:22
+msgid "What is a 'study' about cognitive development?"
+msgstr ""
+
+#: web/templates/web/faq.html:30
+msgid ""
+"\n"
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
+
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
+msgid ""
+"\n"
+"                            <p>If you have a child and would like to "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Who creates the studies?"
+msgstr "Ваши прошлые исследования"
+
+#: web/templates/web/faq.html:114
+#, python-format
+msgid ""
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+#, fuzzy
+#| msgid "We are not running any studies at this time!"
+msgid "Why are you running studies online instead of in person?"
+msgstr "Сейчас мы не проводим никаких исследований!"
+
+#: web/templates/web/faq.html:159
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:184
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How do we provide consent to participate?"
+msgstr "Войдите, чтобы принять участие"
+
+#: web/templates/web/faq.html:191
+msgid ""
+"\n"
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
+"holds the same weight as a signed form, but should be less hassle for you. "
+"It also lets us verify that you understand written English and that you "
+"understand you're being videotaped.</p>\n"
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:215
+msgid "How is our information kept secure and confidential?"
+msgstr ""
+
+#: web/templates/web/faq.html:223
+msgid ""
+"\n"
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
+"instance, they never publish children's names or birthdates, or information "
+"that could be used to calculate a birthdate.</p>\n"
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
+"encrypted at rest. We take security very seriously; in addition to making "
+"sure any software we use is up-to-date, cloud servers are configured "
+"securely, and unit tests cover checking that accessing data requires correct "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:239
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Who will see our video?"
+msgstr "Какого Вы пола?"
+
+#: web/templates/web/faq.html:246
+msgid ""
+"\n"
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
+"govern what data they can share and what sorts of studies are okay to run on "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
+"Databrary. Data sharing will lead to faster progress in research on human "
+"development and behavior. Researchers who are granted access to the "
+"Databrary library must agree to treat the data with the same high standard "
+"of care they would use in their own laboratories. Learn more about "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:269
+msgid "What information do researchers use from our video?"
+msgstr ""
+
+#: web/templates/web/faq.html:278
+msgid ""
+"For children under about two years old, we usually design our studies to let "
+"their eyes do the talking! We're interested in where on the screen your "
+"child looks and/or how long your child looks at the screen rather than "
+"looking away. Our calibration videos (example shown below) help us get an "
+"idea of what it looks like when your child is looking to the right or the "
+"left, so we can code the rest of the video."
+msgstr ""
+
+#: web/templates/web/faq.html:290
+msgid ""
+"Here's an example of a few children watching our calibration video--it's "
+"easy to see that they look to one side and then the other."
+msgstr ""
+
+#: web/templates/web/faq.html:302
+msgid ""
+"Your child's decisions about where to look can give us lots of information "
+"about what he or she understands. Here are some of the techniques labs use "
+"to learn more about how children learn."
+msgstr ""
+
+#: web/templates/web/faq.html:304
+#, fuzzy
+#| msgid "Duration"
+msgid "Habituation"
+msgstr "Продолжительность"
+
+#: web/templates/web/faq.html:305
+msgid ""
+"\n"
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:308
+msgid "Violation of expectation"
+msgstr ""
+
+#: web/templates/web/faq.html:310
+msgid ""
+"Infants and children already have rich expectations about how events work. "
+"Children (and adults for that matter) tend to look longer at things they "
+"find surprising, so in some cases, we can take their looking times as a "
+"measure of how surprised they are."
+msgstr ""
+
+#: web/templates/web/faq.html:312
+msgid "Preferential looking"
+msgstr ""
+
+#: web/templates/web/faq.html:314
+msgid ""
+"Even when they seem to be passive observers, children are making lots of "
+"decisions about where to look and what to pay attention to. In this "
+"technique, we present children with a choice between two side-by-side images "
+"or videos, and see if children spend more time looking at one of them. We "
+"may additionally play audio that matches one of the videos. The video below "
+"shows a participant looking to her left when asked to 'find clapping'; the "
+"display she's watching is shown at the top."
+msgstr ""
+
+#: web/templates/web/faq.html:325
+msgid "Predictive looking"
+msgstr ""
+
+#: web/templates/web/faq.html:327
+msgid ""
+"Children can often make sophisticated predictions about what they expect to "
+"see or hear next. One way we can see those predictions in young children is "
+"to look at their eye movements. For example, if a child sees a ball roll "
+"behind a barrier, she may look to the other edge of the barrier, expecting "
+"the ball to emerge there. We may also set up artificial predictive "
+"relationships--for instance, the syllable 'da' means a toy will appear at "
+"the left of the screen, and 'ba' means a toy will appear at the right. Then "
+"we can see whether children learn these relationships, and how they "
+"generalize, by watching where they look when they hear a syllable."
+msgstr ""
+
+#: web/templates/web/faq.html:330
+msgid ""
+"Older children may simply be able to answer spoken questions about what they "
+"think is happening. For instance, in a recent study, two women called an "
+"object two different made-up names, and children were asked which is the "
+"correct name for the object."
+msgstr ""
+
+#: web/templates/web/faq.html:342
+msgid ""
+"Another way we can learn about how older children (and adults) think is to "
+"measure their reaction times. For instance, we might ask you to help your "
+"child learn to press one key when a circle appears and another key when a "
+"square appears, and then look at factors that influence how quickly they "
+"press a key."
+msgstr ""
+
+#: web/templates/web/faq.html:355
+msgid ""
+"My child wasn't paying attention, or we were interrupted. Can we try the "
+"study again?"
+msgstr ""
+
+#: web/templates/web/faq.html:364
+msgid ""
+"Certainly--thanks for your dedication! You may see a warning that you have "
+"already participated in the study when you go to try it again, but you can "
+"ignore it. You don't need to tell us that you tried the study before; we'll "
+"have a record of your previous participation."
+msgstr ""
+
+#: web/templates/web/faq.html:377
+msgid ""
+"My child is outside the age range. Can he/she still participate in this "
+"study?"
+msgstr ""
+
+#: web/templates/web/faq.html:386
+msgid ""
+"Sure! We may not be able to use his or her data in our research directly, "
+"but if you're curious you're welcome to try the study anyway. (Sometimes big "
+"siblings really want their own turn!) If your child is just below the "
+"minimum age for a study, however, we encourage you to wait so that we'll be "
+"able to use the data."
+msgstr ""
+
+#: web/templates/web/faq.html:399
+msgid "My child was born prematurely. Should we use his/her adjusted age?"
+msgstr ""
+
+#: web/templates/web/faq.html:408
+msgid ""
+"For study eligibility, we usually use the child's chronological age (time "
+"since birth), even for premature babies. If adjusted age is important for a "
+"particular study, we will make that clear in the study eligibility criteria."
+msgstr ""
+
+#: web/templates/web/faq.html:421
+msgid ""
+"Our family speaks a language other than English at home. Can my child "
+"participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:430
+msgid ""
+"Sure! Right now, instructions for children and parents are written only in "
+"English, so some of them may be confusing to a child who does not hear "
+"English regularly. However, you're welcome to try any of the studies and "
+"translate for your child if you can. If it matters for the study whether "
+"your child speaks any languages besides English, we'll ask specifically. You "
+"can also indicate the languages your child speaks or is learning to speak on "
+"your demographic survey."
+msgstr ""
+
+#: web/templates/web/faq.html:443
+msgid ""
+"My child has been diagnosed with a developmental disorder or has special "
+"needs. Can he/she still participate?"
+msgstr ""
+
+#: web/templates/web/faq.html:451
+msgid ""
+"\n"
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:466
+msgid ""
+"I have multiple children in the age range for a study. Can they participate "
+"together?"
+msgstr ""
+
+#: web/templates/web/faq.html:475
+msgid ""
+"If possible, we ask that each child participate separately. When children "
+"participate together they generally influence each other. That's a "
+"fascinating subject in its own right but usually not the focus of our "
+"research."
+msgstr ""
+
+#: web/templates/web/faq.html:488
+msgid "But I've heard that young children should avoid 'screen time.'"
+msgstr ""
+
+#: web/templates/web/faq.html:496
+msgid ""
+"\n"
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
+"people, not screens! However, our studies are not intended to educate "
+"children, but to learn from them.</p>\n"
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:510
+msgid "Will we be paid for our participation?"
+msgstr ""
+
+#: web/templates/web/faq.html:518
+msgid ""
+"Some research groups provide gift cards or other compensation for completing "
+"their studies, and others rely on volunteers. (This often depends on the "
+"rules of the university that's doing the research.) This information will be "
+"listed on the study description page."
+msgstr ""
+
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
+
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
+msgid ""
+"\n"
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
+msgid "Technical"
+msgstr ""
+
+#: web/templates/web/faq.html:652
+msgid "What browsers are supported?"
+msgstr ""
+
+#: web/templates/web/faq.html:660
+msgid ""
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
+msgstr ""
+
+#: web/templates/web/faq.html:672
+msgid "Can we do a study on my phone or tablet?"
+msgstr ""
+
+#: web/templates/web/faq.html:679
+msgid ""
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
+
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "В каком регионе Вы живете?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "researcher login"
+msgid "For Researchers"
+msgstr "Вход для исследователя"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Сколько Вам лет?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Войдите, чтобы принять участие"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Исследователи"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participate"
+msgid "Participate in a Study"
+msgstr "Участвовать"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Главная страница"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
 msgid "I would like to be contacted when:"
 msgstr "Я хотел(-а) бы, чтобы со мной связались, когда:"
 
-#: web/templates/web/participant-signup.html:18
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Войдите, чтобы принять участие"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Cоздать учетную запись"
+
+#: web/templates/web/participant-signup.html:13
 #, fuzzy
 #| msgid "Participant account"
 msgid "Create Participant Account"
 msgstr "Учетная запись участника"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+msgid "To make a researcher account, please use"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+msgid "instead."
+msgstr "вместо?"
+
+#: web/templates/web/participant-signup.html:28
 msgid ""
 "By clicking 'Create Account', I agree that I have read and accepted the "
 msgstr ""
 "Нажимая \"Создать учетную запись\", я подтверждаю, что прочитал(-а) и "
 "принял(-а)"
 
-#: web/templates/web/participant-signup.html:31
+#: web/templates/web/participant-signup.html:28
 msgid "Privacy Statement"
 msgstr "Заявление о конфиденциальности"
 
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Cоздать учетную запись"
+#: web/templates/web/privacy.html:9
+#, fuzzy
+#| msgid "Privacy Statement"
+msgid "Privacy statement"
+msgstr "Заявление о конфиденциальности"
 
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/privacy.html:11
+msgid "Introduction"
+msgstr ""
+
+#: web/templates/web/privacy.html:14
+msgid ""
+"Lookit is committed to supporting the privacy of individuals who enroll on "
+"our Platform to conduct\n"
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
+msgstr ""
+
+#: web/templates/web/privacy.html:19
+#, fuzzy
+#| msgid "All Participants"
+msgid "For participants"
+msgstr "Все участники"
+
+#: web/templates/web/privacy.html:22
+msgid ""
+"Lookit is a platform that many different researchers use to conduct studies "
+"about how children learn and\n"
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
+msgstr ""
+
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
+msgid "What personal information we collect"
+msgstr ""
+
+#: web/templates/web/privacy.html:30
+msgid "We collect the following kinds of personal information:"
+msgstr ""
+
+#: web/templates/web/privacy.html:33
+msgid ""
+"<ul>\n"
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
+"child(ren), including nickname, date of birth,\n"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
+msgid "How we collect personal information about you"
+msgstr ""
+
+#: web/templates/web/privacy.html:48
+msgid ""
+"The information we collect and maintain about you is the information you "
+"provide to us when registering\n"
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
+msgstr ""
+
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
+msgid "When we share your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:56
+msgid ""
+"When you participate in a Lookit study, we share the following information "
+"with the research group conducting the study:"
+msgstr ""
+
+#: web/templates/web/privacy.html:60
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
+msgstr ""
+
+#: web/templates/web/privacy.html:68
+msgid ""
+"Your email address is not shared directly with the research group, although "
+"they can contact you via Lookit in accordance with your contact preferences."
+msgstr ""
+
+#: web/templates/web/privacy.html:71
+msgid ""
+"Researchers may publish the results of a study, including individual "
+"responses. However, although they\n"
+"        may publish the ages of participants, they may not publish "
+"participant birthdates (or information that\n"
+"    could be used to calculate birthdates)."
+msgstr ""
+
+#: web/templates/web/privacy.html:76
+msgid ""
+"We and/or the researchers responsible for a study may share video of your "
+"family’s participation for\n"
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:84
+msgid ""
+"We don’t share, sell, publish, or otherwise disclose your contact "
+"information (email and/or mailing\n"
+"        address) to anyone but the researchers involved in a study. "
+"Researchers must also agree not to disclose\n"
+"        your contact information in order to use Lookit."
+msgstr ""
+
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
+msgid "How we use your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:92
+msgid ""
+"We may use your personal information (account, child, demographic, and study "
+"data) for a variety of purposes, including to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:94
+msgid ""
+"<ul>\n"
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:113
+msgid ""
+"Researchers use the data collected in their studies to address particular "
+"scientific questions. It may\n"
+"            also turn out that data collected for one study can help to "
+"answer a related question later on. If\n"
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
+msgstr ""
+
+#: web/templates/web/privacy.html:120
+msgid ""
+"There are some basic rules about how personal information may be used that "
+"all Lookit researchers agree to, including:"
+msgstr ""
+
+#: web/templates/web/privacy.html:122
+msgid ""
+"\n"
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
+"information as a subject of research.</li>\n"
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+msgid ""
+"If you have concerns about any of these purposes, or how we communicate with "
+"you, please contact us at\n"
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
+msgstr ""
+
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
+msgid "How your information is stored and secured"
+msgstr ""
+
+#: web/templates/web/privacy.html:138
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
+msgstr ""
+
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
+msgid "How long we keep your personal information"
+msgstr ""
+
+#: web/templates/web/privacy.html:153
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
+msgstr ""
+
+#: web/templates/web/privacy.html:165
+msgid ""
+"We may collect basic biographic/contact information about you and your "
+"representative organization,\n"
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
+msgstr ""
+
+#: web/templates/web/privacy.html:172
+msgid ""
+"The information we collect and maintain about you is that which you have "
+"provided to us when registering\n"
+"        to use Lookit, updating your profile, or creating or editing a study."
+msgstr ""
+
+#: web/templates/web/privacy.html:179
+msgid ""
+"We use your personal information for a number of legitimate purposes, "
+"including the performance of contractual obligations. Specifically, we use "
+"your personal information to:"
+msgstr ""
+
+#: web/templates/web/privacy.html:181
+msgid ""
+"<ul>\n"
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
+msgstr ""
+
+#: web/templates/web/privacy.html:196
+msgid "We do not share your personal information with any third parties."
+msgstr ""
+
+#: web/templates/web/privacy.html:201
+#, python-format
+msgid ""
+"We have implemented industry-standard security safeguards designed to "
+"protect the personal information\n"
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
+msgstr ""
+
+#: web/templates/web/privacy.html:214
+msgid ""
+"We consider our relationship with our research community to be lifelong. "
+"This means that we will maintain\n"
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
+msgstr ""
+
+#: web/templates/web/privacy.html:220
+msgid "For everyone"
+msgstr ""
+
+#: web/templates/web/privacy.html:221
+msgid "Rights for individuals in the European Economic Area"
+msgstr ""
+
+#: web/templates/web/privacy.html:224
+msgid ""
+"You have the right in certain circumstances to (1) access your personal "
+"information; (2) to correct or\n"
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
+"Protection Regulation provides further\n"
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
+msgstr ""
+
+#: web/templates/web/privacy.html:231
+msgid ""
+"If you are inclined to exercise these rights, we request an opportunity to "
+"discuss with you any concerns\n"
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
+"inadvertently in the future, as well as any\n"
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
+msgstr ""
+
+#: web/templates/web/privacy.html:241
+msgid ""
+"By providing information directly to Lookit, you consent to the transfer of "
+"your personal information\n"
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
+msgstr ""
+
+#: web/templates/web/privacy.html:246
+msgid ""
+"You are under no statutory or contractual obligation to provide any personal "
+"data to us."
+msgstr ""
+
+#: web/templates/web/privacy.html:248
+#, fuzzy
+#| msgid "Additional Info"
+msgid "Additional Information"
+msgstr "Дополнительная информация"
+
+#: web/templates/web/privacy.html:251
+msgid ""
+"We may change this Privacy Statement from time to time. If we make any "
+"significant changes in the way we\n"
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
+msgstr ""
+
+#: web/templates/web/privacy.html:255
+msgid ""
+"The controller for your personal information is MIT. We can be contacted at "
+"dataprotection@mit.edu."
+msgstr ""
+
+#: web/templates/web/privacy.html:257
+msgid "This policy was last updated in June 2018."
+msgstr ""
+
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
+msgstr ""
+
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
+msgstr ""
+
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
+msgid ""
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
+msgstr ""
+
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Прошлые исследования"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
-msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+#: web/templates/web/studies-history.html:15
+msgid "Next Video"
 msgstr ""
-"Эта страница недоступна для Вашей учетной записи. Чтобы продолжить, войдите "
-"в систему используя учетную запись, для которой открыт доступ."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Пожалуйста, войдите, чтобы увидеть эту страницу."
+#: web/templates/web/studies-history.html:31
+msgid ""
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Текущие исследования"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Ваши прошлые исследования"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Здесь вы можете просмотреть свои исследования и комментарии, которые "
 "оставили исследователи:"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 #, fuzzy
 msgid "Study Thumbnail"
 msgstr "Обзор исследования"
 
-#: web/templates/web/studies-history.html:79
+#: web/templates/web/studies-history.html:55
 #, fuzzy
-msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Условия участия:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "Контакты:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Вы еще собираете данные?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Да"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Нет"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Компенсация: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Компенсация"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 #, fuzzy
 msgid "Study Responses"
 msgstr "Отклик на исследование"
 
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Дата"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Статус согласия"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Одобрено"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Ваше видеосогласие было рассмотрено исследователем и является действительным."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 #, fuzzy
 msgid "Pending"
 msgstr "Рассматривается"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "Ваше видеосогласие еще не было рассмотрено исследователем."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Недействительно"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -1403,159 +3214,182 @@ msgstr ""
 "видно, что Вы читаете заявление о согласии вслух. Другие Ваши данные из этой "
 "сессии не будут просматриваться или использоваться исследователями."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr "Информация о статусе верификации видеосогласия отсутствует."
 
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:131
+msgid "Feedback"
+msgstr ""
+
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Вы еще не участвовали в исследованиях."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Текущие исследования"
+#: web/templates/web/studies-history.html:147
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Вы еще не участвовали в исследованиях."
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Исследования"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Обратите внимание, что для участия Вам понадобится ноутбук или компьютер "
-"(мобильное устройство не подойдет), на котором установлен браузер Chrome или "
-"Firefox."
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Смотрите подробности"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "Сейчас мы не проводим никаких исследований!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"Вам интересно, как еще можно внести вклад в науку, находясь дома? Посетите "
-"<a href=\"https://childrenhelpingscience.com/\" target=\"_blank\" rel="
-"\"noreferrer noopener\"> Children Helping Science </a>, где Вы найдете ещё "
-"больше исследований!"
 
-#: web/templates/web/study-detail.html:53
-#, fuzzy
-msgid "days"
-msgstr " дней"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:93
-#, fuzzy
-msgid "Study overview"
-msgstr "Об исследовании"
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Вернуться к списку"
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ресурсы"
 
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Критерии участия"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Продолжительность"
+#: web/templates/web/study-detail.html:17
+msgid "preview"
+msgstr ""
 
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Компенсация"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Что будет происходить"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Что мы изучаем"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Это исследование проводится"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Хотели бы вы принять участие в этом исследовании?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Войдите, чтобы принять участие"
-
-#: web/templates/web/study-detail.html:142
-#, fuzzy
-#| msgid "No child profiles registered!"
-msgid "Add child profile to "
-msgstr "Нет зарегистрированых профилей детей!"
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 #, fuzzy
 #| msgid "Participate"
 msgid "participate"
 msgstr "Участвовать"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr ""
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Создайте среду запуска эксперимента для предварительного просмотра"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Войдите, чтобы принять участие"
+
+#: web/templates/web/study-detail.html:22
+#, fuzzy
+#| msgid "No child profiles registered!"
+msgid "Add child profile to "
+msgstr "Нет зарегистрированых профилей детей!"
+
+#: web/templates/web/study-detail.html:23
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Complete demographic survey to "
 msgstr "Демографическая анкета"
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Участвовать"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Что будет происходить"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Что мы изучаем"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Продолжительность"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Это исследование проводится"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Хотели бы вы принять участие в этом исследовании?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Выберите ребенка:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Ничего не выбрано"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Ваш ребенок все еще младше рекомендованного возрастного диапазона для этого "
 "исследования. Если Вы подождёте <span id = 'wait-until'>, пока </span> он "
 "или она подрастет, мы сможем использовать собранные данные в нашем "
 "исследовании!"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Ваш ребенок старше рекомендованного возрастного диапазона для этого "
 "исследования. Вы все равно можете принять участие в исследовании, но мы не "
 "сможем использовать собранные данные."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Ваш ребенок не соответствует критериям отбора для этого исследования. Вы все "
 "равно можете принять участие, но мы не сможем использовать собранные данные. "
 "Пожалуйста, свяжитесь с исследователями. "
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Создайте среду запуска эксперимента для предварительного просмотра"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Участвовать"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -1564,33 +3398,273 @@ msgstr ""
 "добавьте в закладки URL-адрес, на который Вы можете перейти, нажав кнопку "
 "выше."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Зарегистрироваться"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Обратите внимание, что для участия Вам понадобится ноутбук или компьютер "
+"(мобильное устройство не подойдет), на котором установлен браузер Chrome или "
+"Firefox."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 #, fuzzy
 #| msgid "Participant account"
 msgid "Participant created."
 msgstr "Учетная запись участника"
 
-#: web/views.py:88
+#: web/views.py:157
 #, fuzzy
 #| msgid "Demographic Survey"
 msgid "Demographic data saved."
 msgstr "Демографическая анкета"
 
-#: web/views.py:156
+#: web/views.py:223
 #, fuzzy
 #| msgid "Children"
 msgid "Child added."
 msgstr "Дети"
 
-#: web/views.py:217
+#: web/views.py:264
+#, fuzzy
+#| msgid "Children"
+msgid "Child deleted."
+msgstr "Дети"
+
+#: web/views.py:266
+#, fuzzy
+#| msgid "Children"
+msgid "Child updated."
+msgstr "Дети"
+
+#: web/views.py:294
 #, fuzzy
 #| msgid "Email Preferences"
 msgid "Email preferences saved."
 msgstr "Настройки электронной почты"
 
+#: web/views.py:699
+#, python-brace-format
+msgid ""
+"The study {study.name} is not currently collecting data - the study is "
+"either completed or paused. If you think this is an error, please contact "
+"{study.contact_info}"
+msgstr ""
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr ""
+#~ "Как бы Вы охарактеризовали \n"
+#~ "Вашу семью?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Только числовые ответы; Вы можете ответить приблизительно!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "На каком языке (языках) в Вашей семье говорят дома?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr ""
+#~ "Самый высокий уровень образования, который получил(-а) Ваш супруг(-а)?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Сколько примерно детских книг у Вас дома?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Если ситуация меняется из-за договоренности о совместной опеке или "
+#~ "длительных поездок одного из родителей/опекунов, укажите количество "
+#~ "родителей/опекунов, с которыми обычно проживают Ваши дети, или поясните "
+#~ "дополнительно."
+
+#~ msgid "other"
+#~ msgstr "другой"
+
+#~ msgid "3 or more"
+#~ msgstr "3 и более"
+
+#~ msgid "varies"
+#~ msgstr "варьируется"
+
+#~ msgid "My Account"
+#~ msgstr "Мой аккаунт"
+
+#~ msgid "Last Active:"
+#~ msgstr "Последнее посещение:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "Глобальный ID участника:"
+
+#~ msgid "Dashboard"
+#~ msgstr "Управление"
+
 #, fuzzy
-#~ msgid "instead"
-#~ msgstr "вместо?"
+#~| msgid "Yes"
+#~ msgid "Yue"
+#~ msgstr "Да"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#, fuzzy
+#~| msgid "Log in to participate"
+#~ msgid "How can we participate online?"
+#~ msgstr "Войдите, чтобы принять участие"
+
+#, fuzzy
+#~| msgid "Your username and password didn't match. Please try again."
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr ""
+#~ "Ваше имя пользователя и/или пароль введены неверно. Пожалуйста, "
+#~ "попробуйте еще раз."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Впервые на Lookit?"
+
+#~ msgid "New password:"
+#~ msgstr "Новый пароль:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Подтвердить пароль:"
+
+#, fuzzy, python-format
+#~ msgid "The %(site_name)s team"
+#~ msgstr "Команда % (site_name) s"
+
+#~ msgid "Email address:"
+#~ msgstr "Адрес электронной почты:"
+
+#~ msgid "FAQ"
+#~ msgstr "FAQ"
+
+#~ msgid "Hi"
+#~ msgstr "Здравствуйте!"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Не указана дата рождения"
+
+#~ msgid " day"
+#~ msgstr " день"
+
+#, fuzzy
+#~ msgid " days"
+#~ msgstr " дней"
+
+#~ msgid " month"
+#~ msgstr " месяц"
+
+#, fuzzy
+#~ msgid " months"
+#~ msgstr " месяцев"
+
+#~ msgid " year"
+#~ msgstr " год"
+
+#, fuzzy
+#~ msgid " years"
+#~ msgstr " лет"
+
+#~ msgid "Hide Form"
+#~ msgstr "Скрыть форму"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Эта страница недоступна для Вашей учетной записи. Чтобы продолжить, "
+#~ "войдите в систему используя учетную запись, для которой открыт доступ."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Пожалуйста, войдите, чтобы увидеть эту страницу."
+
+#~ msgid "Compensation: "
+#~ msgstr "Компенсация: "
+
+#~ msgid "Current Studies"
+#~ msgstr "Текущие исследования"
+
+#~ msgid "See details"
+#~ msgstr "Смотрите подробности"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Сейчас мы не проводим никаких исследований!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Вам интересно, как еще можно внести вклад в науку, находясь дома? "
+#~ "Посетите <a href=\"https://childrenhelpingscience.com/\" "
+#~ "target=\"_blank\" rel=\"noreferrer noopener\"> Children Helping Science </"
+#~ "a>, где Вы найдете ещё больше исследований!"
+
+#, fuzzy
+#~ msgid "days"
+#~ msgstr " дней"
+
+#, fuzzy
+#~ msgid "Study overview"
+#~ msgstr "Об исследовании"
+
+#~ msgid "Back to list"
+#~ msgstr "Вернуться к списку"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Критерии участия"
 
 #~ msgid "Login Unsuccessful"
 #~ msgstr "Не удалось войти"
@@ -1637,8 +3711,8 @@ msgstr "Настройки электронной почты"
 #~ "      <p>\n"
 #~ "        Используя Lookit или запрашивая доступ к нему, вы соглашаетесь с "
 #~ "тем, что прочитали и приняли <a href=\"/termsofuse/\" target=\"_blank\"> "
-#~ "Условия использования </a> и <a href = \"/ privacy /\" target = \"_ blank"
-#~ "\"> Заявление о конфиденциальности </a>.\n"
+#~ "Условия использования </a> и <a href = \"/ privacy /\" target = \"_ "
+#~ "blank\"> Заявление о конфиденциальности </a>.\n"
 #~ "        "
 
 #~ msgid ""
@@ -1666,6 +3740,3 @@ msgstr "Настройки электронной почты"
 
 #~ msgid "Signup"
 #~ msgstr "Регистрация"
-
-#~ msgid "Update account information"
-#~ msgstr "Обновить информацию об учетной записи"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -3323,10 +3323,8 @@ msgstr "Продолжительность"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Это исследование проводится"
+msgstr "Это исследование проводится %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -4299,10 +4299,8 @@ msgstr "Süre"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "Bu çalışma şu kişiler tarafından yürütülmektedir"
+msgstr "Bu çalışma şu kişiler tarafından yürütülmektedir %(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-15 17:00+0200\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr ""
 "Google Authenticator'dan 6 basamaklı geçerli bir tek kullanımlık şifre girin"
@@ -36,42 +36,24 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "Bu hesap aktif değil."
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr "Şifreniz diğer kişisel bilgilerinizle çok benzer olamaz. "
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "Şifreniz en az 16 karakter içermelidir."
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "Şifreniz sık kullanılan bir şifre olamaz."
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "Şifreniz tamamen sayısal olamaz."
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "Email adresi"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "Takma ad"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "Şu anda katıldığımız çalışmanın başka bir oturumunun zamanı geldi"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "Çocuklarımdan biri için uygun olan yeni bir çalışma var"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
@@ -79,7 +61,7 @@ msgstr ""
 "Katıldığımız bir çalışma ile ilgili bir gelişme mevcut(örneğin, sonuçlar "
 "yayınlandı)"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
@@ -87,100 +69,92 @@ msgstr ""
 "Araştırmacının bireysel yanıtlarımla ilgili soruları var (örneğin, çalışma "
 "esnasında teknik bir problemi rapor edersem)"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "Hangi kategori(ler) ailenizi tanımlıyor?"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "Ülke"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "Virgülle ayrılmış listeyi giriniz: YYYY-AA-GG, YYYY-AA-GG, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "Yalnızca sayısal cevaplar- kabaca bir tahmin uygundur!"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "Hangi ülkede yaşıyorsunuz?"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "Hangi ilde yaşıyorsunuz?"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "Yaşadığınız bölgeyi nasıl tanımlarsınız?"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "Aileniz evinizde hangi dil(ler)i konuşuyor?"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "Kaç tane çocuğunuz var?"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "Lütfen her bir çocuğunuzun doğum tarihini girin: "
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "Çocuğunuz kaç ebeveyn/bakıcı ile birlikte yaşıyor?"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "Yaşınız kaç?"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "Cinsiyetiniz nedir?"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "Cinsiyetiniz nedir?"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "Tamamladığınız en yüksek eğitim seviyesi nedir?"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "Eşinizin tamamladığı en yüksek eğitim seviyesi nedir?"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "Ailenizin yıllık geliri ortalama ne kadar (Türk Lirası)?"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "Evinizde tahmini kaç tane çocuk kitabı var?"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "Bilmemizi istediğiniz başka bir şey var mı?"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "Lookit'den nasıl haberdar oldunuz?"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"Eğer cevabınız ortak velayet düzenlemelerine veya seyahatlere göre "
-"değişiyorsa, lütfen çocuğunuzun genellikle birlikte yaşadığı ebeveyn/bakıcı "
-"sayısını belirtin veya açıklayın."
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "Doğum tarihi"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "Başka bir ırk, etnisite veya köken"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -190,39 +164,42 @@ msgstr ""
 "anlamamızı sağlar. Çocukların doğum tarihlerini veya okuyucunun doğum "
 "tarihini hesaplamasını sağlayacak bilgileri asla yayınlamayız."
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "Doğum tarihi gelecek bir zamanda olamaz."
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "İsim"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "Doğum tarihi"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "Cinsiyet"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "Doğum Haftası"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "Bilmemizi istediğiniz başka ek bilgi"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "Özellikler ve şartlar"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
 msgstr "Bu çocuğun evde, okulda veya başka bir bakıcıdan maruz kaldığı diller."
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -234,511 +211,600 @@ msgstr ""
 "emaile ekleyebiliriz (örneğin, \"Merve için uygun olan yeni bir çalışma var!"
 "\") ama isimleri asla yayınlamayız veya araştırmalarımızda kullanmayız."
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr ""
 "Örneğin, tanı almış gelişimsel bozukluklar ya da görme veya işitme "
 "problemleri"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "Lütfen hamilelik haftasını tamamlanan en yakın tam haftaya yuvarlayın"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "Çalışmalar"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "Mevcut çalışmalar"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+#, fuzzy
+#| msgid "Meet the Lookit team"
+msgid "here on the Lookit platform"
+msgstr "Lookit ekibiyle tanışın"
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "Geçmiş çalışmalarınız"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "Mevcut çalışmalar"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "Emin değilim veya cevap vermemeyi tercih ediyorum"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "24 haftanın altında"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39 hafta"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40 veya daha fazla hafta"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "Organizasyonu Görüntüleyebilir"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "Organizasyonu Düzenleyebilir"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "Organizasyon Oluşturabilir"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "Organizasyonu Kaldırabilir"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "Deneyciyi Görüntüleyebilir"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "Analitikleri Görüntüleyebilir"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "Kullanıcı Yaratabilir"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "Kullanıcı Görüntüleyebilir"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "Kullanıcıyı Düzenleyebilir"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "Kullanıcıyı Kaldırabilir"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "Kullanıcı İzinlerini Görüntüleyebilir"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "Kullanıcı İzinlerini Düzenleyebilir"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "Bütün Kullanıcıların Verilerini Okuyabilir"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "Kullanıcıların Kullanıcı adlarını Okuyabilir"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "erkek"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "kadın"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "diğer"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "cevaplamamayı tercih ediyorum"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "Organizasyonu Görüntüleyebilir"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "Organizasyonu Düzenleyebilir"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "Organizasyon Oluşturabilir"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "Organizasyonu Kaldırabilir"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "Deneyciyi Görüntüleyebilir"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "Analitikleri Görüntüleyebilir"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "Kullanıcı Yaratabilir"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "Kullanıcı Görüntüleyebilir"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "Kullanıcıyı Düzenleyebilir"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "Kullanıcıyı Kaldırabilir"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "Kullanıcı İzinlerini Görüntüleyebilir"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "Kullanıcı İzinlerini Düzenleyebilir"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "Bütün Kullanıcıların Verilerini Okuyabilir"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "Kullanıcıların Kullanıcı adlarını Okuyabilir"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "Beyaz"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "Hispanik, Latin veya İspanyol kökenli"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "Siyahi veya Afrikalı Amerikalı"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "Asyalı"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "Amerikan Yerlisi veya Alaska Yerlisi"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "Orta Doğulu veya Kuzey Afrikalı"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "Hawaiian Yerlisi veya Diğer Pasifik Adasından"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "Başka bir ırk, etnisite veya köken"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "Lise terk veya lise öğrencisi"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "Lise diploması veya muadili"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "Üniversite terk veya üniversite öğrencisi"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "İki yıllık üniversite mezunu"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "Dört yıllık üniversite mezunu"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "Yüksek lisans veya meslek yüksekokulu terk veya öğrencisi"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "Yüksek lisans veya meslek yüksekokulu mezunu"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "geçersiz - eş veya partnerim yok"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "11"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "18 yaş altı"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70 veya üstü"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3 veya daha fazla"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "değişiyor"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "5000"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "10000"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "15000"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "20000"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "30000"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "40000"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "50000"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "60000"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "70000"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "80000"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "90000"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "100000"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "110000"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "120000"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "130000"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "140000"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "150000"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "160000"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "170000"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "180000"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "190000"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "200000 üstü"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "kentsel"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "banliyö"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "kırsal"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "Bölge Seçiniz"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "Gan"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "Hesap Bilgisi"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "Oturum açma bilgilerinizi ve/veya takma adınızı değiştirin."
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "Demografik Anket"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "Bize biraz daha kendinizden bahsedin."
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "Çocuk Bilgisi"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "Katılımcı bilgisi ekle veya düzenle"
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "Email tercihleri"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "İletişime geçilebileceğiniz zamanları düzenle"
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:38 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "Hesabım"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "Hesap Bilgisi"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "Kaydet"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "Şifreni değiştir"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "İki Faktörlü Kimlik Doğrulamayı Yönetin"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -747,11 +813,18 @@ msgstr ""
 "seferlik şifrenizi buraya girin, gönder düğmesine basın ve sizin için "
 "silinecek!"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "İki Faktörlü Kimlik Doğrulamayı ayarlayın."
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "Tüm Katılımcılar"
 
@@ -759,146 +832,63 @@ msgstr "Tüm Katılımcılar"
 msgid "Participant ID"
 msgstr "Katılımcı ID"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "Son aktif olma:"
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "Katılımcı global ID"
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "Çocuk"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "Yaş"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "Ek Bilgi"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "Kayıtlı çocuk profili yok."
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "Son Demografik Veri"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "Ülke"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "Bölge"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "Bölge tarifi"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "Evde konuşulan diller"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "Çocuk sayısı"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "Çocukların güncel yaşları"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "Çalışma Yanıtları"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "Bakıcı sayısı"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "Bakıcılar için Açıklama:"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "Irk"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "Gösterge Paneli"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "Almanca"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "İngilizce"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "İspanyolca"
-
-#: project/settings.py:231
-msgid "Argentinian Spanish"
-msgstr "Arjantin İspanyolcası"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "Fransız"
-
-#: project/settings.py:233
-msgid "Canadian French"
-msgstr "Kanada Fransızcası"
-
-#: project/settings.py:234
-msgid "Hebrew"
-msgstr "İbranice"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "İtalyanca"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "Japonca"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "Korece"
-
-#: project/settings.py:238
-msgid "Norwegian Bokmål"
-msgstr "Norveççe Bokmål"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "Lehçe"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "Portekizce"
-
-#: project/settings.py:241
-msgid "Brazilian Portuguese"
-msgstr "Brezilya Portekizcesi"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "Romence"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "Rusça"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "Türkçe"
-
-#: project/settings.py:245
-msgid "Simplified Chinese"
-msgstr "Basitleştirilmiş Çince"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "Flemenkçe"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -948,6 +938,10 @@ msgstr "Yediz"
 msgid "Octuplet"
 msgstr "Sekiziz"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "İngilizce"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "Amharca"
@@ -972,13 +966,25 @@ msgstr "Cebuano"
 msgid "Chhattisgarhi"
 msgstr "Chhattisgarhi"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "Flemenkçe"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "Mısırda Konuşulan Arapça"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "Fransız"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "Gan"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "Almanca"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -993,162 +999,204 @@ msgid "Hausa"
 msgstr "Hausa"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr "İbranice"
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "Hintçe"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "Igbo"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "Endonezya dili"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "İran Farsçası"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "İtalyanca"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "Japonca"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "Cava dili"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "Jinyu"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "Kannada"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "Khmer"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "Korece"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "Magahi"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "Maithili"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "Malayca"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "Malayalam dili"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "Mandarin"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "Marathi"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "Min Nan"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "Fas Arapçası"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "Kuzey Peştuca"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "Kuzey Özbekçe"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "Odia"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "Lehçe"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "Portekizce"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "Romence"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "Rusça"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "Saraiki"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "Sindice"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "Somali dili"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "İspanyolca"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "Sunda"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "Tagalog"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "Tamilce"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "Telugu"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "Tay dili"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "Türkçe"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "Ukraynaca"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "Urduca"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "Vietnam dili"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "Batı Pencap dili"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "Wu"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "Xiang Çince"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "Yue"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "Cevaplanmadı"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "Diğer"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "Erkek"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "Kadın"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
@@ -1156,35 +1204,199 @@ msgstr ""
 "Bu Lab'a ait olan kullanıcılar. Bu Labdaki kullanıcı, lab ile bağlantılı "
 "çalışmalar yaratabilecek ve bu Lab'ın çalışmalarına eklenebilecektir."
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "Bu Lab'a katılmayı talep eden kullanıcılar"
 
-#: web/templates/frontpages/contact.html:15
-msgid "Technical difficulties"
-msgstr "Teknik zorluklar"
+#: web/templates/registration/logged_out.html:5
+msgid "You've successfully logged out."
+msgstr "Başarılı bir şekilde çıkış yaptınız."
 
-#: web/templates/frontpages/contact.html:17
-msgid "Questions about the studies"
-msgstr "Çalışmalarla ilgili sorular"
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
+msgid "Login"
+msgstr "Giriş yap"
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-msgid "For researchers"
-msgstr "Araştırmacılar için"
+#: web/templates/registration/login.html:25
+msgid "Forgot password?"
+msgstr "Şifrenizi mi unuttunuz?"
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:16 web/templates/web/_navigation.html:21
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/frontpages/default.html:53
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr "Ailenizi kaydedin!"
+
+#: web/templates/registration/password_change_done.html:9
+msgid "Password changed"
+msgstr "Şifre değiştirildi"
+
+#: web/templates/registration/password_change_done.html:12
+msgid "Your password was changed."
+msgstr "Şifreniz değiştirildi."
+
+#: web/templates/registration/password_change_form.html:12
+msgid "Documentation"
+msgstr "Belgeler"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Change password"
+msgstr "Şifreyi değiştir"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Log out"
+msgstr "Çıkış yap"
+
+#: web/templates/registration/password_change_form.html:18
+msgid "Home"
+msgstr "Anasayfa"
+
+#: web/templates/registration/password_change_form.html:19
+msgid "Password change"
+msgstr "Şifre değiştirme"
+
+#: web/templates/registration/password_change_form.html:36
+msgid "Please correct the error below."
+msgstr "Lütfen aşağıdaki hatayı düzeltiniz."
+
+#: web/templates/registration/password_change_form.html:38
+msgid "Please correct the errors below."
+msgstr "Lütfen aşağıdaki hataları düzeltiniz."
+
+#: web/templates/registration/password_change_form.html:43
+msgid ""
+"Please enter your old password, for security's sake, and then enter your new "
+"password twice so we can verify you typed it in correctly."
+msgstr ""
+"Lütfen güvenlik için eski şifrenizi girin ve daha sonra yeni şifrenizi doğru "
+"yazdığınızı onaylayabilmemiz için iki kez girin."
+
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
+msgid "Change my password"
+msgstr "Şifremi değiştir"
+
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "Giriş yap"
+
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "Şifre sıfırlama tamamlandı"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "Şifreniz oluşturuldu. Şimdi giriş yapabilirsiniz."
+
+#: web/templates/registration/password_reset_confirm.html:8
+msgid "Password reset confirmation"
+msgstr "Şifre sıfırlama onayı"
+
+#: web/templates/registration/password_reset_confirm.html:11
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly."
+msgstr ""
+"Lütfen doğru yazdığınızı onaylayabilmemiz için yeni şifrenizi iki kez "
+"giriniz."
+
+#: web/templates/registration/password_reset_confirm.html:21
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+"Şifre sıfırlama bağlantısı geçersizdir çünkü muhtemelen daha önce "
+"kullanıldı. Lütfen yeni bir şifre sıfırlama isteği gönderin."
+
+#: web/templates/registration/password_reset_done.html:6
+msgid "Password reset link sent"
+msgstr "Şifre sıfırlama linki gönderildi"
+
+#: web/templates/registration/password_reset_done.html:9
+msgid ""
+"If an account exists with the email you entered, we've emailed instructions "
+"for resetting your password and you should receive them shortly."
+msgstr ""
+"Eğer girdiğiniz email ile bir hesap mevcutsa, şifre sıfırlama yönergelerini "
+"size email ile gönderdik bu emaili kısa sürede almış olmalısınız."
+
+#: web/templates/registration/password_reset_done.html:12
+msgid ""
+"If you don't receive an email, please check your spam folder and make sure "
+"you've entered the address you registered with. (You won't get an email "
+"unless there's already an account for that email address!)"
+msgstr ""
+"Eğer email almadıysanız, lütfen spam klasörünü kontrol edin ve kayıt "
+"olduğunuz email adresini girdiğinizden emin olun. (Eğer o email adresi için "
+"bir hesap mevcut değilse email almayacaksınız!)"
+
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at Children Helping Science."
+msgstr ""
+"Bu emaili alıyorsunuz çünkü %(site_name) adresindeki hesabınız için "
+"şifrenizi sıfırlama talebinde bulundunuz."
+
+#: web/templates/registration/password_reset_email.html:4
+msgid "Please go to the following page and choose a new password:"
+msgstr "Lütfen bir sonraki sayfaya gidin ve yeni bir şifre seçin:"
+
+#: web/templates/registration/password_reset_email.html:8
+msgid "Your username, in case you've forgotten:"
+msgstr "Kullanıcı adınız, unuttuysanız:"
+
+#: web/templates/registration/password_reset_email.html:9
+msgid "Thanks for using our site!"
+msgstr "Sitemizi kullandığınız için teşekkürler!"
+
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "Şifremi sıfırla"
+
+#: web/templates/registration/password_reset_form.html:8
+msgid "Password reset"
+msgstr "Şifre sıfırlama"
+
+#: web/templates/registration/password_reset_form.html:11
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll email "
+"instructions for setting a new one."
+msgstr ""
+"Şifrenizi mi unuttunuz? Aşağıya e-mailinizi girin, size yeni bir şifre "
+"belirlemeniz için yönergeleri mail atalım."
+
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "Şifre sıfırlama linki gönderildi"
+
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
 msgid ""
 "This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
 "findings, and conclusions or recommendations expressed in this material are "
 "those of the authors(s) and do not necessarily reflect the views of the "
 "National Science Foundation."
@@ -1197,48 +1409,304 @@ msgstr ""
 "fikir, bulgu ve sonuç veya öneri yazar(lar)a aittir ve National Science "
 "Foundation'ın görüşlerini yansıtmayabilir."
 
-#: web/templates/frontpages/default.html:58 web/templates/frontpages/home.html:48
+#: web/templates/web/_footer.html:14
 msgid "Privacy"
 msgstr "Gizlilik"
 
-#: web/templates/frontpages/default.html:59 web/templates/frontpages/home.html:49
+#: web/templates/web/_footer.html:17
 msgid "Contact us"
 msgstr "Bizimle iletişime geçin"
 
-#: web/templates/frontpages/default.html:60
+#: web/templates/web/_footer.html:20
 msgid "Connect"
 msgstr "Bağlan"
 
-#: web/templates/frontpages/faq.html:11
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr "Çıkış yap"
+
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "Deneyci"
+
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "Çocuk"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "İptal et"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "Çocuk Ekle"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr "Çocuk"
+
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr "Çocuk Listesi'ne Geri Dön"
+
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr "Sil"
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "Kaydet"
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "Güncelle"
+
+#: web/templates/web/children-list.html:9
+msgid "Update child"
+msgstr "Çocuk bilgisini güncelle"
+
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "İsim"
+
+#: web/templates/web/children-list.html:64
+msgid "No child profiles registered!"
+msgstr "Hiçbir çocuk profili kaydedilmedi!"
+
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr "Teknik zorluklar"
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr "Çalışmalarla ilgili sorular"
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr "Araştırmacılar için"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "Belgeler"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
+msgid "Update demographics"
+msgstr "Demografikleri güncelle"
+
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
+msgid ""
+"One reason we are developing Internet-based experiments is to represent a "
+"more diverse group of families in our research. Your answers to these "
+"questions will help us understand what audience we reach, as well as how "
+"factors like speaking multiple languages or having older siblings affect "
+"children's learning."
+msgstr ""
+"Internet tabanlı deneyleri geliştirmemizin bir nedeni çalışmalarımızda daha "
+"çok aile çeşidini temsil edebilmektir. Bu sorulara vereceğiniz cevaplar "
+"bizim hangi hedef kitleye ulaştığımızı ve aynı zamanda birden çok dili "
+"konuşmak veya kendinden büyük kardeş sahibi olmak gibi faktörlerin "
+"çocukların öğrenmesini nasıl etkilediğini anlamamızı sağlayacak."
+
+#: web/templates/web/demographic-data-update.html:47
+msgid ""
+"Even if you allow your study videos to be published for scientific or "
+"publicity purposes, your demographic information is never published in "
+"conjunction with your video."
+msgstr ""
+"Çalışma videolarınızın bilimsel veya tanıtım amaçlı kullanılmasına izin "
+"verseniz bile, demografik bilgileriniz asla videonuzla bağlantılı olarak "
+"yayınlanmaz."
+
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
 msgid "Frequently Asked Questions"
 msgstr "Sıkça Sorulan Sorular"
 
-#: web/templates/frontpages/faq.html:16
+#: web/templates/web/faq.html:12
 msgid "Participation"
 msgstr "Katılım"
 
-#: web/templates/frontpages/faq.html:20
+#: web/templates/web/faq.html:22
 msgid "What is a 'study' about cognitive development?"
 msgstr "Bilişsel gelişimle ilgili \"çalışma\" nedir?"
 
-#: web/templates/frontpages/faq.html:25
+#: web/templates/web/faq.html:30
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Cognitive development is the science "
+#| "of what kids understand and how they learn. Researchers in cognitive "
+#| "development are interested in questions like...</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li>what knowledge and abilities "
+#| "infants are born with, and what they have to learn from experience</li>\n"
+#| "                                    <li>how abilities like mathematical "
+#| "reasoning are organized and how they develop over time</li>\n"
+#| "                                    <li>what strategies children use to "
+#| "learn from the wide variety of data they observe</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>A study is meant to answer a very "
+#| "specific question about how children learn or what they know: for "
+#| "instance, 'Do three-month-olds recognize their parents' faces?'</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Cognitive development is the science of "
-"what kids understand and how they learn. Researchers in cognitive "
-"development are interested in questions like...</p>\n"
-"                                <ul>\n"
-"                                    <li>what knowledge and abilities infants "
-"are born with, and what they have to learn from experience</li>\n"
-"                                    <li>how abilities like mathematical "
-"reasoning are organized and how they develop over time</li>\n"
-"                                    <li>what strategies children use to "
-"learn from the wide variety of data they observe</li>\n"
-"                                </ul>\n"
-"                                <p>A study is meant to answer a very "
-"specific question about how children learn or what they know: for instance, "
-"'Do three-month-olds recognize their parents' faces?'</p>\n"
-"                                "
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
 msgstr ""
 "\n"
 "                                <p>Bilişsel gelişim, çocukların neyi "
@@ -1258,95 +1726,263 @@ msgstr ""
 "p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:40
-msgid "How can we participate online?"
-msgstr "Çevrimiçi olarak nasıl katılabiliriz?"
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
 
-#: web/templates/frontpages/faq.html:45
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
 msgid ""
 "\n"
 "                            <p>If you have a child and would like to "
-"participate, create an account and take a look at what we have available for "
-"your child's age range. You'll need a working webcam to participate.</p>\n"
-"                                <p>When you select a study, you'll be asked "
-"to read a consent form and record yourself stating that you and your child "
-"agree to participate. Then we'll guide you through what will happen during "
-"the study. Depending on your child's age, your child may answer questions "
-"directly or we may be looking for indirect signs of what she thinks is going "
-"on--like how long she looks at a surprising outcome.</p>\n"
-"                                <p>Some portions of the study will be "
-"automatically recorded using your webcam and sent securely to the Lookit "
-"platform. Trained researchers will watch the video and record your child's "
-"responses--for instance, which way he pointed, or how long she looked at "
-"each image. We'll put these together with responses from lots of other "
-"children to learn more about how kids think!</p>\n"
-"                            "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
 msgstr ""
-"\n"
-"                            <p>Eğer çocuğunuz varsa ve katılmak "
-"istiyorsanız, bir hesap oluşturarak çocuğunuzun yaş aralığında katılımcı "
-"aranan çalışmalarımıza göz atabilirsiniz. Çalışmalara katılabilmek için "
-"çalışır durumda bir bilgisayar kameranızın bulunması gerekmektedir.</p>\n"
-"                                <p>Bir çalışmayı seçtiğinizde, bir onay "
-"formu okumanız ve sizin ve çocuğunuzun çalışmaya katılmayı kabul ettiğinizi "
-"belirttiğiniz bir video kaydı göndermeniz istenecektir. Sonrasında, çalışma "
-"sırasında yapılacaklar konusunda sizi yönlendiriyor olacağız. Çocuğunuzun "
-"yaşına bağlı olarak çocuğunuz sorulan sorulara doğrudan kendisi cevap "
-"verebilir, ya da çocuğunuzun ne düşündüğüyle ilgili çıkarımlarda "
-"bulunabileceğimiz dolaylı işaretleri inceleriz – şaşırtıcı bir sonuca ne "
-"kadar uzun süre baktığı gibi.</p>\n"
-"                                <p>Çalışmanın kamerayla kayıt altına alınan "
-"bazı kısımları otomatik olarak kaydedilip güvenli bir şekilde Lookit "
-"arayüzüne aktarılacaktır. Bu videoları alanında eğitimli araştırmacılar "
-"inceleyecek ve çocuğunuzun birtakım tepkilerini kaydedecektir- örneğin "
-"parmağıyla gösterdiği yön ya da resimlere bakma süresi gibi. Çocukların "
-"nasıl düşündükleri hakkında daha çok şey öğrenmek için bu tepkileri diğer "
-"birçok çocuktan gelen bu tepkiler ile birleştireceğiz!</p>\n"
-"                            "
 
-#: web/templates/frontpages/faq.html:56
-msgid "Who can create studies on Lookit?"
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Who can create studies on Lookit?"
+msgid "Who creates the studies?"
 msgstr "Kimler Lookit'te çalışma yaratabilir?"
 
-#: web/templates/frontpages/faq.html:61
+#: web/templates/web/faq.html:114
+#, python-format
 msgid ""
-"Any researcher with questions about how kids learn and grow can propose a "
-"Lookit study! Each institution using Lookit has to sign a contract with MIT "
-"where they agree to the <a href='/termsofuse'>Terms of Use</a> and certify "
-"that their studies will be reviewed and approved by an institutional review "
-"board. Studies are also subject to approval by Lookit. As of June 2020 we "
-"have agreements with 20 universities!"
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
 msgstr ""
-"Çocukların nasıl öğrendiği ve büyüdüğü hakkında soruları olan her "
-"araştırmacı bir Lookit çalışması önerebilir! Lookit kullanan her kurum MIT "
-"ile <a \n"
-"href='/termsofuse'> Kullanım Şartları </a> 'nı kabul ettikleri ve "
-"çalışmalarının bir bağımsız etik komitesi tarafından incelenip "
-"onaylanacağını kabul ettikleri bir sözleşme imzalamalıdır. Çalışmalar "
-"Lookit'in de onayına tabidir. Haziran 2020 itibariyle 20 üniversite ile "
-"anlaşmamız var!"
 
-#: web/templates/frontpages/faq.html:69
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+msgid "Why are you running studies online instead of in person?"
+msgstr "Çalışmaları neden yüz yüze yapmak yerine çevrimiçi yürütüyorsunuz?"
+
+#: web/templates/web/faq.html:159
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <ul>\n"
+#| "                                    <li>Make it easier for you to take "
+#| "part in research, especially for families without a stay-at-home parent</"
+#| "li>\n"
+#| "                                    <li>Work with more kids when needed--"
+#| "right now a limiting factor in designing studies is the time it takes to "
+#| "recruit participants</li>\n"
+#| "                                    <li>Draw conclusions from a more "
+#| "representative population of families--not just those who live near a "
+#| "university and are able to visit the lab during the day.\n"
+#| "                                    </li>\n"
+#| "                                    <li>Make it easier for families to "
+#| "continue participating in longitudinal studies, which may involve "
+#| "multiple testing sessions separated by months or years</li>\n"
+#| "                                    <li>Observe more natural behavior "
+#| "because children are at home rather than in an unfamiliar place</li>\n"
+#| "                                    <li>Create a system for learning "
+#| "about special populations--for instance, children with specific "
+#| "developmental disorders</li>\n"
+#| "                                    <li>Make the procedures we use in "
+#| "doing research more transparent, and make it easier to replicate our "
+#| "findings</li>\n"
+#| "                                    <li>Communicate with families about "
+#| "the research we're doing and what we can learn from it</li>\n"
+#| "                                </ul>\n"
+#| "                                "
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+"\n"
+"                                <ul>\n"
+"                                    <li>Araştırmalarda yer almanız "
+"kolaylaşsın, özellikle her iki ebeveynin de çalıştığı aileler için</"
+"li>                                   \n"
+"                                    <li>İhtiyacınız olduğunda daha fazla "
+"çocukla çalışın—şu anda çalışmaları tasarlamada sınırlayıcı bir faktör, "
+"katılımcı toplamak için geçen süredir</li>\n"
+"                                    <li>Daha temsili bir aile "
+"popülasyonundan sonuçlar çıkarın - sadece bir üniversitenin yakınında "
+"yaşayan ve gün içinde laboratuvarı ziyaret edebilenlerden değil.\n"
+"                                    </li>\n"
+"                                    <li>Ailelerin birkaç ay ya da yıl ile "
+"birbirinden ayrılmış birden fazla test oturumlarını içerebilecek boylamsal "
+"çalışmalara devam edebilmesi kolaylaşsın</li>\n"
+"                                    <li>Çocuklar yabancı bir yerde değil "
+"evlerinde oldukları için daha doğal davranışlar gözlemleyin</li>\n"
+"                                    <li>Özel popülasyonları öğrenmek için "
+"bir sistem oluşturun--örneğin, belirli gelişimsel bozuklukları olan "
+"çocuklar</li>\n"
+"                                    <li>Araştırma yaparken kullandığımız "
+"prosedürleri daha şeffaf hale getirin ve bulgularımızı replike etmeyi "
+"kolaylaştırın</li>\n"
+"                                    <li>Yaptığımız araştırma ve bu "
+"araştırmadan ne öğrenebileceğimiz hakkında ailelerle iletişim kurun</li>\n"
+"                                </ul>"
+
+#: web/templates/web/faq.html:184
 msgid "How do we provide consent to participate?"
 msgstr "Katılmak için nasıl onay veririz?"
 
-#: web/templates/frontpages/faq.html:74
+#: web/templates/web/faq.html:191
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Rather than having the parent or legal "
+#| "guardian sign a form, we ask that you read aloud (or sign in ASL) a "
+#| "statement of consent which is recorded using your webcam. This statement "
+#| "holds the same weight as a signed form, but should be less hassle for "
+#| "you. It also lets us verify that you understand written English and that "
+#| "you understand you're being videotaped.</p>\n"
+#| "                                <p>Researchers watch these consent videos "
+#| "on a special page of the researcher interface, and record for each one "
+#| "whether the video shows informed consent. They cannot view other video or "
+#| "download data from a session unless they have confirmed that you "
+#| "consented to participate! If they see a consent video that does NOT "
+#| "clearly demonstrate informed consent--for instance, there was a technical "
+#| "problem and there's no audio--they may contact you to check, depending on "
+#| "your email settings.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Rather than having the parent or legal "
-"guardian sign a form, we ask that you read aloud (or sign in ASL) a "
-"statement of consent which is recorded using your webcam. This statement "
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
 "holds the same weight as a signed form, but should be less hassle for you. "
 "It also lets us verify that you understand written English and that you "
 "understand you're being videotaped.</p>\n"
-"                                <p>Researchers watch these consent videos on "
-"a special page of the researcher interface, and record for each one whether "
-"the video shows informed consent. They cannot view other video or download "
-"data from a session unless they have confirmed that you consented to "
-"participate! If they see a consent video that does NOT clearly demonstrate "
-"informed consent--for instance, there was a technical problem and there's no "
-"audio--they may contact you to check, depending on your email settings.</p>\n"
-"                                "
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>Bir ebeveyn ya da yasal vasinin "
@@ -1365,39 +2001,59 @@ msgstr ""
 "teknik bir problemden var ve videonun sesi yoksa--araştırmacılar size "
 "iletişim tercihlerinize bağlı olarak ulaşıp doğrulama yapmak isteyebilir.</p>"
 
-#: web/templates/frontpages/faq.html:80
-msgid "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-msgstr ""
-"https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-
-#: web/templates/frontpages/faq.html:89
+#: web/templates/web/faq.html:215
 msgid "How is our information kept secure and confidential?"
 msgstr "Bilgilerimiz nasıl güvenli ve gizli tutulacak?"
 
-#: web/templates/frontpages/faq.html:94
+#: web/templates/web/faq.html:223
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>\n"
+#| "                                Researchers using Lookit agree to uphold "
+#| "a common set of standards about how data is protected and shared. For "
+#| "instance, they never publish children's names or birthdates, or "
+#| "information that could be used to calculate a birthdate.</p>\n"
+#| "                                <p>The Lookit researcher interface is "
+#| "designed with participant data protection as the top priority. For "
+#| "instance, a special interface lets researchers confirm consent videos "
+#| "before they are able to download any other data from your session. "
+#| "Research groups can control who has access to what data in a very fine-"
+#| "grained way, for instance allowing an assistant to confirm consent and "
+#| "send gift cards, but not download study data.</p>\n"
+#| "                                <p>All of your data, including video, is "
+#| "transmitted over a secure HTTPS connection to Lookit storage, and is "
+#| "encrypted at rest. We take security very seriously; in addition to making "
+#| "sure any software we use is up-to-date, cloud servers are configured "
+#| "securely, and unit tests cover checking that accessing data requires "
+#| "correct permissions, we conducted a risk assessment and detailed manual "
+#| "penetration testing with a security contractor prior to our 2020 launch.</"
+#| "p>\n"
+#| "                                <p>See also 'Who will see our video?'</"
+#| "p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>\n"
-"                                Researchers using Lookit agree to uphold a "
-"common set of standards about how data is protected and shared. For "
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
 "instance, they never publish children's names or birthdates, or information "
 "that could be used to calculate a birthdate.</p>\n"
-"                                <p>The Lookit researcher interface is "
-"designed with participant data protection as the top priority. For instance, "
-"a special interface lets researchers confirm consent videos before they are "
-"able to download any other data from your session. Research groups can "
-"control who has access to what data in a very fine-grained way, for instance "
-"allowing an assistant to confirm consent and send gift cards, but not "
-"download study data.</p>\n"
-"                                <p>All of your data, including video, is "
-"transmitted over a secure HTTPS connection to Lookit storage, and is "
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
 "encrypted at rest. We take security very seriously; in addition to making "
 "sure any software we use is up-to-date, cloud servers are configured "
 "securely, and unit tests cover checking that accessing data requires correct "
-"permissions, we conducted a risk assessment and detailed manual penetration "
-"testing with a security contractor prior to our 2020 launch.</p>\n"
-"                                <p>See also 'Who will see our video?'</p>\n"
-"                                "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>\n"
@@ -1426,35 +2082,106 @@ msgstr ""
 "                                <p>Ayrıca şurayı inceleyin: ‘Videomuzu "
 "kimler görecek?’</p>"
 
-#: web/templates/frontpages/faq.html:107
+#: web/templates/web/faq.html:239
 msgid "Who will see our video?"
 msgstr "Videomuzu kimler görecek?"
 
-#: web/templates/frontpages/faq.html:112
+#: web/templates/web/faq.html:246
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Lookit staff at MIT will have access "
+#| "to your video and other data in order to improve and promote the platform "
+#| "and help with troubleshooting. The researchers running the study you "
+#| "participated in will also have access to your video and other data (like "
+#| "responses to questions during the study, and information you fill out "
+#| "when registering a child) for research purposes. They will watch the "
+#| "video segments you send to mark down information specific to the study--"
+#| "for instance, what your child said, or how long he/she looked to the left "
+#| "versus the right of the screen. This research group may be at MIT or at "
+#| "another institution. All studies run on Lookit must be approved by an "
+#| "Institutional Review Board (IRB) that ensures participants' rights and "
+#| "welfare are protected. All researchers using Lookit also agree to Terms "
+#| "of Use that govern what data they can share and what sorts of studies are "
+#| "okay to run on Lookit; these rules are sometimes stricter than their own "
+#| "institution might be.  </p>\n"
+#| "                                <p>Whether anyone else may view the video "
+#| "depends on the privacy settings you select at the end of the study. There "
+#| "are two decisions to make: whether to share your data with Databrary, and "
+#| "how to allow your video clips to be used by the researchers you have "
+#| "selected.</p>\n"
+#| "                                <p>First, we ask if you would like to "
+#| "share your data (including video) with authorized users fo the secure "
+#| "data library Databrary. Data sharing will lead to faster progress in "
+#| "research on human development and behavior. Researchers who are granted "
+#| "access to the Databrary library must agree to treat the data with the "
+#| "same high standard of care they would use in their own laboratories. "
+#| "Learn more about Databrary's <a href=\"https://databrary.org/about."
+#| "html\">mission</a> or the <a href=\"https://databrary.org/about/agreement."
+#| "html\">requirements for authorized users</a>.</p>\n"
+#| "                                <p>Next, we ask what types of uses of "
+#| "your video are okay with you.</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li><strong>Private</strong> This "
+#| "privacy level ensures that your video clips will be viewed only by "
+#| "authorized scientists (Lookit staff, the research group running the study "
+#| "and, if you have opted to share your data with Databrary, authorized "
+#| "Databrary users.) They will view the videos to record information about "
+#| "what your child did during the study--for instance, looking for 9 seconds "
+#| "at one image and 7 seconds at another image.</li>\n"
+#| "                                    <li><strong>Scientific and "
+#| "educational</strong> This privacy level gives permission to share your "
+#| "video clips with other researchers or students for scientific or "
+#| "educational purposes. For example, researchers might show a video clip in "
+#| "a talk at a scientific conference or an undergraduate class about "
+#| "cognitive development, or include an image or video in a scientific "
+#| "paper. In some circumstances, video or images may be available online, "
+#| "for instance as supplemental material in a scientific paper. Sharing "
+#| "videos with other researchers helps other groups trust and build on our "
+#| "work.</li>\n"
+#| "                                    <li><strong>Publicity</strong> This "
+#| "privacy level is for families who would be excited to see their child "
+#| "featured on the Lookit website or in the news! Selecting this privacy "
+#| "level gives permission to use your video clips to communicate about "
+#| "developmental studies and the Lookit platform with the public. For "
+#| "instance, we might post a short video clip on the Lookit website, on our "
+#| "Facebook page, or in a press release. Your video will never be used for "
+#| "commercial purposes.</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>If for some reason you do not select a "
+#| "privacy level, we treat the data as 'Private' and do not share with "
+#| "Databrary. Participants also have the option to withdraw all video "
+#| "besides consent at the end of the study if necessary (for instance, "
+#| "because someone was discussing state secrets in the background), and in "
+#| "this case it is automatically deleted. Privacy settings for completed "
+#| "sessions cannot automatically be changed retroactively. If you have any "
+#| "questions or concerns about privacy, please contact our team at <a "
+#| "href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Lookit staff at MIT will have access to "
-"your video and other data in order to improve and promote the platform and "
-"help with troubleshooting. The researchers running the study you "
-"participated in will also have access to your video and other data (like "
-"responses to questions during the study, and information you fill out when "
-"registering a child) for research purposes. They will watch the video "
-"segments you send to mark down information specific to the study--for "
-"instance, what your child said, or how long he/she looked to the left versus "
-"the right of the screen. This research group may be at MIT or at another "
-"institution. All studies run on Lookit must be approved by an Institutional "
-"Review Board (IRB) that ensures participants' rights and welfare are "
-"protected. All researchers using Lookit also agree to Terms of Use that "
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
 "govern what data they can share and what sorts of studies are okay to run on "
-"Lookit; these rules are sometimes stricter than their own institution might "
-"be.  </p>\n"
-"                                <p>Whether anyone else may view the video "
-"depends on the privacy settings you select at the end of the study. There "
-"are two decisions to make: whether to share your data with Databrary, and "
-"how to allow your video clips to be used by the researchers you have "
-"selected.</p>\n"
-"                                <p>First, we ask if you would like to share "
-"your data (including video) with authorized users fo the secure data library "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
 "Databrary. Data sharing will lead to faster progress in research on human "
 "development and behavior. Researchers who are granted access to the "
 "Databrary library must agree to treat the data with the same high standard "
@@ -1462,43 +2189,44 @@ msgid ""
 "Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
 "<a href=\"https://databrary.org/about/agreement.html\">requirements for "
 "authorized users</a>.</p>\n"
-"                                <p>Next, we ask what types of uses of your "
-"video are okay with you.</p>\n"
-"                                <ul>\n"
-"                                    <li><strong>Private</strong> This "
-"privacy level ensures that your video clips will be viewed only by "
-"authorized scientists (Lookit staff, the research group running the study "
-"and, if you have opted to share your data with Databrary, authorized "
-"Databrary users.) They will view the videos to record information about what "
-"your child did during the study--for instance, looking for 9 seconds at one "
-"image and 7 seconds at another image.</li>\n"
-"                                    <li><strong>Scientific and educational</"
-"strong> This privacy level gives permission to share your video clips with "
-"other researchers or students for scientific or educational purposes. For "
-"example, researchers might show a video clip in a talk at a scientific "
-"conference or an undergraduate class about cognitive development, or include "
-"an image or video in a scientific paper. In some circumstances, video or "
-"images may be available online, for instance as supplemental material in a "
-"scientific paper. Sharing videos with other researchers helps other groups "
-"trust and build on our work.</li>\n"
-"                                    <li><strong>Publicity</strong> This "
-"privacy level is for families who would be excited to see their child "
-"featured on the Lookit website or in the news! Selecting this privacy level "
-"gives permission to use your video clips to communicate about developmental "
-"studies and the Lookit platform with the public. For instance, we might post "
-"a short video clip on the Lookit website, on our Facebook page, or in a "
-"press release. Your video will never be used for commercial purposes.</li>\n"
-"                                </ul>\n"
-"                                <p>If for some reason you do not select a "
-"privacy level, we treat the data as 'Private' and do not share with "
-"Databrary. Participants also have the option to withdraw all video besides "
-"consent at the end of the study if necessary (for instance, because someone "
-"was discussing state secrets in the background), and in this case it is "
-"automatically deleted. Privacy settings for completed sessions cannot "
-"automatically be changed retroactively. If you have any questions or "
-"concerns about privacy, please contact our team at <a href=\"mailto:"
-"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
-"                                "
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>MIT’deki Lookit çalışanları arayüzü "
@@ -1529,8 +2257,8 @@ msgstr ""
 "insan gelişimi ve davranışına ilişkin araştırmalarda daha hızlı ilerlemeyi "
 "sağlayacaktır. Databrary’ye erişim izni olan araştırmacılar verilerinizi "
 "kendi laboratuvarlarındaki verileri korudukları hassasiyetle korumayı kabul "
-"etmelidirler. Databrary hakkında daha fazla bilgi için tıklayın <a href="
-"\"https://databrary.org/about.html\">misyon</a> ya da <a href=\"https://"
+"etmelidirler. Databrary hakkında daha fazla bilgi için tıklayın <a "
+"href=\"https://databrary.org/about.html\">misyon</a> ya da <a href=\"https://"
 "databrary.org/about/agreement.html\">yetkili kullanıcılar için "
 "yükümlülükler</a>.</p> \n"
 "                                <p>Sonrasında, videonuzun hangi amaçlarla "
@@ -1570,14 +2298,14 @@ msgstr ""
 "onay videosu dışındaki bütün videolarını geri çekme seçeneği vardır, ve bu "
 "durumda videolar otomatik olarak silinir. Tamamlanmış oturumların gizlilik "
 "ayarları geri dönülerek değiştirilemez. Gizlilik hakkında daha fazla sorunuz "
-"ya da endişeniz varsa, lütfen ekibimiz ile buradan iletişime geçin <a href="
-"\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>"
+"ya da endişeniz varsa, lütfen ekibimiz ile buradan iletişime geçin <a "
+"href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>"
 
-#: web/templates/frontpages/faq.html:130
+#: web/templates/web/faq.html:269
 msgid "What information do researchers use from our video?"
 msgstr "Araştırmacılar videomuzdaki hangi bilgiyi kullanacak?"
 
-#: web/templates/frontpages/faq.html:136
+#: web/templates/web/faq.html:278
 msgid ""
 "For children under about two years old, we usually design our studies to let "
 "their eyes do the talking! We're interested in where on the screen your "
@@ -1594,7 +2322,7 @@ msgstr ""
 "bir fikir edinmemize yardımcı olur, böylece videonun geri kalanını "
 "kodlayabiliriz."
 
-#: web/templates/frontpages/faq.html:143
+#: web/templates/web/faq.html:290
 msgid ""
 "Here's an example of a few children watching our calibration video--it's "
 "easy to see that they look to one side and then the other."
@@ -1602,7 +2330,7 @@ msgstr ""
 "İşte kalibrasyon videomuzu izleyen birkaç çocuğun bir örneği-- önce bir "
 "tarafa sonra diğerine baktıklarını görmek kolay."
 
-#: web/templates/frontpages/faq.html:149
+#: web/templates/web/faq.html:302
 msgid ""
 "Your child's decisions about where to look can give us lots of information "
 "about what he or she understands. Here are some of the techniques labs use "
@@ -1612,36 +2340,62 @@ msgstr ""
 "pek çok bilgi verebilir. İşte laboratuvarların çocukların nasıl öğrendikleri "
 "hakkında daha fazla bilgi edinmek için kullandıkları tekniklerden bazıları."
 
-#: web/templates/frontpages/faq.html:150
+#: web/templates/web/faq.html:304
 msgid "Habituation"
 msgstr "Alıştırma"
 
-#: web/templates/frontpages/faq.html:151
+#: web/templates/web/faq.html:305
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>In a habituation study, we first show "
+#| "infants many examples of one type of object or event, and they lose "
+#| "interest over time. Infants typically look for a long time at the first "
+#| "pictures, but then they start to look away more quickly. Once their "
+#| "looking times are much less than they were initially, we show either a "
+#| "picture from a new category or a new picture from the familiar category. "
+#| "If infants now look longer to the novel example, we can tell that they "
+#| "understood--and got bored of--the category we showed initially.</p>\n"
+#| "                                <p>Habituation requires waiting for each "
+#| "individual infant to achieve some threshold of \"boredness\"--for "
+#| "instance, looking half as long at a picture as he or she did initially. "
+#| "Sometimes this is impractical, and we use familiarization instead. In a "
+#| "familiarization study, we show all babies the same number of examples, "
+#| "and then see how interested they are in the familiar versus a new "
+#| "category. Younger infants and those who have seen few examples tend to "
+#| "show a familiarity preference--they look longer at images similar to what "
+#| "they have seen before. Older infants and those who have seen many "
+#| "examples tend to show a novelty preference--they look longer at images "
+#| "that are different from the ones they saw before. You probably notice the "
+#| "same phenomenon when you hear a new song on the radio: initially you "
+#| "don't recognize it; after it's played several times you may like it and "
+#| "sing along; after it's played hundreds of times you would choose to "
+#| "listen to anything else.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>In a habituation study, we first show "
-"infants many examples of one type of object or event, and they lose interest "
-"over time. Infants typically look for a long time at the first pictures, but "
-"then they start to look away more quickly. Once their looking times are much "
-"less than they were initially, we show either a picture from a new category "
-"or a new picture from the familiar category. If infants now look longer to "
-"the novel example, we can tell that they understood--and got bored of--the "
-"category we showed initially.</p>\n"
-"                                <p>Habituation requires waiting for each "
-"individual infant to achieve some threshold of \"boredness\"--for instance, "
-"looking half as long at a picture as he or she did initially. Sometimes this "
-"is impractical, and we use familiarization instead. In a familiarization "
-"study, we show all babies the same number of examples, and then see how "
-"interested they are in the familiar versus a new category. Younger infants "
-"and those who have seen few examples tend to show a familiarity preference--"
-"they look longer at images similar to what they have seen before. Older "
-"infants and those who have seen many examples tend to show a novelty "
-"preference--they look longer at images that are different from the ones they "
-"saw before. You probably notice the same phenomenon when you hear a new song "
-"on the radio: initially you don't recognize it; after it's played several "
-"times you may like it and sing along; after it's played hundreds of times "
-"you would choose to listen to anything else.</p>\n"
-"                                "
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>Bir alıştırma çalışmasında, bebeklere "
@@ -1668,11 +2422,11 @@ msgstr ""
 "beğenebilir ve şarkıyı söyleyebilirsiniz; yüzlerce kez oynatıldıktan sonra "
 "artık başka bir şey dinlemeyi seçersiniz.</p>"
 
-#: web/templates/frontpages/faq.html:156
+#: web/templates/web/faq.html:308
 msgid "Violation of expectation"
 msgstr "Beklenti İhlali"
 
-#: web/templates/frontpages/faq.html:157
+#: web/templates/web/faq.html:310
 msgid ""
 "Infants and children already have rich expectations about how events work. "
 "Children (and adults for that matter) tend to look longer at things they "
@@ -1684,11 +2438,11 @@ msgstr ""
 "daha uzun süre bakma eğilimindedirler, bu nedenle bazı durumlarda ne kadar "
 "şaşırdıklarının bir ölçüsü olarak bakma sürelerini alabiliriz."
 
-#: web/templates/frontpages/faq.html:158
+#: web/templates/web/faq.html:312
 msgid "Preferential looking"
 msgstr "Tercihli İzleme"
 
-#: web/templates/frontpages/faq.html:159
+#: web/templates/web/faq.html:314
 msgid ""
 "Even when they seem to be passive observers, children are making lots of "
 "decisions about where to look and what to pay attention to. In this "
@@ -1706,11 +2460,11 @@ msgstr ""
 "'alkışlamayı bulması' istendiğinde sola bakan bir katılımcıyı "
 "göstermektedir; izlediği ekran en üstte gösterilir."
 
-#: web/templates/frontpages/faq.html:165
+#: web/templates/web/faq.html:325
 msgid "Predictive looking"
 msgstr "Öngörücü İzleme"
 
-#: web/templates/frontpages/faq.html:166
+#: web/templates/web/faq.html:327
 msgid ""
 "Children can often make sophisticated predictions about what they expect to "
 "see or hear next. One way we can see those predictions in young children is "
@@ -1733,7 +2487,7 @@ msgstr ""
 "öğrenip öğrenmediklerini ve bir hece duyduklarında nasıl "
 "genelleştirdiklerini görebiliriz."
 
-#: web/templates/frontpages/faq.html:168
+#: web/templates/web/faq.html:330
 msgid ""
 "Older children may simply be able to answer spoken questions about what they "
 "think is happening. For instance, in a recent study, two women called an "
@@ -1745,7 +2499,7 @@ msgstr ""
 "bir nesneye iki farklı uydurma isim vermiş ve çocuklara nesnenin doğru "
 "adının hangisi olduğu sorulmuştur."
 
-#: web/templates/frontpages/faq.html:174
+#: web/templates/web/faq.html:342
 msgid ""
 "Another way we can learn about how older children (and adults) think is to "
 "measure their reaction times. For instance, we might ask you to help your "
@@ -1759,98 +2513,7 @@ msgstr ""
 "öğrenmesine yardımcı olmanızı isteyebilir ve ardından bir tuşa ne kadar "
 "hızlı bastığını etkileyen faktörlere bakarız."
 
-#: web/templates/frontpages/faq.html:181
-msgid "Why are you running studies online instead of in person?"
-msgstr "Çalışmaları neden yüz yüze yapmak yerine çevrimiçi yürütüyorsunuz?"
-
-#: web/templates/frontpages/faq.html:186
-msgid ""
-"Traditionally, developmental studies happen in a quiet room in a university "
-"lab. Researchers call or email local parents to see if they'd like to take "
-"part and schedule an appointment for them to come visit the lab. Why "
-"complement these in-lab studies with online ones? We're hoping to..."
-msgstr ""
-"Geleneksel olarak, gelişim çalışmaları bir üniversite laboratuvarındaki "
-"sessiz bir odada yapılır. Araştırmacılar, yer almak isteyip istemediklerini "
-"öğrenmek ve bir laboratuvar ziyareti randevusu ayarlamak için ebeveynleri "
-"arar veya email gönderir. Bu laboratuvar içi çalışmaları neden çevrimiçi "
-"araştırmalarla tamamlamayalım? Umuyoruz ki ..."
-
-#: web/templates/frontpages/faq.html:187
-msgid ""
-"\n"
-"                                <ul>\n"
-"                                    <li>Make it easier for you to take part "
-"in research, especially for families without a stay-at-home parent</li>\n"
-"                                    <li>Work with more kids when needed--"
-"right now a limiting factor in designing studies is the time it takes to "
-"recruit participants</li>\n"
-"                                    <li>Draw conclusions from a more "
-"representative population of families--not just those who live near a "
-"university and are able to visit the lab during the day.\n"
-"                                    </li>\n"
-"                                    <li>Make it easier for families to "
-"continue participating in longitudinal studies, which may involve multiple "
-"testing sessions separated by months or years</li>\n"
-"                                    <li>Observe more natural behavior "
-"because children are at home rather than in an unfamiliar place</li>\n"
-"                                    <li>Create a system for learning about "
-"special populations--for instance, children with specific developmental "
-"disorders</li>\n"
-"                                    <li>Make the procedures we use in doing "
-"research more transparent, and make it easier to replicate our findings</"
-"li>\n"
-"                                    <li>Communicate with families about the "
-"research we're doing and what we can learn from it</li>\n"
-"                                </ul>\n"
-"                                "
-msgstr ""
-"\n"
-"                                <ul>\n"
-"                                    <li>Araştırmalarda yer almanız "
-"kolaylaşsın, özellikle her iki ebeveynin de çalıştığı aileler için</"
-"li>                                   \n"
-"                                    <li>İhtiyacınız olduğunda daha fazla "
-"çocukla çalışın—şu anda çalışmaları tasarlamada sınırlayıcı bir faktör, "
-"katılımcı toplamak için geçen süredir</li>\n"
-"                                    <li>Daha temsili bir aile "
-"popülasyonundan sonuçlar çıkarın - sadece bir üniversitenin yakınında "
-"yaşayan ve gün içinde laboratuvarı ziyaret edebilenlerden değil.\n"
-"                                    </li>\n"
-"                                    <li>Ailelerin birkaç ay ya da yıl ile "
-"birbirinden ayrılmış birden fazla test oturumlarını içerebilecek boylamsal "
-"çalışmalara devam edebilmesi kolaylaşsın</li>\n"
-"                                    <li>Çocuklar yabancı bir yerde değil "
-"evlerinde oldukları için daha doğal davranışlar gözlemleyin</li>\n"
-"                                    <li>Özel popülasyonları öğrenmek için "
-"bir sistem oluşturun--örneğin, belirli gelişimsel bozuklukları olan "
-"çocuklar</li>\n"
-"                                    <li>Araştırma yaparken kullandığımız "
-"prosedürleri daha şeffaf hale getirin ve bulgularımızı replike etmeyi "
-"kolaylaştırın</li>\n"
-"                                    <li>Yaptığımız araştırma ve bu "
-"araştırmadan ne öğrenebileceğimiz hakkında ailelerle iletişim kurun</li>\n"
-"                                </ul>"
-
-#: web/templates/frontpages/faq.html:206
-msgid "When will we see the results of the study?"
-msgstr "Çalışmanın sonuçlarını ne zaman göreceğiz?"
-
-#: web/templates/frontpages/faq.html:211
-msgid ""
-"The process of publishing a scientific study, from starting data collection "
-"to seeing the paper in a journal, can take several years. You can check the "
-"Lookit home page for updates on papers, or set your communication "
-"preferences to be notified when we have results from studies you "
-"participated in."
-msgstr ""
-"Veri toplamaya başlamaktan makaleyi bir dergide görmeye kadar bilimsel bir "
-"çalışma yayınlama süreci birkaç yıl sürebilir. Belgelerle ilgili "
-"güncellemeler için Lookit ana sayfasını kontrol edebilir veya katıldığınız "
-"çalışmalardan sonuçlar aldığımızda bilgilendirilmek üzere iletişim "
-"tercihlerinizi ayarlayabilirsiniz."
-
-#: web/templates/frontpages/faq.html:218
+#: web/templates/web/faq.html:355
 msgid ""
 "My child wasn't paying attention, or we were interrupted. Can we try the "
 "study again?"
@@ -1858,7 +2521,7 @@ msgstr ""
 "Çocuğum dikkatini vermiyor, veya kesintiye uğradık. Çalışmayı yeniden "
 "deneyebilir miyiz?"
 
-#: web/templates/frontpages/faq.html:223
+#: web/templates/web/faq.html:364
 msgid ""
 "Certainly--thanks for your dedication! You may see a warning that you have "
 "already participated in the study when you go to try it again, but you can "
@@ -1870,14 +2533,14 @@ msgstr ""
 "görmezden gelebilirsiniz. Çalışmayı daha önce denediğinizi bize söylemenize "
 "gerek yok; önceki katılımınızın bir kaydını alacağız."
 
-#: web/templates/frontpages/faq.html:230
+#: web/templates/web/faq.html:377
 msgid ""
 "My child is outside the age range. Can he/she still participate in this "
 "study?"
 msgstr ""
 "Çocuğum yaş aralığının dışında kalıyor. Bu çalışmaya yine de katılabilir mi?"
 
-#: web/templates/frontpages/faq.html:235
+#: web/templates/web/faq.html:386
 msgid ""
 "Sure! We may not be able to use his or her data in our research directly, "
 "but if you're curious you're welcome to try the study anyway. (Sometimes big "
@@ -1891,11 +2554,11 @@ msgstr ""
 "çocuğunuzun yaşı bir çalışma için minimum yaşın hemen altındaysa beklemenizi "
 "öneririz, bu sayede verileri kullanabiliriz."
 
-#: web/templates/frontpages/faq.html:242
+#: web/templates/web/faq.html:399
 msgid "My child was born prematurely. Should we use his/her adjusted age?"
 msgstr "Çocuğum prematüre doğdu. Düzeltilmiş yaşını mı kullanmalıyız?"
 
-#: web/templates/frontpages/faq.html:247
+#: web/templates/web/faq.html:408
 msgid ""
 "For study eligibility, we usually use the child's chronological age (time "
 "since birth), even for premature babies. If adjusted age is important for a "
@@ -1906,14 +2569,14 @@ msgstr ""
 "çalışma için düzeltilmiş yaş önemliyse, bunu çalışmaya uygunluk "
 "kriterlerinde açıklığa kavuşturacağız."
 
-#: web/templates/frontpages/faq.html:254
+#: web/templates/web/faq.html:421
 msgid ""
 "Our family speaks a language other than English at home. Can my child "
 "participate?"
 msgstr ""
 "Ailemiz evde İngilizce dışında bir dil konuşuyor. Çocuğum katılabilir mi? "
 
-#: web/templates/frontpages/faq.html:259
+#: web/templates/web/faq.html:430
 msgid ""
 "Sure! Right now, instructions for children and parents are written only in "
 "English, so some of them may be confusing to a child who does not hear "
@@ -1931,7 +2594,7 @@ msgstr ""
 "soracağız. Ayrıca demografik ankette çocuğunuzun konuştuğu veya öğrenmekte "
 "olduğu dilleri belirtebilirsiniz. "
 
-#: web/templates/frontpages/faq.html:266
+#: web/templates/web/faq.html:443
 msgid ""
 "My child has been diagnosed with a developmental disorder or has special "
 "needs. Can he/she still participate?"
@@ -1939,20 +2602,32 @@ msgstr ""
 "Çocuğuma gelişimsel bir bozukluk teşhisi kondu veya özel ihtiyaçları var. "
 "Yine de katılabilir mi?"
 
-#: web/templates/frontpages/faq.html:271
+#: web/templates/web/faq.html:451
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Of course! We're interested in how all "
+#| "children learn and grow. If you'd like, you can make a note of any "
+#| "developmental disorders in the comments section at the end of the study. "
+#| "We are excited that in the future, online studies may help more families "
+#| "participate in research to better understand their own children's "
+#| "diagnoses.</p>\n"
+#| "                                <p>One note: most of our studies include "
+#| "both images and sound, and may be hard to understand if your child is "
+#| "blind or deaf. If you can, please feel free to help out by describing "
+#| "images or signing.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Of course! We're interested in how all "
-"children learn and grow. If you'd like, you can make a note of any "
-"developmental disorders in the comments section at the end of the study. We "
-"are excited that in the future, online studies may help more families "
-"participate in research to better understand their own children's diagnoses."
-"</p>\n"
-"                                <p>One note: most of our studies include "
-"both images and sound, and may be hard to understand if your child is blind "
-"or deaf. If you can, please feel free to help out by describing images or "
-"signing.</p>\n"
-"                                "
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>Elbette! Çocukların nasıl öğrendikleri ve "
@@ -1966,7 +2641,7 @@ msgstr ""
 "onun için zor olabilir. Yapabiliyorsanız, lütfen resimleri açıklayarak veya "
 "işaret dili kullanarak yardımcı olmaktan çekinmeyin.</p>"
 
-#: web/templates/frontpages/faq.html:281
+#: web/templates/web/faq.html:466
 msgid ""
 "I have multiple children in the age range for a study. Can they participate "
 "together?"
@@ -1974,7 +2649,7 @@ msgstr ""
 "Çalışmanın yaş aralığında olan birden fazla çocuğum var. Birlikte "
 "katılabilirler mi?"
 
-#: web/templates/frontpages/faq.html:286
+#: web/templates/web/faq.html:475
 msgid ""
 "If possible, we ask that each child participate separately. When children "
 "participate together they generally influence each other. That's a "
@@ -1985,32 +2660,46 @@ msgstr ""
 "katıldıklarında genellikle birbirlerini etkilerler. Bu başlı başına "
 "büyüleyici bir konu ama genellikle araştırmamızın odak noktası değildir."
 
-#: web/templates/frontpages/faq.html:293
+#: web/templates/web/faq.html:488
 msgid "But I've heard that young children should avoid 'screen time.'"
 msgstr ""
 "Fakat küçük çocukların 'ekran süresi'nden kaçınması gerektiğini duydum."
 
-#: web/templates/frontpages/faq.html:298
+#: web/templates/web/faq.html:496
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>We agree with the American Academy of "
+#| "Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
+#| "e20162591\" target=\"_blank\">advice</a> that children learn best from "
+#| "people, not screens! However, our studies are not intended to educate "
+#| "children, but to learn from them.</p>\n"
+#| "                                <p>As part of a child's limited screen "
+#| "time, we hope that our studies will foster family conversation and "
+#| "engagement with science that offsets the few minutes spent watching a "
+#| "video instead of playing. And we do \"walk the walk\"--our own young "
+#| "children provide lots of feedback on our studies!</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>We agree with the American Academy of "
-"Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
-"e20162591\" target=\"_blank\">advice</a> that children learn best from "
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
 "people, not screens! However, our studies are not intended to educate "
 "children, but to learn from them.</p>\n"
-"                                <p>As part of a child's limited screen time, "
-"we hope that our studies will foster family conversation and engagement with "
-"science that offsets the few minutes spent watching a video instead of "
-"playing. And we do \"walk the walk\"--our own young children provide lots of "
-"feedback on our studies!</p>\n"
-"                                "
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>Çocukların en iyi ekranlardan değil, "
-"insanlardan öğrendiği konusunda Amerikan Pediatri Akademisi’nin <a href="
-"\"https://pediatrics.aappublications.org/content/138/5/e20162591\" target="
-"\"_blank\">tavsiyesine</a> katılıyoruz! Ancak, çalışmalarımız çocukları "
-"eğitmeyi değil, onlardan öğrenmeyi amaçlıyor.</p>\n"
+"insanlardan öğrendiği konusunda Amerikan Pediatri Akademisi’nin <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\">tavsiyesine</a> katılıyoruz! Ancak, çalışmalarımız "
+"çocukları eğitmeyi değil, onlardan öğrenmeyi amaçlıyor.</p>\n"
 "                                <p>Gün içinde ekrana maruz kaldıkları "
 "sınırlı sürenin içine katabileceğiniz çalışmalarımızın, aile içinde sohbet "
 "etmeyi ve bilimle uğraşmayı teşvik ederek, oyun oynamak yerine video "
@@ -2018,11 +2707,11 @@ msgstr ""
 "de işe koyuluyoruz—kendi küçük çocuklarımız çalışmalarımızla ilgili çok "
 "sayıda geri bildirim sağlıyor!</p>"
 
-#: web/templates/frontpages/faq.html:308
+#: web/templates/web/faq.html:510
 msgid "Will we be paid for our participation?"
 msgstr "Katılımımız için bize ödeme yapılacak mı?"
 
-#: web/templates/frontpages/faq.html:313
+#: web/templates/web/faq.html:518
 msgid ""
 "Some research groups provide gift cards or other compensation for completing "
 "their studies, and others rely on volunteers. (This often depends on the "
@@ -2034,97 +2723,185 @@ msgstr ""
 "araştırmayı yapan üniversitenin kurallarına bağlıdır.) Bu bilgiler "
 "çalışmanın açıklama sayfasında listelenecektir."
 
-#: web/templates/frontpages/faq.html:320
-msgid "Can I get my child's results?"
-msgstr "Çocuğumun sonuçlarını alabilir miyim?"
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
 
-#: web/templates/frontpages/faq.html:325
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "                                <p>For some studies, yes! Usually, "
-#| "developmental researchers only interpret children's abilities and "
-#| "developmental trends at a group level, and the individual data collected "
-#| "just isn't very interpretable. But for \"Your baby, the physicist\" and "
-#| "other longitudinal studies (where you come back for more than one "
-#| "session), we can sometimes collect enough data to give you a report of "
-#| "your child's responses after you complete all the sessions.</p>\n"
-#| "                                <p>Please note that none of the measures "
-#| "we collect are diagnostic! For instance, while we hope you'll be "
-#| "interested to learn that your child looked 70%% of the time at videos "
-#| "where things fell up versus falling down, we won't be able to tell you "
-#| "whether this means your child is going to be especially good at physics.</"
-#| "p>\n"
-#| "                                <p>If you're interested in getting "
-#| "individual results right away, please see our <a "
-#| "href='resources'>Resources</a> section for fun at-home activities you can "
-#| "try with your child.</p>\n"
-#| "                                "
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
 msgid ""
 "\n"
-"                                <p>For some studies, yes! Usually, "
-"developmental researchers only interpret children's abilities and "
-"developmental trends at a group level, and the individual data collected "
-"just isn't very interpretable. But for \"Your baby, the physicist\" and "
-"other longitudinal studies (where you come back for more than one session), "
-"we can sometimes collect enough data to give you a report of your child's "
-"responses after you complete all the sessions.</p>\n"
-"                                <p>Please note that none of the measures we "
-"collect are diagnostic! For instance, while we hope you'll be interested to "
-"learn that your child looked 70%% of the time at videos where things fell up "
-"versus falling down, we won't be able to tell you whether this means your "
-"child is going to be especially good at physics.</p>\n"
-"                                <p>If you're interested in getting "
-"individual results right away, please see our <a href='resources'>Resources</"
-"a> section for fun at-home activities you can try with your child.</p>\n"
-"                                "
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
 msgstr ""
-"\n"
-"                                <p>Bazı çalışmalar için, evet! Genellikle, "
-"gelişim araştırmacıları çocukların becerilerini ve gelişimsel trendleri "
-"yalnızca grup seviyesinde yorumlar, ve toplanan bireysel veriler pek "
-"yorumlanamaz. Ancak “Fizikçi Bebeğiniz” çalışması ve diğer boylamsal (birden "
-"fazla oturum için geri geldiğiniz) çalışmalarda bazen siz tüm seansları "
-"tamamladıktan sonra çocuğunuzun yanıtları hakkında size bir rapor vermek "
-"için yeterli veri toplayabiliyoruz.</p>\n"
-"                                <p>Lütfen topladığımız ölçümlerin hiçbirinin "
-"teşhis amaçlı olmadığını unutmayın! Örneğin, çocuğunuzun nesnelerin yukarı "
-"doğru düştüğü (aşağı doğru düşmek yerine) videolarda zamanın %70’inde ekranı "
-"izlediğini öğrenmek ilginizi çekebilir, ancak size çocuğunuzun özellikle "
-"fizik dersinde başarılı olup olamayacağını söyleyebileceğimiz anlamına "
-"gelmez.</p>\n"
-"                                <p>Eğer hemen bireysel sonuçlar almakla "
-"ilgileniyorsanız, lütfen çocuğunuzla birlikte deneyebileceğiniz evde "
-"eğlenceli aktiviteler için <a href='resources'>Kaynaklar</a> bölümüne bakın."
-"</p>"
 
-#: web/templates/frontpages/faq.html:335
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
 msgid "Technical"
 msgstr "Teknik"
 
-#: web/templates/frontpages/faq.html:339
+#: web/templates/web/faq.html:652
 msgid "What browsers are supported?"
 msgstr "Hangi tarayıcılar destekleniyor?"
 
-#: web/templates/frontpages/faq.html:344
+#: web/templates/web/faq.html:660
+#, fuzzy
+#| msgid ""
+#| "Lookit supports recent versions of Chrome and Firefox. We are not "
+#| "currently able to support Internet Explorer or Safari."
 msgid ""
-"Lookit supports recent versions of Chrome and Firefox. We are not currently "
-"able to support Internet Explorer or Safari."
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
 msgstr ""
 "Lookit Chrome ve Firefox'un güncel versiyonlarını destekler. Şu anda Safari "
 "ve Internet Explorer'ı destekleyemiyoruz."
 
-#: web/templates/frontpages/faq.html:351
+#: web/templates/web/faq.html:672
 msgid "Can we do a study on my phone or tablet?"
 msgstr "Telefon veya tabletimden çalışma yapabilir miyiz?"
 
-#: web/templates/frontpages/faq.html:357
+#: web/templates/web/faq.html:679
+#, fuzzy
+#| msgid ""
+#| "Not yet! Because we're measuring kids' looking patterns, we need a "
+#| "reasonably stable view of their eyes and a big enough screen that we can "
+#| "tell whether they're looking at the left or the right side of it. We're "
+#| "excited about the potential for touchscreen studies that allow us to "
+#| "observe infants and toddlers exploring, though!"
 msgid ""
-"Not yet! Because we're measuring kids' looking patterns, we need a "
-"reasonably stable view of their eyes and a big enough screen that we can "
-"tell whether they're looking at the left or the right side of it. We're "
-"excited about the potential for touchscreen studies that allow us to observe "
-"infants and toddlers exploring, though!"
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
 msgstr ""
 "Henüz değil! Çocukların bakış modellerini ölçtüğümüz için, gözlerinin "
 "oldukça dengeli bir görüntüsüne ve soluna mı yoksa sağına mı baktıklarını "
@@ -2132,70 +2909,294 @@ msgstr ""
 "keşfeden bebekleri ve küçük çocukları gözlemlememizi sağlayan dokunmatik "
 "ekran çalışmalarının potansiyeli bizi heyecanlandırıyor!"
 
-#: web/templates/frontpages/home.html:11
-msgid "the online child lab"
-msgstr "çevrimiçi çocuk laboratuvarı"
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
+msgstr ""
 
-#: web/templates/frontpages/home.html:12
-msgid "A project of the MIT Early Childhood Cognition Lab"
-msgstr "MIT Erken Çocukluk Biliş Lab'ı projesi"
+#: web/templates/web/faq.html:700
+msgid ""
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
+msgstr ""
 
-#: web/templates/frontpages/home.html:12
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "Hangi ilde yaşıyorsunuz?"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "For researchers"
+msgid "For Researchers"
+msgstr "Araştırmacılar için"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "Yaşınız kaç?"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "Katılmak için giriş yapın:"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "Bilim insanları"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
 msgid "Participate in a Study"
 msgstr "Katılım"
 
-#: web/templates/frontpages/home.html:22
-msgid "Bringing science home"
-msgstr "Bilimi eve getiriyoruz"
-
-#: web/templates/frontpages/home.html:23
-msgid ""
-"Here at MIT's Early Childhood Cognition Lab, we're trying a new approach in "
-"developmental psychology: bringing the experiments to you."
+#: web/templates/web/home.html:52
+msgid "Help Science"
 msgstr ""
-"MIT'nin Erken Çocukluk Biliş Laboratuvarı'nda gelişim psikolojisinde yeni "
-"bir yaklaşım deniyoruz: deneyleri size getirmek."
 
-#: web/templates/frontpages/home.html:29
-msgid "Help us understand how your child thinks"
-msgstr "Çocuğunuzun nasıl düşündüğünü anlamamızda bize yardımcı olun"
-
-#: web/templates/frontpages/home.html:30
+#: web/templates/web/home.html:54
 msgid ""
-"Your family can contribute to research about how children learn by doing fun "
-"activities together, right in your web browser."
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
 msgstr ""
-"Aileniz, doğrudan web tarayıcınızdan birlikte eğlenceli aktiviteler yaparak "
-"çocukların nasıl öğrendiklerine ilişkin araştırmalara katkıda bulunabilir."
 
-#: web/templates/frontpages/home.html:36
-msgid "Participate whenever and wherever"
-msgstr "Her zaman ve her yerde katılın"
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "Anasayfa"
 
-#: web/templates/frontpages/home.html:37
+#: web/templates/web/home.html:61
 msgid ""
-"Log in or create an account at the top right to get started! You can "
-"participate with your child from any computer with a webcam."
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
 msgstr ""
-"Başlamak için giriş yapın veya sağ üstten bir hesap oluşturun! Çocuğunuzla "
-"birlikte  kamerası olan herhangi bir bilgisayardan katılabilirsiniz."
 
-#: web/templates/frontpages/privacy.html:11
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
+msgid "I would like to be contacted when:"
+msgstr "Şu durumda iletişime geçilmesini isterim:"
+
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "Katılmak için giriş yapın:"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "Hesap oluştur"
+
+#: web/templates/web/participant-signup.html:13
+msgid "Create Participant Account"
+msgstr "Katılımcı Hesabı Oluştur"
+
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "Araştırmacı olarak kayıt olmak için, lütfen kullanın"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+#, fuzzy
+#| msgid "instead"
+msgid "instead."
+msgstr "yerine"
+
+#: web/templates/web/participant-signup.html:28
+msgid ""
+"By clicking 'Create Account', I agree that I have read and accepted the "
+msgstr ""
+"'Hesap Oluştur' a tıklayarak, şunu okuduğumu ve kabul ettiğimi kabul ediyorum"
+
+#: web/templates/web/participant-signup.html:28
+msgid "Privacy Statement"
+msgstr "Gizlilik Bildirimi"
+
+#: web/templates/web/privacy.html:9
 msgid "Privacy statement"
 msgstr "Gizlilik Beyanı"
 
-#: web/templates/frontpages/privacy.html:17
+#: web/templates/web/privacy.html:11
 msgid "Introduction"
 msgstr "Giriş"
 
-#: web/templates/frontpages/privacy.html:18
+#: web/templates/web/privacy.html:14
+#, fuzzy
+#| msgid ""
+#| "Lookit is committed to supporting the privacy of individuals who enroll "
+#| "on our Platform to conduct\n"
+#| "                research or serve as research subjects. This Privacy "
+#| "Statement explains how we handle and use the\n"
+#| "                personal information we collect about our researchers and "
+#| "research participant community."
 msgid ""
 "Lookit is committed to supporting the privacy of individuals who enroll on "
 "our Platform to conduct\n"
-"                research or serve as research subjects. This Privacy "
-"Statement explains how we handle and use the\n"
-"                personal information we collect about our researchers and "
-"research participant community."
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
 msgstr ""
 "Lookit, araştırma yürütmek veya araştırma öznesi olarak görev almak için\n"
 "               Platformumuza kaydolan kişilerin mahremiyetini desteklemeye "
@@ -2204,19 +3205,28 @@ msgstr ""
 "               topluluğumuz hakkında topladığımız kişisel bilgileri nasıl "
 "işlediğimizi ve kullandığımızı açıklamaktadır."
 
-#: web/templates/frontpages/privacy.html:22
+#: web/templates/web/privacy.html:19
 msgid "For participants"
 msgstr "Katılımcılar için"
 
-#: web/templates/frontpages/privacy.html:24
+#: web/templates/web/privacy.html:22
+#, fuzzy
+#| msgid ""
+#| "Lookit is a platform that many different researchers use to conduct "
+#| "studies about how children learn and\n"
+#| "                develop. It is run by the MIT Early Childhood Cognition "
+#| "Lab, which has access to all of the data\n"
+#| "                collected on Lookit. Researchers using Lookit to conduct "
+#| "studies only access your personal information\n"
+#| "                if you choose to participate in their study."
 msgid ""
 "Lookit is a platform that many different researchers use to conduct studies "
 "about how children learn and\n"
-"                develop. It is run by the MIT Early Childhood Cognition Lab, "
-"which has access to all of the data\n"
-"                collected on Lookit. Researchers using Lookit to conduct "
-"studies only access your personal information\n"
-"                if you choose to participate in their study."
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
 msgstr ""
 "Lookit, pek çok farklı araştırmacının çocukların nasıl öğrendiği ve "
 "geliştiği konusunda araştırmalar yapmak için kullandığı bir platformdur.\n"
@@ -2225,35 +3235,54 @@ msgstr ""
 "                Lookit'i araştırma yapmak için kullanan araştırmacılar, "
 "kişisel bilgilerinize yalnızca çalışmalarına katılmayı seçerseniz erişirler."
 
-#: web/templates/frontpages/privacy.html:29
-#: web/templates/frontpages/privacy.html:142
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
 msgid "What personal information we collect"
 msgstr "Hangi kişisel bilgileri topluyoruz"
 
-#: web/templates/frontpages/privacy.html:31
+#: web/templates/web/privacy.html:30
 msgid "We collect the following kinds of personal information:"
 msgstr "Aşağıdaki kişisel bilgileri topluyoruz:"
 
-#: web/templates/frontpages/privacy.html:32
+#: web/templates/web/privacy.html:33
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Account data: basic contact information that may "
+#| "include your email address, nickname, mailing\n"
+#| "                    address, and contact preferences.</li>\n"
+#| "                <li>Child data: basic biographical information about your "
+#| "child(ren), including nickname, date of birth,\n"
+#| "                    and gestational age at birth.</li>\n"
+#| "                <li>Demographic data: background and biographical "
+#| "information such as your native language, race, age,\n"
+#| "                    educational background, and family history of "
+#| "particular medical conditions.</li>\n"
+#| "                <li>Study data: responses collected during particular "
+#| "studies conducted on Lookit, including webcam\n"
+#| "                    video of your family participating in the study, text "
+#| "entered in forms, the particular images that\n"
+#| "                    were shown, the timing of progression through the "
+#| "study, etc.</li>\n"
+#| "            </ul>"
 msgid ""
 "<ul>\n"
-"                <li>Account data: basic contact information that may include "
-"your email address, nickname, mailing\n"
-"                    address, and contact preferences.</li>\n"
-"                <li>Child data: basic biographical information about your "
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
 "child(ren), including nickname, date of birth,\n"
-"                    and gestational age at birth.</li>\n"
-"                <li>Demographic data: background and biographical "
-"information such as your native language, race, age,\n"
-"                    educational background, and family history of particular "
-"medical conditions.</li>\n"
-"                <li>Study data: responses collected during particular "
-"studies conducted on Lookit, including webcam\n"
-"                    video of your family participating in the study, text "
-"entered in forms, the particular images that\n"
-"                    were shown, the timing of progression through the study, "
-"etc.</li>\n"
-"            </ul>"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
 msgstr ""
 "<ul>\n"
 "                <li>Hesap verileri: e-mail adresinizi, takma adınızı, posta "
@@ -2271,31 +3300,37 @@ msgstr ""
 "toplanan yanıtlar</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:44
-#: web/templates/frontpages/privacy.html:147
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
 msgid "How we collect personal information about you"
 msgstr "Sizin hakkınızdaki kişisel bilgileri nasıl topluyoruz"
 
-#: web/templates/frontpages/privacy.html:46
+#: web/templates/web/privacy.html:48
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is the information you "
+#| "provide to us when registering\n"
+#| "                for a Lookit account, registering your children, updating "
+#| "your account or your children’s profiles,\n"
+#| "                completing or updating surveys, or participating in "
+#| "individual Lookit studies."
 msgid ""
 "The information we collect and maintain about you is the information you "
 "provide to us when registering\n"
-"                for a Lookit account, registering your children, updating "
-"your account or your children’s profiles,\n"
-"                completing or updating surveys, or participating in "
-"individual Lookit studies."
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
 msgstr ""
 "Hakkınızda topladığımız ve sakladığımız bilgiler, bir Lookit hesabına "
 "kaydolurken, çocuklarınızı kaydederken, hesabınızı veya çocuklarınızın "
 "profillerini güncellerken, anketleri tamamlarken veya güncellerken ya da "
 "bireysel Lookit çalışmalarına katılırken bize sağladığınız bilgilerdir."
 
-#: web/templates/frontpages/privacy.html:50
-#: web/templates/frontpages/privacy.html:167
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
 msgid "When we share your personal information"
 msgstr "Kişisel bilgilerinizi ne zaman paylaşıyoruz"
 
-#: web/templates/frontpages/privacy.html:52
+#: web/templates/web/privacy.html:56
 msgid ""
 "When you participate in a Lookit study, we share the following information "
 "with the research group conducting the study:"
@@ -2303,15 +3338,26 @@ msgstr ""
 "Bir Lookit çalışmasına katıldığınızda, çalışmayı yürüten araştırma grubuyla "
 "aşağıdaki bilgileri paylaşıyoruz:"
 
-#: web/templates/frontpages/privacy.html:54
+#: web/templates/web/privacy.html:60
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>Your account data </li>\n"
+#| "                <li>The child data for the child who is participating</"
+#| "li>\n"
+#| "                <li>Your demographic data</i>\n"
+#| "                <li>The study data for this particular study session</"
+#| "li>\n"
+#| "            </ul>"
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>Your account data </li>\n"
-"                <li>The child data for the child who is participating</li>\n"
-"                <li>Your demographic data</i>\n"
-"                <li>The study data for this particular study session</li>\n"
-"            </ul>"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
 msgstr ""
 "\n"
 "            <ul>\n"
@@ -2321,7 +3367,7 @@ msgstr ""
 "                <li>Bu çalışma oturumuna özel çalışma verileri</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:61
+#: web/templates/web/privacy.html:68
 msgid ""
 "Your email address is not shared directly with the research group, although "
 "they can contact you via Lookit in accordance with your contact preferences."
@@ -2330,13 +3376,20 @@ msgstr ""
 "tercihlerinize uygun olarak sizinle Lookit aracılığıyla iletişim "
 "kurabilirler."
 
-#: web/templates/frontpages/privacy.html:63
+#: web/templates/web/privacy.html:71
+#, fuzzy
+#| msgid ""
+#| "Researchers may publish the results of a study, including individual "
+#| "responses. However, although they\n"
+#| "                may publish the ages of participants, they may not "
+#| "publish participant birthdates (or information that\n"
+#| "                could be used to calculate birthdates)."
 msgid ""
 "Researchers may publish the results of a study, including individual "
 "responses. However, although they\n"
-"                may publish the ages of participants, they may not publish "
+"        may publish the ages of participants, they may not publish "
 "participant birthdates (or information that\n"
-"                could be used to calculate birthdates)."
+"    could be used to calculate birthdates)."
 msgstr ""
 "Araştırmacılar, bireysel yanıtlar da dahil olmak üzere bir çalışmanın "
 "sonuçlarını yayınlayabilirler. Ancak,\n"
@@ -2344,20 +3397,33 @@ msgstr ""
 "doğum tarihlerini  (veya doğum tarihlerini hesaplamak \n"
 "                için kullanılabilecek bilgileri) yayınlayamazlar."
 
-#: web/templates/frontpages/privacy.html:67
+#: web/templates/web/privacy.html:76
+#, fuzzy
+#| msgid ""
+#| "We and/or the researchers responsible for a study may share video of your "
+#| "family’s participation for\n"
+#| "                scientific, educational, and/or publicity purposes, but "
+#| "only if you choose at the conclusion of a study\n"
+#| "                to allow such usage. Researchers may also share your "
+#| "video and other data with Databrary if you choose\n"
+#| "                at the conclusion of a study to allow that. We don’t "
+#| "publish video of participants such that it can be\n"
+#| "                linked to individual demographic data (e.g., household "
+#| "income or number of parents/guardians), and\n"
+#| "                researchers must also agree not to do so in order to use "
+#| "Lookit."
 msgid ""
 "We and/or the researchers responsible for a study may share video of your "
 "family’s participation for\n"
-"                scientific, educational, and/or publicity purposes, but only "
-"if you choose at the conclusion of a study\n"
-"                to allow such usage. Researchers may also share your video "
-"and other data with Databrary if you choose\n"
-"                at the conclusion of a study to allow that. We don’t publish "
-"video of participants such that it can be\n"
-"                linked to individual demographic data (e.g., household "
-"income or number of parents/guardians), and\n"
-"                researchers must also agree not to do so in order to use "
-"Lookit."
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
 msgstr ""
 "Biz ve / veya bir araştırmadan sorumlu araştırmacılar, ailenizin katılımının "
 "videosunu bilimsel, eğitimsel ve / veya tanıtım amaçlı paylaşabilir, ancak "
@@ -2371,13 +3437,20 @@ msgstr ""
 "                araştırmacılar da Lookit'i kullanmak için bunu yapmamayı "
 "kabul etmelidir."
 
-#: web/templates/frontpages/privacy.html:74
+#: web/templates/web/privacy.html:84
+#, fuzzy
+#| msgid ""
+#| "We don’t share, sell, publish, or otherwise disclose your contact "
+#| "information (email and/or mailing\n"
+#| "                address) to anyone but the researchers involved in a "
+#| "study. Researchers must also agree not to disclose\n"
+#| "                your contact information in order to use Lookit."
 msgid ""
 "We don’t share, sell, publish, or otherwise disclose your contact "
 "information (email and/or mailing\n"
-"                address) to anyone but the researchers involved in a study. "
+"        address) to anyone but the researchers involved in a study. "
 "Researchers must also agree not to disclose\n"
-"                your contact information in order to use Lookit."
+"        your contact information in order to use Lookit."
 msgstr ""
 "İletişim bilgilerinizi (e-mail ve / veya posta adresi) bir çalışmaya dahil "
 "olan araştırmacılar dışında herhangi biriyle paylaşmayız, satmayız, "
@@ -2386,12 +3459,11 @@ msgstr ""
 "Lookit'i kullanmak için\n"
 "                 iletişim bilgileriniz ifşa etmemeyi kabul etmelidir."
 
-#: web/templates/frontpages/privacy.html:78
-#: web/templates/frontpages/privacy.html:152
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
 msgid "How we use your personal information"
 msgstr "Kişisel bilgilerinizi nasıl kullanıyoruz"
 
-#: web/templates/frontpages/privacy.html:80
+#: web/templates/web/privacy.html:92
 msgid ""
 "We may use your personal information (account, child, demographic, and study "
 "data) for a variety of purposes, including to:"
@@ -2399,35 +3471,63 @@ msgstr ""
 "Kişisel bilgilerinizi (hesap, çocuk, demografik ve çalışma verileri) şunlar "
 "dahil çeşitli amaçlar için kullanabiliriz:"
 
-#: web/templates/frontpages/privacy.html:81
+#: web/templates/web/privacy.html:94
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Provide you with the research studies you have "
+#| "enrolled in, and information about which studies your\n"
+#| "                    children are eligible for</li>\n"
+#| "                <li>Send you information about studies you may be "
+#| "interested in, reminders to participate in multi-part\n"
+#| "                    studies, and/or results of studies you have "
+#| "participated in, subject to your contact preferences\n"
+#| "                </li>\n"
+#| "                <li>Improve the Lookit platform: e.g., detect and fix "
+#| "technical problems or identify new features that\n"
+#| "                    would be helpful</li>\n"
+#| "                <li>Develop data analysis tools for Lookit researchers </"
+#| "li>\n"
+#| "                <li>Provide technical support to study researchers</li>\n"
+#| "                <li>Assess the quality of data collected on the platform "
+#| "(e.g., how well an observer can tell which\n"
+#| "                    direction children are looking)</li>\n"
+#| "                <li>Evaluate recruitment and family engagement efforts (e."
+#| "g., see how many participants come from rural\n"
+#| "                    vs. urban areas)</li>\n"
+#| "                <li>Recruit participants or researchers to use Lookit (e."
+#| "g., sharing a short video clip of your child\n"
+#| "                    having fun – ONLY if you have chosen to allow use of "
+#| "the video for publicity)</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research studies you have enrolled "
-"in, and information about which studies your\n"
-"                    children are eligible for</li>\n"
-"                <li>Send you information about studies you may be interested "
-"in, reminders to participate in multi-part\n"
-"                    studies, and/or results of studies you have participated "
-"in, subject to your contact preferences\n"
-"                </li>\n"
-"                <li>Improve the Lookit platform: e.g., detect and fix "
-"technical problems or identify new features that\n"
-"                    would be helpful</li>\n"
-"                <li>Develop data analysis tools for Lookit researchers </"
-"li>\n"
-"                <li>Provide technical support to study researchers</li>\n"
-"                <li>Assess the quality of data collected on the platform (e."
-"g., how well an observer can tell which\n"
-"                    direction children are looking)</li>\n"
-"                <li>Evaluate recruitment and family engagement efforts (e."
-"g., see how many participants come from rural\n"
-"                    vs. urban areas)</li>\n"
-"                <li>Recruit participants or researchers to use Lookit (e.g., "
-"sharing a short video clip of your child\n"
-"                    having fun – ONLY if you have chosen to allow use of the "
-"video for publicity)</li>\n"
-"            </ul>\n"
-"            "
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "                <li>Kaydolduğunuz araştırmalar ve çocuklarınızın hangi "
@@ -2455,17 +3555,28 @@ msgstr ""
 "            </ul>\n"
 "            "
 
-#: web/templates/frontpages/privacy.html:100
+#: web/templates/web/privacy.html:113
+#, fuzzy
+#| msgid ""
+#| "Researchers use the data collected in their studies to address particular "
+#| "scientific questions. It may\n"
+#| "                also turn out that data collected for one study can help "
+#| "to answer a related question later on. If\n"
+#| "                researchers are using any additional information about "
+#| "you in their study, beyond what is collected on\n"
+#| "                Lookit – for instance, if you are participating in a "
+#| "follow-up online session for an in-person study –\n"
+#| "                they must tell you that in the study consent form."
 msgid ""
 "Researchers use the data collected in their studies to address particular "
 "scientific questions. It may\n"
-"                also turn out that data collected for one study can help to "
+"            also turn out that data collected for one study can help to "
 "answer a related question later on. If\n"
-"                researchers are using any additional information about you "
-"in their study, beyond what is collected on\n"
-"                Lookit – for instance, if you are participating in a follow-"
-"up online session for an in-person study –\n"
-"                they must tell you that in the study consent form."
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
 msgstr ""
 "Araştırmacılar, çalışmalarında toplanan verileri belirli bilimsel soruları "
 "ele almak için kullanırlar.\n"
@@ -2476,7 +3587,7 @@ msgstr ""
 "çevrimiçi tamamlayıcı oturuma katılıyorsanız- bunu çalışma onay formunda "
 "size söylemelidirler."
 
-#: web/templates/frontpages/privacy.html:106
+#: web/templates/web/privacy.html:120
 msgid ""
 "There are some basic rules about how personal information may be used that "
 "all Lookit researchers agree to, including:"
@@ -2485,17 +3596,28 @@ msgstr ""
 "kişisel bilgilerin nasıl kullanılabileceğine ilişkin bazı temel kurallar "
 "vardır:"
 
-#: web/templates/frontpages/privacy.html:107
+#: web/templates/web/privacy.html:122
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>They may not use usernames, child nicknames, or "
+#| "contact information as a subject of research.</li>\n"
+#| "                <li>They may contact families by postal mail only in "
+#| "order to send compensation for study participation\n"
+#| "                    or materials needed for participation.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>They may not use usernames, child nicknames, or contact "
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
 "information as a subject of research.</li>\n"
-"                <li>They may contact families by postal mail only in order "
-"to send compensation for study participation\n"
-"                    or materials needed for participation.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "\n"
 "            <ul>\n"
@@ -2507,14 +3629,20 @@ msgstr ""
 "            </ul>\n"
 "            "
 
-#: web/templates/frontpages/privacy.html:114
-#: web/templates/frontpages/privacy.html:163
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+#, fuzzy
+#| msgid ""
+#| "If you have concerns about any of these purposes, or how we communicate "
+#| "with you, please contact us at\n"
+#| "                dataprotection@mit.edu. We will always respect a request "
+#| "by you to stop processing your personal\n"
+#| "                information (subject to our legal obligations)."
 msgid ""
 "If you have concerns about any of these purposes, or how we communicate with "
 "you, please contact us at\n"
-"                dataprotection@mit.edu. We will always respect a request by "
-"you to stop processing your personal\n"
-"                information (subject to our legal obligations)."
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
 msgstr ""
 "Bu amaçlardan herhangi biri veya sizinle nasıl iletişim kurduğumuz hakkında "
 "endişeleriniz varsa, lütfen bizimle şuradan iletişime geçin\n"
@@ -2522,12 +3650,11 @@ msgstr ""
 "durdurma isteğinize her zaman saygı duyacağız\n"
 "                 (yasal yükümlülüklerimize tabidir)."
 
-#: web/templates/frontpages/privacy.html:118
-#: web/templates/frontpages/privacy.html:171
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
 msgid "How your information is stored and secured"
 msgstr "Bilgileriniz nasıl saklanır ve gizli tutulur"
 
-#: web/templates/frontpages/privacy.html:120
+#: web/templates/web/privacy.html:138
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2552,23 +3679,23 @@ msgstr "Bilgileriniz nasıl saklanır ve gizli tutulur"
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection, "
-"and all video data is encrypted at rest on\n"
-"                the storage systems used by Lookit to provide data to "
-"researchers. Researchers are responsible for their\n"
-"                own secure storage of data once they obtain it from Lookit. "
-"You should be aware, however, that since the\n"
-"                internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be accessed,\n"
-"                disclosed, altered, or destroyed by breach of any of our "
-"physical, technical, or managerial safeguards.\n"
-"                It's your responsibility to protect the security of your "
-"account details, including your username and\n"
-"                password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
 msgstr ""
 "Sağlayabileceğiniz kişisel bilgileri korumak için tasarlanmış endüstri "
 "standardı güvenlik önlemleri uyguladık. Ayrıca olası güvenlik açıkları ve "
@@ -2585,25 +3712,37 @@ msgstr ""
 "Kullanıcı adınız ve şifreniz dahil olmak üzere hesap detaylarınızın "
 "güvenliğini korumak sizin sorumluluğunuzdadır."
 
-#: web/templates/frontpages/privacy.html:131
-#: web/templates/frontpages/privacy.html:182
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
 msgid "How long we keep your personal information"
 msgstr "Kişisel bilgilerinizi ne kadar süre saklıyoruz"
 
-#: web/templates/frontpages/privacy.html:133
+#: web/templates/web/privacy.html:153
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you wish\n"
+#| "                to remove your account, we will retain a core set of "
+#| "information about you to fulfill administrative\n"
+#| "                tasks and legal obligations. If you have participated in "
+#| "Lookit studies, the personal information\n"
+#| "                already shared with those researchers may not generally "
+#| "be ‘taken back,’ as it is part of a scientific\n"
+#| "                dataset and removing your data could affect already "
+#| "published findings."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you wish\n"
-"                to remove your account, we will retain a core set of "
-"information about you to fulfill administrative\n"
-"                tasks and legal obligations. If you have participated in "
-"Lookit studies, the personal information\n"
-"                already shared with those researchers may not generally be "
-"‘taken back,’ as it is part of a scientific\n"
-"                dataset and removing your data could affect already "
-"published findings."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
 msgstr ""
 "Araştırma topluluğumuzla ilişkimizin ömür boyu süreceğini düşünüyoruz. Bu, "
 "iletişimde kalmamızı istemediğinizi söyleyene kadar sizin için bir kaydı "
@@ -2614,30 +3753,41 @@ msgstr ""
 "parçası olduğundan ve verilerinizin kaldırılması önceden yayınlanmış "
 "bulguları etkileyebileceğinden, genellikle \"geri alınamayabilir\"."
 
-#: web/templates/frontpages/privacy.html:144
+#: web/templates/web/privacy.html:165
+#, fuzzy
+#| msgid ""
+#| "We may collect basic biographic/contact information about you and your "
+#| "representative organization,\n"
+#| "                including name, title, business addresses, phone numbers, "
+#| "and email addresses."
 msgid ""
 "We may collect basic biographic/contact information about you and your "
 "representative organization,\n"
-"                including name, title, business addresses, phone numbers, "
-"and email addresses."
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
 msgstr ""
 "Siz ve temsilci kuruluşunuz hakkındaki temel biyografik/ iletişim "
 "bilgilerini toplayabiliriz,\n"
 "                 ad, unvan, iş adresleri, telefon numaraları ve email "
 "adresleri dahil."
 
-#: web/templates/frontpages/privacy.html:149
+#: web/templates/web/privacy.html:172
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is that which you have "
+#| "provided to us when registering\n"
+#| "                to use Lookit, updating your profile, or creating or "
+#| "editing a study."
 msgid ""
 "The information we collect and maintain about you is that which you have "
 "provided to us when registering\n"
-"                to use Lookit, updating your profile, or creating or editing "
-"a study."
+"        to use Lookit, updating your profile, or creating or editing a study."
 msgstr ""
 "Hakkınızda topladığımız ve sakladığımız bilgiler,  Lookit'i kullanmak için \n"
 "                kayıt olurken, profilinizi güncellerken veya bir çalışma "
 "oluştururken ya da düzenlerken bize sağladığınız bilgilerdir."
 
-#: web/templates/frontpages/privacy.html:154
+#: web/templates/web/privacy.html:179
 msgid ""
 "We use your personal information for a number of legitimate purposes, "
 "including the performance of contractual obligations. Specifically, we use "
@@ -2647,18 +3797,30 @@ msgstr ""
 "dahil olmak üzere bir dizi meşru amaç için kullanıyoruz. Kişisel "
 "bilgilerinizi özellikle şu amaçlarla kullanırız:"
 
-#: web/templates/frontpages/privacy.html:155
+#: web/templates/web/privacy.html:181
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Provide you with the research services for which you "
+#| "have enrolled. </li>\n"
+#| "                <li>Perform administrative tasks and for internal record "
+#| "keeping purposes.</li>\n"
+#| "                <li>Create and analyze aggregated (fully anonymized) "
+#| "information about our users for statistical\n"
+#| "                    research purposes in support of our mission.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research services for which you "
-"have enrolled. </li>\n"
-"                <li>Perform administrative tasks and for internal record "
-"keeping purposes.</li>\n"
-"                <li>Create and analyze aggregated (fully anonymized) "
-"information about our users for statistical\n"
-"                    research purposes in support of our mission.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 " <ul>\n"
 "                <li>Kaydolduğunuz araştırmalar için araştırma hizmetlerini "
@@ -2671,11 +3833,11 @@ msgstr ""
 "            </ul>\n"
 "            "
 
-#: web/templates/frontpages/privacy.html:169
+#: web/templates/web/privacy.html:196
 msgid "We do not share your personal information with any third parties."
 msgstr "Kişisel bilgilerinizi üçüncü partilerle paylaşmayız."
 
-#: web/templates/frontpages/privacy.html:173
+#: web/templates/web/privacy.html:201
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2696,19 +3858,19 @@ msgstr "Kişisel bilgilerinizi üçüncü partilerle paylaşmayız."
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection. "
-"You should be aware, however, that since\n"
-"                the internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be\n"
-"                accessed, disclosed, altered, or destroyed by breach of any "
-"of our physical, technical, or managerial\n"
-"                safeguards. It's your responsibility to protect the security "
-"of your account details, including your\n"
-"                username and password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
 msgstr ""
 "Sağlayabileceğiniz kişisel bilgileri korumak için tasarlanmış endüstri "
 "standardı güvenlik önlemleri uyguladık. Ayrıca olası güvenlik açıkları ve "
@@ -2722,15 +3884,24 @@ msgstr ""
 "Kullanıcı adınız ve şifreniz dahil olmak üzere hesap detaylarınızın "
 "güvenliğini korumak sizin sorumluluğunuzdadır."
 
-#: web/templates/frontpages/privacy.html:184
+#: web/templates/web/privacy.html:214
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you no\n"
+#| "                longer wish to hear from Lookit, we will retain a core "
+#| "set of information about you to fulfill\n"
+#| "                administrative tasks and legal obligations."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you no\n"
-"                longer wish to hear from Lookit, we will retain a core set "
-"of information about you to fulfill\n"
-"                administrative tasks and legal obligations."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
 msgstr ""
 "Araştırma topluluğumuzla ilişkimizin ömür boyu süreceğini düşünüyoruz. Bu, "
 "bize artık iletişimde kalmamızı istemediğinizi söyleyene kadar sizin için "
@@ -2738,25 +3909,36 @@ msgstr ""
 "istemiyorsanız, idari görevleri ve yasal yükümlülükleri yerine getirmek için "
 "sizinle ilgili temel bilgileri saklayacağız."
 
-#: web/templates/frontpages/privacy.html:189
+#: web/templates/web/privacy.html:220
 msgid "For everyone"
 msgstr "Herkes için"
 
-#: web/templates/frontpages/privacy.html:191
+#: web/templates/web/privacy.html:221
 msgid "Rights for individuals in the European Economic Area"
 msgstr "Avrupa Ekonomik Bölgesindeki bireylerin hakları"
 
-#: web/templates/frontpages/privacy.html:192
+#: web/templates/web/privacy.html:224
+#, fuzzy
+#| msgid ""
+#| "You have the right in certain circumstances to (1) access your personal "
+#| "information; (2) to correct or\n"
+#| "                erase information; (3) restrict processing; and (4) "
+#| "object to communications, direct marketing, or\n"
+#| "                profiling. To the extent applicable, the EU’s General "
+#| "Data Protection Regulation provides further\n"
+#| "                information about your rights. You also have the right to "
+#| "lodge complaints with your national or\n"
+#| "                regional data protection authority."
 msgid ""
 "You have the right in certain circumstances to (1) access your personal "
 "information; (2) to correct or\n"
-"                erase information; (3) restrict processing; and (4) object "
-"to communications, direct marketing, or\n"
-"                profiling. To the extent applicable, the EU’s General Data "
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
 "Protection Regulation provides further\n"
-"                information about your rights. You also have the right to "
-"lodge complaints with your national or\n"
-"                regional data protection authority."
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
 msgstr ""
 "Bazı durumlarda (1) kişisel bilgilerinize erişme; (2) bilgileri düzeltme "
 "veya silme; (3) işlemeyi kısıtlama; ve (4) iletişime, doğrudan pazarlamaya "
@@ -2767,23 +3949,40 @@ msgstr ""
 "                Ayrıca ulusal veya bölgesel veri koruma kurumunuza şikayette "
 "bulunma hakkına da sahipsiniz."
 
-#: web/templates/frontpages/privacy.html:198
+#: web/templates/web/privacy.html:231
+#, fuzzy
+#| msgid ""
+#| "If you are inclined to exercise these rights, we request an opportunity "
+#| "to discuss with you any concerns\n"
+#| "                you may have. To protect the personal information we "
+#| "hold, we may also request further information to\n"
+#| "                verify your identify when exercising these rights. Upon a "
+#| "request to erase information, we will maintain\n"
+#| "                a core set of personal data to ensure we do not contact "
+#| "you inadvertently in the future, as well as any\n"
+#| "                information necessary for archival purposes. We may also "
+#| "need to retain some financial information for\n"
+#| "                legal purposes, including US IRS compliance. In the event "
+#| "of an actual or threatened legal claim, we may\n"
+#| "                retain your information for purposes of establishing, "
+#| "defending against or exercising our rights with\n"
+#| "                respect to such claim."
 msgid ""
 "If you are inclined to exercise these rights, we request an opportunity to "
 "discuss with you any concerns\n"
-"                you may have. To protect the personal information we hold, "
-"we may also request further information to\n"
-"                verify your identify when exercising these rights. Upon a "
-"request to erase information, we will maintain\n"
-"                a core set of personal data to ensure we do not contact you "
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
 "inadvertently in the future, as well as any\n"
-"                information necessary for archival purposes. We may also "
-"need to retain some financial information for\n"
-"                legal purposes, including US IRS compliance. In the event of "
-"an actual or threatened legal claim, we may\n"
-"                retain your information for purposes of establishing, "
-"defending against or exercising our rights with\n"
-"                respect to such claim."
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
 msgstr ""
 "Bu hakları kullanma eğilimindeyseniz, endişelerinizi sizinle görüşmek için "
 "bir fırsat talep ediyoruz.\n"
@@ -2798,15 +3997,24 @@ msgstr ""
 "ilişkin haklarımızı tesis etmek, savunmak veya kullanmak amacıyla "
 "saklayabiliriz."
 
-#: web/templates/frontpages/privacy.html:207
+#: web/templates/web/privacy.html:241
+#, fuzzy
+#| msgid ""
+#| "By providing information directly to Lookit, you consent to the transfer "
+#| "of your personal information\n"
+#| "                outside of the European Economic Area to the United "
+#| "States. You understand that the current laws and\n"
+#| "                regulations of the United States may not provide the same "
+#| "level of protection as the data and privacy\n"
+#| "                laws and regulations of the EEA."
 msgid ""
 "By providing information directly to Lookit, you consent to the transfer of "
 "your personal information\n"
-"                outside of the European Economic Area to the United States. "
-"You understand that the current laws and\n"
-"                regulations of the United States may not provide the same "
-"level of protection as the data and privacy\n"
-"                laws and regulations of the EEA."
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
 msgstr ""
 "Doğrudan Lookit'e bilgi sağlayarak, kişisel bilgilerinizin Avrupa Ekonomik "
 "Alanı dışındaki Amerika Birleşik Devletleri'ne \n"
@@ -2816,7 +4024,7 @@ msgstr ""
 "düzeyde \n"
 "                 koruma sağlamayabileceğini bilmelisiniz."
 
-#: web/templates/frontpages/privacy.html:212
+#: web/templates/web/privacy.html:246
 msgid ""
 "You are under no statutory or contractual obligation to provide any personal "
 "data to us."
@@ -2824,23 +4032,29 @@ msgstr ""
 "Bize herhangi bir kişisel veri sağlama konusunda hiçbir yasal veya "
 "sözleşmeye dayalı yükümlülük altında değilsiniz."
 
-#: web/templates/frontpages/privacy.html:214
+#: web/templates/web/privacy.html:248
 msgid "Additional Information"
 msgstr "Ek Bilgi"
 
-#: web/templates/frontpages/privacy.html:216
+#: web/templates/web/privacy.html:251
+#, fuzzy
+#| msgid ""
+#| "We may change this Privacy Statement from time to time. If we make any "
+#| "significant changes in the way we\n"
+#| "                treat your personal information we will make this clear "
+#| "on our website or by contacting you directly."
 msgid ""
 "We may change this Privacy Statement from time to time. If we make any "
 "significant changes in the way we\n"
-"                treat your personal information we will make this clear on "
-"our website or by contacting you directly."
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
 msgstr ""
 "Bu Gizlilik Beyanını zaman zaman değiştirebiliriz. Kişisel bilgilerinizi ele "
 "alışımızda\n"
 "                 önemli bir değişiklik yaparsak bunu web sitemizde veya "
 "sizinle doğrudan iletişime geçerek açıklığa kavuşturacağız."
 
-#: web/templates/frontpages/privacy.html:220
+#: web/templates/web/privacy.html:255
 msgid ""
 "The controller for your personal information is MIT. We can be contacted at "
 "dataprotection@mit.edu."
@@ -2848,507 +4062,130 @@ msgstr ""
 "Kişisel bilgilerinizin denetleyicisi MIT'dir. Bize dataprotection@mit.edu. "
 "adresinden ulaşabilirsiniz."
 
-#: web/templates/frontpages/privacy.html:222
+#: web/templates/web/privacy.html:257
 msgid "This policy was last updated in June 2018."
 msgstr "Anlaşma şartları en son Haziran 2018'de güncellenmiştir."
 
-#: web/templates/frontpages/scientists.html:27
-msgid "Meet the Lookit team"
-msgstr "Lookit ekibiyle tanışın"
-
-#: web/templates/frontpages/scientists.html:33
-msgid "Core Team"
-msgstr "Çekirdek Ekip"
-
-#: web/templates/frontpages/scientists.html:38
-msgid ""
-"Rico is Lookit's lead software engineer, working on planning and adding "
-"features for both participants and researchers."
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
 msgstr ""
-"Rico Lookit'in lider yazılım mühendisidir, hem katılımcılar hem de "
-"araştırmacılar için yeni özellikler planlama ve ekleme üzerine çalışıyor."
 
-#: web/templates/frontpages/scientists.html:43
-msgid ""
-"Laura is the PI of the Early Childhood Cognition Lab. She conducts research "
-"about how children arrive at a common-sense understanding of the physical "
-"and social world through exploration and instruction."
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
 msgstr ""
-"Laura, Erken Çocukluk Biliş Laboratuvarı'nın baş araştırmacısıdır. Keşif ve "
-"öğretim yoluyla çocukların fiziksel ve sosyal dünyanın sağduyulu bir "
-"anlayışına nasıl ulaştıkları hakkında araştırma yapıyor."
 
-#: web/templates/frontpages/scientists.html:49
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
 msgid ""
-"Kim started Lookit as a graduate student, and now runs the project as a "
-"research scientist in the Early Childhood Cognition Lab. Her three children "
-"frequently provide feedback on studies."
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
 msgstr ""
-"Kim, Lookit'e yüksek lisans öğrencisi olarak başladı ve şimdi projeyi Erken "
-"Çocukluk Biliş Laboratuvarı'nda araştırmacı bilim insanı olarak yürütüyor. "
-"Üç çocuğu, çalışmaları hakkında sık sık geri bildirimde bulunuyor."
 
-#: web/templates/frontpages/scientists.html:54
-msgid ""
-"Mark organizes the Lookit Working Groups, which are groups of researchers "
-"working to improve Lookit in a variety of ways."
-msgstr ""
-"Mark Lookit Çalışma Gruplarını organize ediyor, bu gruplar Lookit'in çeşitli "
-"yollardan geliştirilmesi için çalışan araştırmacılardan oluşur."
-
-#: web/templates/registration/logged_out.html:6
-msgid "You've successfully logged out."
-msgstr "Başarılı bir şekilde çıkış yaptınız."
-
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr "Giriş kimlik bilgileriniz çalışmadı. Lütfen tekrar deneyin."
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:45
-msgid "Login"
-msgstr "Giriş yap"
-
-#: web/templates/registration/login.html:34
-msgid "Forgot password?"
-msgstr "Şifrenizi mi unuttunuz?"
-
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Lookit'te yeni misiniz?"
-
-#: web/templates/registration/login.html:36
-msgid "Register your family!"
-msgstr "Ailenizi kaydedin!"
-
-#: web/templates/registration/password_change_done.html:11
-msgid "Password changed"
-msgstr "Şifre değiştirildi"
-
-#: web/templates/registration/password_change_done.html:15
-msgid "Your password was changed."
-msgstr "Şifreniz değiştirildi."
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Documentation"
-msgstr "Belgeler"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Change password"
-msgstr "Şifreyi değiştir"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Log out"
-msgstr "Çıkış yap"
-
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
-msgid "Home"
-msgstr "Anasayfa"
-
-#: web/templates/registration/password_change_form.html:8
-msgid "Password change"
-msgstr "Şifre değiştirme"
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the error below."
-msgstr "Lütfen aşağıdaki hatayı düzeltiniz."
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the errors below."
-msgstr "Lütfen aşağıdaki hataları düzeltiniz."
-
-#: web/templates/registration/password_change_form.html:26
-msgid ""
-"Please enter your old password, for security's sake, and then enter your new "
-"password twice so we can verify you typed it in correctly."
-msgstr ""
-"Lütfen güvenlik için eski şifrenizi girin ve daha sonra yeni şifrenizi doğru "
-"yazdığınızı onaylayabilmemiz için iki kez girin."
-
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
-msgid "Change my password"
-msgstr "Şifremi değiştir"
-
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "Şifre sıfırlama tamamlandı"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "Şifreniz oluşturuldu. Şimdi giriş yapabilirsiniz."
-
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "Giriş yap"
-
-#: web/templates/registration/password_reset_confirm.html:11
-msgid "Password reset confirmation"
-msgstr "Şifre sıfırlama onayı"
-
-#: web/templates/registration/password_reset_confirm.html:17
-msgid ""
-"Please enter your new password twice so we can verify you typed it in "
-"correctly."
-msgstr ""
-"Lütfen doğru yazdığınızı onaylayabilmemiz için yeni şifrenizi iki kez "
-"giriniz."
-
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "Yeni şifre:"
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "Şifrenizi onaylayın:"
-
-#: web/templates/registration/password_reset_confirm.html:37
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr ""
-"Şifre sıfırlama bağlantısı geçersizdir çünkü muhtemelen daha önce "
-"kullanıldı. Lütfen yeni bir şifre sıfırlama isteği gönderin."
-
-#: web/templates/registration/password_reset_done.html:11
-msgid "Password reset link sent"
-msgstr "Şifre sıfırlama linki gönderildi"
-
-#: web/templates/registration/password_reset_done.html:15
-msgid ""
-"If an account exists with the email you entered, we've emailed instructions "
-"for resetting your password and you should receive them shortly."
-msgstr ""
-"Eğer girdiğiniz email ile bir hesap mevcutsa, şifre sıfırlama yönergelerini "
-"size email ile gönderdik bu emaili kısa sürede almış olmalısınız."
-
-#: web/templates/registration/password_reset_done.html:17
-msgid ""
-"If you don't receive an email, please check your spam folder and make sure "
-"you've entered the address you registered with. (You won't get an email "
-"unless there's already an account for that email address!)"
-msgstr ""
-"Eğer email almadıysanız, lütfen spam klasörünü kontrol edin ve kayıt "
-"olduğunuz email adresini girdiğinizden emin olun. (Eğer o email adresi için "
-"bir hesap mevcut değilse email almayacaksınız!)"
-
-#: web/templates/registration/password_reset_email.html:2
-#, fuzzy, python-format
-#| msgid ""
-#| "You're receiving this email because you requested a password reset for "
-#| "your user account at %(site_name)s."
-msgid ""
-"You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
-msgstr ""
-"Bu emaili alıyorsunuz çünkü %(site_name) adresindeki hesabınız için "
-"şifrenizi sıfırlama talebinde bulundunuz."
-
-#: web/templates/registration/password_reset_email.html:4
-msgid "Please go to the following page and choose a new password:"
-msgstr "Lütfen bir sonraki sayfaya gidin ve yeni bir şifre seçin:"
-
-#: web/templates/registration/password_reset_email.html:8
-msgid "Your username, in case you've forgotten:"
-msgstr "Kullanıcı adınız, unuttuysanız:"
-
-#: web/templates/registration/password_reset_email.html:10
-msgid "Thanks for using our site!"
-msgstr "Sitemizi kullandığınız için teşekkürler!"
-
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "%(site_name)nın takımı"
-
-#: web/templates/registration/password_reset_form.html:11
-msgid "Password reset"
-msgstr "Şifre sıfırlama"
-
-#: web/templates/registration/password_reset_form.html:15
-msgid ""
-"Forgotten your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"Şifrenizi mi unuttunuz? Aşağıya e-mailinizi girin, size yeni bir şifre "
-"belirlemeniz için yönergeleri mail atalım."
-
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "Email adresi:"
-
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "Şifremi sıfırla"
-
-#: web/templates/web/_navigation.html:17
-msgid "Experimenter"
-msgstr "Deneyci"
-
-#: web/templates/web/_navigation.html:28 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "Çalışmalar"
-
-#: web/templates/web/_navigation.html:29
-msgid "FAQ"
-msgstr "SSS"
-
-#: web/templates/web/_navigation.html:30
-msgid "The Scientists"
-msgstr "Bilim insanları"
-
-#: web/templates/web/_navigation.html:31
-msgid "Resources"
-msgstr "Kaynaklar"
-
-#: web/templates/web/_navigation.html:40
-msgid "Hi"
-msgstr "Merhaba"
-
-#: web/templates/web/_navigation.html:42
-msgid "Logout"
-msgstr "Çıkış yap"
-
-#: web/templates/web/_navigation.html:44
-msgid "Sign up"
-msgstr "Kayıt ol"
-
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
-msgid "Child"
-msgstr "Çocuk"
-
-#: web/templates/web/child-update.html:26
-msgid "Back to Children List"
-msgstr "Çocuk Listesi'ne Geri Dön"
-
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "Güncelle"
-
-#: web/templates/web/child-update.html:41
-msgid "Delete"
-msgstr "Sil"
-
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "İptal et"
-
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "Doğum tarihi boş"
-
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr "gün"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr "günler"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr "ay"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr "aylar"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr "yıl"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr "yıllar"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "Çocuk Ekle"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "Formu Gizle"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "İsim"
-
-#: web/templates/web/children-list.html:121
-msgid "Update child"
-msgstr "Çocuk bilgisini güncelle"
-
-#: web/templates/web/children-list.html:128
-msgid "No child profiles registered!"
-msgstr "Hiçbir çocuk profili kaydedilmedi!"
-
-#: web/templates/web/demographic-data-update.html:4
-msgid "Update demographics"
-msgstr "Demografikleri güncelle"
-
-#: web/templates/web/demographic-data-update.html:89
-msgid ""
-"One reason we are developing Internet-based experiments is to represent a "
-"more diverse group of families in our research. Your answers to these "
-"questions will help us understand what audience we reach, as well as how "
-"factors like speaking multiple languages or having older siblings affect "
-"children's learning."
-msgstr ""
-"Internet tabanlı deneyleri geliştirmemizin bir nedeni çalışmalarımızda daha "
-"çok aile çeşidini temsil edebilmektir. Bu sorulara vereceğiniz cevaplar "
-"bizim hangi hedef kitleye ulaştığımızı ve aynı zamanda birden çok dili "
-"konuşmak veya kendinden büyük kardeş sahibi olmak gibi faktörlerin "
-"çocukların öğrenmesini nasıl etkilediğini anlamamızı sağlayacak."
-
-#: web/templates/web/demographic-data-update.html:90
-msgid ""
-"Even if you allow your study videos to be published for scientific or "
-"publicity purposes, your demographic information is never published in "
-"conjunction with your video."
-msgstr ""
-"Çalışma videolarınızın bilimsel veya tanıtım amaçlı kullanılmasına izin "
-"verseniz bile, demografik bilgileriniz asla videonuzla bağlantılı olarak "
-"yayınlanmaz."
-
-#: web/templates/web/participant-email-preferences.html:27
-msgid "I would like to be contacted when:"
-msgstr "Şu durumda iletişime geçilmesini isterim:"
-
-#: web/templates/web/participant-signup.html:18
-msgid "Create Participant Account"
-msgstr "Katılımcı Hesabı Oluştur"
-
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
-msgstr "Lookit çalışmalarına katılmaya başlamak için bir aile hesabı oluştur!"
-
-#: web/templates/web/participant-signup.html:31
-msgid ""
-"By clicking 'Create Account', I agree that I have read and accepted the "
-msgstr ""
-"'Hesap Oluştur' a tıklayarak, şunu okuduğumu ve kabul ettiğimi kabul ediyorum"
-
-#: web/templates/web/participant-signup.html:31
-msgid "Privacy Statement"
-msgstr "Gizlilik Bildirimi"
-
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "Hesap oluştur"
-
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "Geçmiş Çalışmalar"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
+#: web/templates/web/studies-history.html:15
+#, fuzzy
+#| msgid "Video"
+msgid "Next Video"
+msgstr "Video"
+
+#: web/templates/web/studies-history.html:31
 msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
 msgstr ""
-"Hesabınızın bu sayfaya erişimi yok. Lütfen devam etmek için erişimi olan bir "
-"hesapla giriş yapınız."
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "Lütfen bu sayfayı görmek için giriş yapınız."
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "Mevcut çalışmalar"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "Geçmiş çalışmalarınız"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr ""
 "Burada çalışmalarınızı görüntüleyebilir ve araştırmacılar tarafından yapılan "
 "yorumları görebilirsiniz."
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "Çalışma Örnek Resmi"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "Uygunluk:"
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "İletişim:"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "Hala veri toplanıyor mu?"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "Evet"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "Hayır"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "Ödeme: "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "Ödeme"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "Çalışma Yanıtları"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "Video"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "Tarih"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "Onay durumu"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "Onaylandı"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr ""
 "Onay videonuz araştırmacı tarafından değerlendirilmiş ve geçerli bulunmuştur."
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "Beklemede"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "Onay videonuz henüz araştırmacı tarafından değerlendirilmedi."
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "Geçersiz"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -3359,175 +4196,176 @@ msgstr ""
 "verileriniz çalışmadaki araştırmacılar tarafından görüntülenemeyecek veya "
 "kullanılamayacak."
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr "Onay videosunun değerlendirilme durumuyla ilgili bilgi bulunmuyor."
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "Geri bildirim"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "Hiçbiri"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "Henüz herhangi bir çalışmaya katılmadınız."
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "Mevcut Çalışmalar"
+#: web/templates/web/studies-history.html:147
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "Henüz herhangi bir çalışmaya katılmadınız."
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Çalışmalar"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"Katılmak için Chrome veya Firefox çalıştıran dizüstü veya masaüstü bir "
-"bilgisayara (mobil cihaz değil) ihtiyacınız olacağına lütfen dikkat ediniz."
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "Detayları gör"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "Şu anda herhangi bir çalışma yürütmüyoruz!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"Araştırmalara evden katkıda bulunmanın daha fazla yollarını mı arıyorsunuz? "
-"Daha çok çalışma için <a href=\"https://childrenhelpingscience.com/\" target="
-"\"_blank\" rel=\"noreferrer noopener\">Children Helping Science</a> sitesine "
-"göz atın."
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "günler"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " 'e dek "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " ne zaman "
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Kaynaklar"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "Çalışma tanıtımı"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "Listeye geri dön"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "Uygunluk kriterleri"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "Süre"
-
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "Ödeme"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "Ne oluyor"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "Ne çalışıyoruz"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "Bu çalışma şu kişiler tarafından yürütülmektedir"
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "Bu çalışmaya katılmak ister misiniz?"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "Katılmak için giriş yapın:"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "Şuraya çocuk profili ekle "
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "önizleme"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "katıl"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "şimdi"
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "Önizleme için deney oynatıcısını oluşturun."
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "Katılmak için giriş yapın:"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "Şuraya çocuk profili ekle "
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "Demografik anketi tamamlayın "
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "Katıl"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "Ne oluyor"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "Ne çalışıyoruz"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "Süre"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "Bu çalışma şu kişiler tarafından yürütülmektedir"
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "Bu çalışmaya katılmak ister misiniz?"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "Çocuk seçin:"
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "Hiçbiri seçilmedi"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "Çocuğunuz bu çalışma için önerilen yaş aralığından küçük. Eğer çocuğunuz "
 "uygun yaş aralığına gelene <span id='wait-until'>kadar</span> "
 "bekleyebilirseniz, toplanan veriyi araştırmamızda kullanabileceğiz."
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "Çocuğunuz bu çalışma için önerilen yaş aralığından büyük. İsterseniz "
 "çalışmayı yine de deneyebilirsiniz ancak toplanan veriyi araştırmamızda "
 "kullanamayacağız."
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "Çocuğunuz bu çalışma için belirlenen uygunluk kriterlerini karşılamıyor. "
 "İsterseniz çalışmayı yine de deneyebilirsiniz ancak toplanan veriyi "
 "araştırmamızda kullanamayacağız. Lütfen çalışma araştırmacıları ile irtibata "
 "geçiniz."
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "Önizleme için deney oynatıcısını oluşturun."
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "Katıl"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "şimdi"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
@@ -3535,31 +4373,89 @@ msgstr ""
 "Çalışma protokolünü güncellediğinizde ne olacağını kolayca görmek için "
 "yukarıdaki butonun size göndereceği bağlantıyı yer imi çubuğuna ekleyin."
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Kayıt ol"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"Katılmak için Chrome veya Firefox çalıştıran dizüstü veya masaüstü bir "
+"bilgisayara (mobil cihaz değil) ihtiyacınız olacağına lütfen dikkat ediniz."
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "Katılımcı oluşturuldu."
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "Demografik veri kaydedildi."
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "Çocuk eklendi."
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "Çocuk silindi."
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "Çocuk güncellendi."
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "Email tercihleri kaydedildi."
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -3570,14 +4466,431 @@ msgstr ""
 "durduruldu. Bunun bir hata olduğunu düşünüyorsanız, lütfen {study."
 "contact_info} ile iletişime geçin."
 
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr "Şifreniz diğer kişisel bilgilerinizle çok benzer olamaz. "
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "Şifreniz en az 16 karakter içermelidir."
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "Şifreniz sık kullanılan bir şifre olamaz."
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "Şifreniz tamamen sayısal olamaz."
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "Hangi kategori(ler) ailenizi tanımlıyor?"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "Yalnızca sayısal cevaplar- kabaca bir tahmin uygundur!"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "Aileniz evinizde hangi dil(ler)i konuşuyor?"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "Eşinizin tamamladığı en yüksek eğitim seviyesi nedir?"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "Evinizde tahmini kaç tane çocuk kitabı var?"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "Eğer cevabınız ortak velayet düzenlemelerine veya seyahatlere göre "
+#~ "değişiyorsa, lütfen çocuğunuzun genellikle birlikte yaşadığı ebeveyn/"
+#~ "bakıcı sayısını belirtin veya açıklayın."
+
+#~ msgid "other"
+#~ msgstr "diğer"
+
+#~ msgid "3 or more"
+#~ msgstr "3 veya daha fazla"
+
+#~ msgid "varies"
+#~ msgstr "değişiyor"
+
+#~ msgid "My Account"
+#~ msgstr "Hesabım"
+
+#~ msgid "Last Active:"
+#~ msgstr "Son aktif olma:"
+
+#~ msgid "Participant global ID:"
+#~ msgstr "Katılımcı global ID"
+
+#~ msgid "Dashboard"
+#~ msgstr "Gösterge Paneli"
+
+#~ msgid "Argentinian Spanish"
+#~ msgstr "Arjantin İspanyolcası"
+
+#~ msgid "Canadian French"
+#~ msgstr "Kanada Fransızcası"
+
+#~ msgid "Norwegian Bokmål"
+#~ msgstr "Norveççe Bokmål"
+
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "Brezilya Portekizcesi"
+
+#~ msgid "Simplified Chinese"
+#~ msgstr "Basitleştirilmiş Çince"
+
+#~ msgid "Yue"
+#~ msgstr "Yue"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#~ msgid "How can we participate online?"
+#~ msgstr "Çevrimiçi olarak nasıl katılabiliriz?"
+
+#~ msgid ""
+#~ "\n"
+#~ "                            <p>If you have a child and would like to "
+#~ "participate, create an account and take a look at what we have available "
+#~ "for your child's age range. You'll need a working webcam to participate.</"
+#~ "p>\n"
+#~ "                                <p>When you select a study, you'll be "
+#~ "asked to read a consent form and record yourself stating that you and "
+#~ "your child agree to participate. Then we'll guide you through what will "
+#~ "happen during the study. Depending on your child's age, your child may "
+#~ "answer questions directly or we may be looking for indirect signs of what "
+#~ "she thinks is going on--like how long she looks at a surprising outcome.</"
+#~ "p>\n"
+#~ "                                <p>Some portions of the study will be "
+#~ "automatically recorded using your webcam and sent securely to the Lookit "
+#~ "platform. Trained researchers will watch the video and record your "
+#~ "child's responses--for instance, which way he pointed, or how long she "
+#~ "looked at each image. We'll put these together with responses from lots "
+#~ "of other children to learn more about how kids think!</p>\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ "                            <p>Eğer çocuğunuz varsa ve katılmak "
+#~ "istiyorsanız, bir hesap oluşturarak çocuğunuzun yaş aralığında katılımcı "
+#~ "aranan çalışmalarımıza göz atabilirsiniz. Çalışmalara katılabilmek için "
+#~ "çalışır durumda bir bilgisayar kameranızın bulunması gerekmektedir.</p>\n"
+#~ "                                <p>Bir çalışmayı seçtiğinizde, bir onay "
+#~ "formu okumanız ve sizin ve çocuğunuzun çalışmaya katılmayı kabul "
+#~ "ettiğinizi belirttiğiniz bir video kaydı göndermeniz istenecektir. "
+#~ "Sonrasında, çalışma sırasında yapılacaklar konusunda sizi yönlendiriyor "
+#~ "olacağız. Çocuğunuzun yaşına bağlı olarak çocuğunuz sorulan sorulara "
+#~ "doğrudan kendisi cevap verebilir, ya da çocuğunuzun ne düşündüğüyle "
+#~ "ilgili çıkarımlarda bulunabileceğimiz dolaylı işaretleri inceleriz – "
+#~ "şaşırtıcı bir sonuca ne kadar uzun süre baktığı gibi.</p>\n"
+#~ "                                <p>Çalışmanın kamerayla kayıt altına "
+#~ "alınan bazı kısımları otomatik olarak kaydedilip güvenli bir şekilde "
+#~ "Lookit arayüzüne aktarılacaktır. Bu videoları alanında eğitimli "
+#~ "araştırmacılar inceleyecek ve çocuğunuzun birtakım tepkilerini "
+#~ "kaydedecektir- örneğin parmağıyla gösterdiği yön ya da resimlere bakma "
+#~ "süresi gibi. Çocukların nasıl düşündükleri hakkında daha çok şey öğrenmek "
+#~ "için bu tepkileri diğer birçok çocuktan gelen bu tepkiler ile "
+#~ "birleştireceğiz!</p>\n"
+#~ "                            "
+
+#~ msgid ""
+#~ "Any researcher with questions about how kids learn and grow can propose a "
+#~ "Lookit study! Each institution using Lookit has to sign a contract with "
+#~ "MIT where they agree to the <a href='/termsofuse'>Terms of Use</a> and "
+#~ "certify that their studies will be reviewed and approved by an "
+#~ "institutional review board. Studies are also subject to approval by "
+#~ "Lookit. As of June 2020 we have agreements with 20 universities!"
+#~ msgstr ""
+#~ "Çocukların nasıl öğrendiği ve büyüdüğü hakkında soruları olan her "
+#~ "araştırmacı bir Lookit çalışması önerebilir! Lookit kullanan her kurum "
+#~ "MIT ile <a \n"
+#~ "href='/termsofuse'> Kullanım Şartları </a> 'nı kabul ettikleri ve "
+#~ "çalışmalarının bir bağımsız etik komitesi tarafından incelenip "
+#~ "onaylanacağını kabul ettikleri bir sözleşme imzalamalıdır. Çalışmalar "
+#~ "Lookit'in de onayına tabidir. Haziran 2020 itibariyle 20 üniversite ile "
+#~ "anlaşmamız var!"
+
+#~ msgid ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+#~ msgstr ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+
+#~ msgid ""
+#~ "Traditionally, developmental studies happen in a quiet room in a "
+#~ "university lab. Researchers call or email local parents to see if they'd "
+#~ "like to take part and schedule an appointment for them to come visit the "
+#~ "lab. Why complement these in-lab studies with online ones? We're hoping "
+#~ "to..."
+#~ msgstr ""
+#~ "Geleneksel olarak, gelişim çalışmaları bir üniversite laboratuvarındaki "
+#~ "sessiz bir odada yapılır. Araştırmacılar, yer almak isteyip "
+#~ "istemediklerini öğrenmek ve bir laboratuvar ziyareti randevusu ayarlamak "
+#~ "için ebeveynleri arar veya email gönderir. Bu laboratuvar içi çalışmaları "
+#~ "neden çevrimiçi araştırmalarla tamamlamayalım? Umuyoruz ki ..."
+
+#~ msgid "When will we see the results of the study?"
+#~ msgstr "Çalışmanın sonuçlarını ne zaman göreceğiz?"
+
+#~ msgid ""
+#~ "The process of publishing a scientific study, from starting data "
+#~ "collection to seeing the paper in a journal, can take several years. You "
+#~ "can check the Lookit home page for updates on papers, or set your "
+#~ "communication preferences to be notified when we have results from "
+#~ "studies you participated in."
+#~ msgstr ""
+#~ "Veri toplamaya başlamaktan makaleyi bir dergide görmeye kadar bilimsel "
+#~ "bir çalışma yayınlama süreci birkaç yıl sürebilir. Belgelerle ilgili "
+#~ "güncellemeler için Lookit ana sayfasını kontrol edebilir veya "
+#~ "katıldığınız çalışmalardan sonuçlar aldığımızda bilgilendirilmek üzere "
+#~ "iletişim tercihlerinizi ayarlayabilirsiniz."
+
+#~ msgid "Can I get my child's results?"
+#~ msgstr "Çocuğumun sonuçlarını alabilir miyim?"
+
+#, fuzzy, python-format
+#~| msgid ""
+#~| "\n"
+#~| "                                <p>For some studies, yes! Usually, "
+#~| "developmental researchers only interpret children's abilities and "
+#~| "developmental trends at a group level, and the individual data collected "
+#~| "just isn't very interpretable. But for \"Your baby, the physicist\" and "
+#~| "other longitudinal studies (where you come back for more than one "
+#~| "session), we can sometimes collect enough data to give you a report of "
+#~| "your child's responses after you complete all the sessions.</p>\n"
+#~| "                                <p>Please note that none of the measures "
+#~| "we collect are diagnostic! For instance, while we hope you'll be "
+#~| "interested to learn that your child looked 70%% of the time at videos "
+#~| "where things fell up versus falling down, we won't be able to tell you "
+#~| "whether this means your child is going to be especially good at physics."
+#~| "</p>\n"
+#~| "                                <p>If you're interested in getting "
+#~| "individual results right away, please see our <a "
+#~| "href='resources'>Resources</a> section for fun at-home activities you "
+#~| "can try with your child.</p>\n"
+#~| "                                "
+#~ msgid ""
+#~ "\n"
+#~ "                                <p>For some studies, yes! Usually, "
+#~ "developmental researchers only interpret children's abilities and "
+#~ "developmental trends at a group level, and the individual data collected "
+#~ "just isn't very interpretable. But for \"Your baby, the physicist\" and "
+#~ "other longitudinal studies (where you come back for more than one "
+#~ "session), we can sometimes collect enough data to give you a report of "
+#~ "your child's responses after you complete all the sessions.</p>\n"
+#~ "                                <p>Please note that none of the measures "
+#~ "we collect are diagnostic! For instance, while we hope you'll be "
+#~ "interested to learn that your child looked 70%% of the time at videos "
+#~ "where things fell up versus falling down, we won't be able to tell you "
+#~ "whether this means your child is going to be especially good at physics.</"
+#~ "p>\n"
+#~ "                                <p>If you're interested in getting "
+#~ "individual results right away, please see our <a "
+#~ "href='resources'>Resources</a> section for fun at-home activities you can "
+#~ "try with your child.</p>\n"
+#~ "                                "
+#~ msgstr ""
+#~ "\n"
+#~ "                                <p>Bazı çalışmalar için, evet! "
+#~ "Genellikle, gelişim araştırmacıları çocukların becerilerini ve gelişimsel "
+#~ "trendleri yalnızca grup seviyesinde yorumlar, ve toplanan bireysel "
+#~ "veriler pek yorumlanamaz. Ancak “Fizikçi Bebeğiniz” çalışması ve diğer "
+#~ "boylamsal (birden fazla oturum için geri geldiğiniz) çalışmalarda bazen "
+#~ "siz tüm seansları tamamladıktan sonra çocuğunuzun yanıtları hakkında size "
+#~ "bir rapor vermek için yeterli veri toplayabiliyoruz.</p>\n"
+#~ "                                <p>Lütfen topladığımız ölçümlerin "
+#~ "hiçbirinin teşhis amaçlı olmadığını unutmayın! Örneğin, çocuğunuzun "
+#~ "nesnelerin yukarı doğru düştüğü (aşağı doğru düşmek yerine) videolarda "
+#~ "zamanın %70’inde ekranı izlediğini öğrenmek ilginizi çekebilir, ancak "
+#~ "size çocuğunuzun özellikle fizik dersinde başarılı olup olamayacağını "
+#~ "söyleyebileceğimiz anlamına gelmez.</p>\n"
+#~ "                                <p>Eğer hemen bireysel sonuçlar almakla "
+#~ "ilgileniyorsanız, lütfen çocuğunuzla birlikte deneyebileceğiniz evde "
+#~ "eğlenceli aktiviteler için <a href='resources'>Kaynaklar</a> bölümüne "
+#~ "bakın.</p>"
+
+#~ msgid "the online child lab"
+#~ msgstr "çevrimiçi çocuk laboratuvarı"
+
+#~ msgid "A project of the MIT Early Childhood Cognition Lab"
+#~ msgstr "MIT Erken Çocukluk Biliş Lab'ı projesi"
+
+#~ msgid "Bringing science home"
+#~ msgstr "Bilimi eve getiriyoruz"
+
+#~ msgid ""
+#~ "Here at MIT's Early Childhood Cognition Lab, we're trying a new approach "
+#~ "in developmental psychology: bringing the experiments to you."
+#~ msgstr ""
+#~ "MIT'nin Erken Çocukluk Biliş Laboratuvarı'nda gelişim psikolojisinde yeni "
+#~ "bir yaklaşım deniyoruz: deneyleri size getirmek."
+
+#~ msgid "Help us understand how your child thinks"
+#~ msgstr "Çocuğunuzun nasıl düşündüğünü anlamamızda bize yardımcı olun"
+
+#~ msgid ""
+#~ "Your family can contribute to research about how children learn by doing "
+#~ "fun activities together, right in your web browser."
+#~ msgstr ""
+#~ "Aileniz, doğrudan web tarayıcınızdan birlikte eğlenceli aktiviteler "
+#~ "yaparak çocukların nasıl öğrendiklerine ilişkin araştırmalara katkıda "
+#~ "bulunabilir."
+
+#~ msgid "Participate whenever and wherever"
+#~ msgstr "Her zaman ve her yerde katılın"
+
+#~ msgid ""
+#~ "Log in or create an account at the top right to get started! You can "
+#~ "participate with your child from any computer with a webcam."
+#~ msgstr ""
+#~ "Başlamak için giriş yapın veya sağ üstten bir hesap oluşturun! "
+#~ "Çocuğunuzla birlikte  kamerası olan herhangi bir bilgisayardan "
+#~ "katılabilirsiniz."
+
+#~ msgid "Core Team"
+#~ msgstr "Çekirdek Ekip"
+
+#~ msgid ""
+#~ "Rico is Lookit's lead software engineer, working on planning and adding "
+#~ "features for both participants and researchers."
+#~ msgstr ""
+#~ "Rico Lookit'in lider yazılım mühendisidir, hem katılımcılar hem de "
+#~ "araştırmacılar için yeni özellikler planlama ve ekleme üzerine çalışıyor."
+
+#~ msgid ""
+#~ "Laura is the PI of the Early Childhood Cognition Lab. She conducts "
+#~ "research about how children arrive at a common-sense understanding of the "
+#~ "physical and social world through exploration and instruction."
+#~ msgstr ""
+#~ "Laura, Erken Çocukluk Biliş Laboratuvarı'nın baş araştırmacısıdır. Keşif "
+#~ "ve öğretim yoluyla çocukların fiziksel ve sosyal dünyanın sağduyulu bir "
+#~ "anlayışına nasıl ulaştıkları hakkında araştırma yapıyor."
+
+#~ msgid ""
+#~ "Kim started Lookit as a graduate student, and now runs the project as a "
+#~ "research scientist in the Early Childhood Cognition Lab. Her three "
+#~ "children frequently provide feedback on studies."
+#~ msgstr ""
+#~ "Kim, Lookit'e yüksek lisans öğrencisi olarak başladı ve şimdi projeyi "
+#~ "Erken Çocukluk Biliş Laboratuvarı'nda araştırmacı bilim insanı olarak "
+#~ "yürütüyor. Üç çocuğu, çalışmaları hakkında sık sık geri bildirimde "
+#~ "bulunuyor."
+
+#~ msgid ""
+#~ "Mark organizes the Lookit Working Groups, which are groups of researchers "
+#~ "working to improve Lookit in a variety of ways."
+#~ msgstr ""
+#~ "Mark Lookit Çalışma Gruplarını organize ediyor, bu gruplar Lookit'in "
+#~ "çeşitli yollardan geliştirilmesi için çalışan araştırmacılardan oluşur."
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "Giriş kimlik bilgileriniz çalışmadı. Lütfen tekrar deneyin."
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Lookit'te yeni misiniz?"
+
+#~ msgid "New password:"
+#~ msgstr "Yeni şifre:"
+
+#~ msgid "Confirm password:"
+#~ msgstr "Şifrenizi onaylayın:"
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "%(site_name)nın takımı"
+
+#~ msgid "Email address:"
+#~ msgstr "Email adresi:"
+
+#~ msgid "FAQ"
+#~ msgstr "SSS"
+
+#~ msgid "Hi"
+#~ msgstr "Merhaba"
+
+#~ msgid "Empty birthday"
+#~ msgstr "Doğum tarihi boş"
+
+#~ msgid " day"
+#~ msgstr "gün"
+
+#~ msgid " days"
+#~ msgstr "günler"
+
+#~ msgid " month"
+#~ msgstr "ay"
+
+#~ msgid " months"
+#~ msgstr "aylar"
+
+#~ msgid " year"
+#~ msgstr "yıl"
+
+#~ msgid " years"
+#~ msgstr "yıllar"
+
+#~ msgid "Hide Form"
+#~ msgstr "Formu Gizle"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr ""
+#~ "Lookit çalışmalarına katılmaya başlamak için bir aile hesabı oluştur!"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr ""
+#~ "Hesabınızın bu sayfaya erişimi yok. Lütfen devam etmek için erişimi olan "
+#~ "bir hesapla giriş yapınız."
+
+#~ msgid "Please login to see this page."
+#~ msgstr "Lütfen bu sayfayı görmek için giriş yapınız."
+
+#~ msgid "Compensation: "
+#~ msgstr "Ödeme: "
+
+#~ msgid "None"
+#~ msgstr "Hiçbiri"
+
+#~ msgid "Current Studies"
+#~ msgstr "Mevcut Çalışmalar"
+
+#~ msgid "See details"
+#~ msgstr "Detayları gör"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "Şu anda herhangi bir çalışma yürütmüyoruz!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "Araştırmalara evden katkıda bulunmanın daha fazla yollarını mı "
+#~ "arıyorsunuz? Daha çok çalışma için <a href=\"https://"
+#~ "childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
+#~ "noopener\">Children Helping Science</a> sitesine göz atın."
+
+#~ msgid "days"
+#~ msgstr "günler"
+
+#~ msgid " until "
+#~ msgstr " 'e dek "
+
+#~ msgid " when "
+#~ msgstr " ne zaman "
+
+#~ msgid "Study overview"
+#~ msgstr "Çalışma tanıtımı"
+
+#~ msgid "Back to list"
+#~ msgstr "Listeye geri dön"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "Uygunluk kriterleri"
+
 #~ msgid "Alumni &amp; Collaborators"
 #~ msgstr "Mezunlar &amp; İşbirlikçiler"
 
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "Araştırmacı olarak kayıt olmak için, lütfen kullanın"
-
 #~ msgid "this form"
 #~ msgstr "bu formu"
-
-#~ msgid "instead"
-#~ msgstr "yerine"

--- a/locale/zh_HANS/LC_MESSAGES/django.po
+++ b/locale/zh_HANS/LC_MESSAGES/django.po
@@ -4054,10 +4054,8 @@ msgstr "时长"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
-#, fuzzy, python-format
-#| msgid "This study is conducted by"
 msgid "This study is conducted by %(contact)s."
-msgstr "研究负责人："
+msgstr "研究负责人：%(contact)s."
 
 #: web/templates/web/study-detail.html:96
 msgid "Would you like to participate in this study?"

--- a/locale/zh_HANS/LC_MESSAGES/django.po
+++ b/locale/zh_HANS/LC_MESSAGES/django.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-13 14:40+0000\n"
+"POT-Creation-Date: 2024-04-09 19:34-0400\n"
 "Language: zh-Hans\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 
-#: accounts/forms.py:58
+#: accounts/forms.py:56
 msgid "Enter a valid 6-digit one-time password from Google Authenticator"
 msgstr "请输入来自谷歌身份验证器一次性的有效六位数密码"
 
@@ -33,146 +33,121 @@ msgstr ""
 msgid "This account is inactive."
 msgstr "此账号尚未激活。"
 
-#: accounts/forms.py:197
-msgid "Your password can’t be too similar to your other personal information."
-msgstr "您的密码不能与您的个人信息过于相似。"
-
-#: accounts/forms.py:198
-msgid "Your password must contain at least 16 characters."
-msgstr "您的密码必须至少包含16个字符。"
-
-#: accounts/forms.py:199
-msgid "Your password can’t be a commonly used password."
-msgstr "您的密码不能为常见密码。"
-
-#: accounts/forms.py:200
-msgid "Your password can’t be entirely numeric."
-msgstr "您的密码不能全是数字。"
-
-#: accounts/forms.py:216 accounts/forms.py:232 accounts/models.py:141
+#: accounts/forms.py:222 accounts/forms.py:238 accounts/models.py:148
 msgid "Email address"
 msgstr "邮箱地址"
 
-#: accounts/forms.py:217 accounts/models.py:146
-#: accounts/templates/accounts/participant_list.html:37
-#: accounts/templates/accounts/participant_list.html:58
+#: accounts/forms.py:223
 msgid "Nickname"
 msgstr "昵称"
 
-#: accounts/forms.py:257
+#: accounts/forms.py:286
 msgid ""
 "It's time for another session of a study we are currently participating in"
 msgstr "是时候进行本实验中的另一个部分了"
 
-#: accounts/forms.py:259
+#: accounts/forms.py:288
 msgid "A new study is available for one of my children"
 msgstr "有一项新研究可供我的一位孩子参加"
 
-#: accounts/forms.py:261
+#: accounts/forms.py:290
 msgid ""
 "There's an update about a study we participated in (for example, results are "
 "published)"
 msgstr "我们曾经参加过的一项研究有了新的进展（例如：实验结果已发表）"
 
-#: accounts/forms.py:264
+#: accounts/forms.py:293
 msgid ""
 "A researcher has questions about my individual responses (for example, if I "
 "report a technical problem during the study)"
 msgstr "一位研究员对于我的个人反馈有疑问（例如：在研究中我反映了技术问题）"
 
-#: accounts/forms.py:273 accounts/forms.py:322
-msgid "What category(ies) does your family identify as?"
-msgstr "您认为您的家庭属于哪种类别？"
-
-#: accounts/forms.py:277 accounts/models.py:527
-#: accounts/templates/accounts/participant_detail.html:86
-msgid "Country"
-msgstr "国家"
-
-#: accounts/forms.py:304
+#: accounts/forms.py:323
 msgid "Enter as a comma-separated list: YYYY-MM-DD, YYYY-MM-DD, ..."
 msgstr "请用逗号分隔日期，如：2015-05-10, 2018-01-22, ..."
 
-#: accounts/forms.py:306
-msgid "Numerical answers only - a rough guess is fine!"
-msgstr "仅填写数字（可估计）"
+#: accounts/forms.py:326
+msgid ""
+"If the answer varies or needs more explanation, you can tell us more below."
+msgstr ""
 
-#: accounts/forms.py:310
+#: accounts/forms.py:329
+msgid ""
+"Please select the appropriate responses for everyone in your children's "
+"immediate family."
+msgstr ""
+
+#: accounts/forms.py:334
 msgid "What country do you live in?"
 msgstr "您居住在哪个国家？"
 
-#: accounts/forms.py:311
+#: accounts/forms.py:335
 msgid "What state do you live in?"
 msgstr "您居住在哪个省份/自治区/直辖市/特别行政区？"
 
-#: accounts/forms.py:312
+#: accounts/forms.py:336
 msgid "How would you describe the area where you live?"
 msgstr "您会如何描述您所居住的区域？"
 
-#: accounts/forms.py:314
-msgid "What language(s) does your family speak at home?"
-msgstr "您的家庭在家中使用什么语言？"
-
-#: accounts/forms.py:316
+#: accounts/forms.py:337
 msgid "How many children do you have?"
 msgstr "您有几位子女？"
 
-#: accounts/forms.py:317
+#: accounts/forms.py:338
 msgid "For each child, please enter his or her birthdate:"
 msgstr "请输入每一位子女的出生日期："
 
-#: accounts/forms.py:319
+#: accounts/forms.py:340
 msgid "How many parents/guardians do your children live with?"
 msgstr "您的孩子与几位父母/监护人居住在一起？"
 
-#: accounts/forms.py:324
+#: accounts/forms.py:342
 msgid "What is your age?"
 msgstr "您的年龄是？"
 
-#: accounts/forms.py:325
+#: accounts/forms.py:343
 msgid "What is your gender?"
 msgstr "您的性别是？"
 
-#: accounts/forms.py:327
+#: accounts/forms.py:344
+#, fuzzy
+#| msgid "What is your gender?"
+msgid "Describe your gender"
+msgstr "您的性别是？"
+
+#: accounts/forms.py:346
 msgid "What is the highest level of education you've completed?"
 msgstr "您获得的最高学历是什么？"
 
-#: accounts/forms.py:330
-msgid "What is the highest level of education your spouse has completed?"
-msgstr "您的配偶获得的最高学历是什么？"
-
-#: accounts/forms.py:333
+#: accounts/forms.py:349
 msgid "What is your approximate family yearly income (in US dollars)?"
 msgstr "您的家庭年收入大概是多少（人民币）？"
 
-#: accounts/forms.py:336
-msgid "About how many children's books are there in your home?"
-msgstr "您家中大约有多少本儿童读物？"
-
-#: accounts/forms.py:338
+#: accounts/forms.py:351
 msgid "Anything else you'd like us to know?"
 msgstr "请问您还有什么想让我们知道的吗？"
 
-#: accounts/forms.py:339
+#: accounts/forms.py:352
 msgid "How did you hear about Lookit?"
 msgstr "您是怎么了解到Lookit的？"
 
-#: accounts/forms.py:341
+#: accounts/forms.py:354
 msgid ""
-"If the answer varies due to shared custody arrangements or travel, please "
-"enter the number of parents/guardians your children are usually living with "
-"or explain."
+"What racial group(s) does your family identify with/belong to? Please select "
+"any that apply to someone in your children's immediate family."
 msgstr ""
-"如果监护人数量会因共同监护或旅行而有变动，请输入和您孩子平时一同居住的父母/监"
-"护人人数或做额外解释。"
 
-#: accounts/forms.py:356 accounts/forms.py:382 accounts/forms.py:434
-#: accounts/templates/accounts/participant_detail.html:38
-#: web/templates/web/children-list.html:112
-msgid "Birthday"
-msgstr "出生日期"
+#: accounts/forms.py:357
+#, fuzzy
+#| msgid "Another race, ethnicity, or origin"
+msgid "Share more about your family's race, ethnicity, or origin:"
+msgstr "其他种族、民族或出身"
 
-#: accounts/forms.py:358
+#: accounts/forms.py:360
+msgid "Share more about your children's parents/guardians:"
+msgstr ""
+
+#: accounts/forms.py:379
 msgid ""
 "This lets us figure out exactly how old your child is when they participate "
 "in a study. We never publish children's birthdates or information that would "
@@ -181,39 +156,42 @@ msgstr ""
 "这能帮助我们计算出您孩子参加研究时的确切年龄。我们从不公布儿童的出生日期或能"
 "让读者计算出生日期的信息。"
 
-#: accounts/forms.py:365
+#: accounts/forms.py:386
 msgid "Birthdays cannot be in the future."
 msgstr "生日不能为将来的时间。"
 
-#: accounts/forms.py:381 accounts/forms.py:433
+#: accounts/forms.py:403
 msgid "First Name"
 msgstr "名"
 
-#: accounts/forms.py:383 accounts/forms.py:435
-#: accounts/templates/accounts/participant_detail.html:54
+#: accounts/forms.py:404 accounts/templates/accounts/participant_detail.html:36
+#: web/templates/web/children-list.html:45
+msgid "Birthday"
+msgstr "出生日期"
+
+#: accounts/forms.py:405 accounts/templates/accounts/participant_detail.html:44
 msgid "Gender"
 msgstr "性别"
 
-#: accounts/forms.py:384 accounts/forms.py:436
-#: accounts/templates/accounts/participant_detail.html:62
+#: accounts/forms.py:406 accounts/templates/accounts/participant_detail.html:48
 msgid "Gestational Age at Birth"
 msgstr "出生时的胎龄"
 
-#: accounts/forms.py:386 accounts/forms.py:438
+#: accounts/forms.py:408
 msgid "Any additional information you'd like us to know"
 msgstr "您想让我们知道的其他信息。"
 
-#: accounts/forms.py:388 accounts/forms.py:440
+#: accounts/forms.py:410
 msgid "Characteristics and conditions"
 msgstr "特殊情况"
 
-#: accounts/forms.py:390 accounts/forms.py:442
+#: accounts/forms.py:412
 msgid ""
 "Languages this child is exposed to at home, school, or with another "
 "caregiver."
 msgstr "该儿童在家庭、学校或与其他照顾者在一起时所接触的语言。"
 
-#: accounts/forms.py:396 accounts/forms.py:448
+#: accounts/forms.py:418
 msgid ""
 "This lets you select the correct child to participate in a particular study. "
 "A nickname or initials are fine! We may include your child's name in email "
@@ -224,509 +202,598 @@ msgstr ""
 "电子邮件中使用您孩子的名字（例如，\"小明可以参加一项新的研究！\"），但绝不会"
 "在我们的研究中公布或使用姓名。"
 
-#: accounts/forms.py:399 accounts/forms.py:451
+#: accounts/forms.py:421
 msgid ""
 "For instance, diagnosed developmental disorders or vision or hearing problems"
 msgstr "例如，被诊断为发育障碍，或有视力、听力问题。"
 
-#: accounts/forms.py:402
+#: accounts/forms.py:424
 msgid "Please round down to the nearest full week of pregnancy completed"
 msgstr "请将怀孕周数四舍五入到整数。"
 
+#: accounts/forms.py:427
+msgid ""
+"Most research studies are designed for a general age range, but some focus "
+"on a particular group of children. The choices you make below are used to "
+"show you studies that are designed for children with these characteristics."
+msgstr ""
+
+#: accounts/forms.py:457
+#, fuzzy
+#| msgid "Studies"
+msgid "All studies"
+msgstr "研究"
+
+#: accounts/forms.py:458
+msgid "Studies happening right now"
+msgstr ""
+
+#: accounts/forms.py:459
+#, fuzzy
+#| msgid "Current studies"
+msgid "Scheduled studies"
+msgstr "当前的研究"
+
+#: accounts/forms.py:462
+msgid "Find studies for..."
+msgstr ""
+
+#: accounts/forms.py:463
+msgid "babies (under 1)"
+msgstr ""
+
+#: accounts/forms.py:464
+msgid "toddlers (1-2)"
+msgstr ""
+
+#: accounts/forms.py:465
+msgid "preschoolers (3-4)"
+msgstr ""
+
+#: accounts/forms.py:466
+msgid "school-age kids (5-17)"
+msgstr ""
+
+#: accounts/forms.py:467
+msgid "adults (18+)"
+msgstr ""
+
+#: accounts/forms.py:470
+msgid "Show studies happening..."
+msgstr ""
+
+#: accounts/forms.py:471
+#, fuzzy
+#| msgid "Meet the Lookit team"
+msgid "here on the Lookit platform"
+msgstr "Lookit团队"
+
+#: accounts/forms.py:472
+msgid "on other websites"
+msgstr ""
+
+#: accounts/forms.py:477
+msgid "Hide Studies We've Done"
+msgstr ""
+
+#: accounts/forms.py:516
+#, fuzzy
+#| msgid "Your past studies"
+msgid "Lookit studies"
+msgstr "您参与过的研究"
+
+#: accounts/forms.py:517
+#, fuzzy
+#| msgid "Current studies"
+msgid "External studies"
+msgstr "当前的研究"
+
 #: accounts/migrations/0041_add_existing_conditions.py:12
-#: accounts/models.py:302 studies/fields.py:135
+#: accounts/models.py:339 studies/fields.py:136
 msgid "Not sure or prefer not to answer"
 msgstr "不确定或不愿回答"
 
 #: accounts/migrations/0041_add_existing_conditions.py:13
-#: accounts/models.py:303 studies/fields.py:136
+#: accounts/models.py:340 studies/fields.py:137
 msgid "Under 24 weeks"
 msgstr "24周以下"
 
 #: accounts/migrations/0041_add_existing_conditions.py:14
-#: accounts/models.py:304 studies/fields.py:137
+#: accounts/models.py:341 studies/fields.py:138
 msgid "24 weeks"
 msgstr "24周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:15
-#: accounts/models.py:305 studies/fields.py:138
+#: accounts/models.py:342 studies/fields.py:139
 msgid "25 weeks"
 msgstr "25周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:16
-#: accounts/models.py:306 studies/fields.py:139
+#: accounts/models.py:343 studies/fields.py:140
 msgid "26 weeks"
 msgstr "26周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:17
-#: accounts/models.py:307 studies/fields.py:140
+#: accounts/models.py:344 studies/fields.py:141
 msgid "27 weeks"
 msgstr "27周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:18
-#: accounts/models.py:308 studies/fields.py:141
+#: accounts/models.py:345 studies/fields.py:142
 msgid "28 weeks"
 msgstr "28周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:19
-#: accounts/models.py:309 studies/fields.py:142
+#: accounts/models.py:346 studies/fields.py:143
 msgid "29 weeks"
 msgstr "29周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:20
-#: accounts/models.py:310 studies/fields.py:143
+#: accounts/models.py:347 studies/fields.py:144
 msgid "30 weeks"
 msgstr "30周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:21
-#: accounts/models.py:311 studies/fields.py:144
+#: accounts/models.py:348 studies/fields.py:145
 msgid "31 weeks"
 msgstr "31周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:22
-#: accounts/models.py:312 studies/fields.py:145
+#: accounts/models.py:349 studies/fields.py:146
 msgid "32 weeks"
 msgstr "32周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:23
-#: accounts/models.py:313 studies/fields.py:146
+#: accounts/models.py:350 studies/fields.py:147
 msgid "33 weeks"
 msgstr "33周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:24
-#: accounts/models.py:314 studies/fields.py:147
+#: accounts/models.py:351 studies/fields.py:148
 msgid "34 weeks"
 msgstr "34周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:25
-#: accounts/models.py:315 studies/fields.py:148
+#: accounts/models.py:352 studies/fields.py:149
 msgid "35 weeks"
 msgstr "35周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:26
-#: accounts/models.py:316 studies/fields.py:149
+#: accounts/models.py:353 studies/fields.py:150
 msgid "36 weeks"
 msgstr "36周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:27
-#: accounts/models.py:317 studies/fields.py:150
+#: accounts/models.py:354 studies/fields.py:151
 msgid "37 weeks"
 msgstr "37周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:28
-#: accounts/models.py:318 studies/fields.py:151
+#: accounts/models.py:355 studies/fields.py:152
 msgid "38 weeks"
 msgstr "38周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:29
-#: accounts/models.py:319 studies/fields.py:152
+#: accounts/models.py:356 studies/fields.py:153
 msgid "39 weeks"
 msgstr "39周"
 
 #: accounts/migrations/0041_add_existing_conditions.py:30
-#: accounts/models.py:320 studies/fields.py:153
+#: accounts/models.py:357 studies/fields.py:154
 msgid "40 or more weeks"
 msgstr "40周及以上"
 
-#: accounts/models.py:80
-msgid "Can View Organization"
-msgstr "可查看机构"
-
-#: accounts/models.py:81
-msgid "Can Edit Organization"
-msgstr "可编辑机构"
-
-#: accounts/models.py:82
-msgid "Can Create Organization"
-msgstr "可创建机构"
-
-#: accounts/models.py:83
-msgid "Can Remove Organization"
-msgstr "可移除机构"
-
-#: accounts/models.py:84
-msgid "Can View Experimenter"
-msgstr "可查看实验员"
-
-#: accounts/models.py:85
-msgid "Can View Analytics"
-msgstr "可查看分析"
-
-#: accounts/models.py:280
-msgid "Can Create User"
-msgstr "可创建用户"
-
-#: accounts/models.py:281
-msgid "Can View User"
-msgstr "可查看用户"
-
-#: accounts/models.py:282
-msgid "Can Edit User"
-msgstr "可编辑用户"
-
-#: accounts/models.py:283
-msgid "Can Remove User"
-msgstr "可移除用户"
-
-#: accounts/models.py:284
-msgid "Can View User Permissions"
-msgstr "可查看用户许可"
-
-#: accounts/models.py:285
-msgid "Can Edit User Permissions"
-msgstr "可编辑用户许可"
-
-#: accounts/models.py:286
-msgid "Can Read All User Data"
-msgstr "可阅读所有用户数据"
-
-#: accounts/models.py:287
-msgid "Can Read User Usernames"
-msgstr "可阅读用户名"
-
-#: accounts/models.py:294 accounts/models.py:397
+#: accounts/models.py:45
 msgid "male"
 msgstr "男性"
 
-#: accounts/models.py:295 accounts/models.py:398
+#: accounts/models.py:46
 msgid "female"
 msgstr "女性"
 
-#: accounts/models.py:296 accounts/models.py:399
-msgid "other"
-msgstr "其他"
+#: accounts/models.py:47
+msgid "open response"
+msgstr ""
 
-#: accounts/models.py:297 accounts/models.py:400 accounts/models.py:476
+#: accounts/models.py:48 accounts/models.py:510
 msgid "prefer not to answer"
 msgstr "不愿回答"
 
-#: accounts/models.py:387
+#: accounts/models.py:87
+msgid "Can View Organization"
+msgstr "可查看机构"
+
+#: accounts/models.py:88
+msgid "Can Edit Organization"
+msgstr "可编辑机构"
+
+#: accounts/models.py:89
+msgid "Can Create Organization"
+msgstr "可创建机构"
+
+#: accounts/models.py:90
+msgid "Can Remove Organization"
+msgstr "可移除机构"
+
+#: accounts/models.py:91
+msgid "Can View Experimenter"
+msgstr "可查看实验员"
+
+#: accounts/models.py:92
+msgid "Can View Analytics"
+msgstr "可查看分析"
+
+#: accounts/models.py:324
+msgid "Can Create User"
+msgstr "可创建用户"
+
+#: accounts/models.py:325
+msgid "Can View User"
+msgstr "可查看用户"
+
+#: accounts/models.py:326
+msgid "Can Edit User"
+msgstr "可编辑用户"
+
+#: accounts/models.py:327
+msgid "Can Remove User"
+msgstr "可移除用户"
+
+#: accounts/models.py:328
+msgid "Can View User Permissions"
+msgstr "可查看用户许可"
+
+#: accounts/models.py:329
+msgid "Can Edit User Permissions"
+msgstr "可编辑用户许可"
+
+#: accounts/models.py:330
+msgid "Can Read All User Data"
+msgstr "可阅读所有用户数据"
+
+#: accounts/models.py:331
+msgid "Can Read User Usernames"
+msgstr "可阅读用户名"
+
+#: accounts/models.py:425
 msgid "White"
 msgstr "白人"
 
-#: accounts/models.py:388
+#: accounts/models.py:426
 msgid "Hispanic, Latino, or Spanish origin"
 msgstr "西班牙裔、拉美裔或西班牙血统"
 
-#: accounts/models.py:389
+#: accounts/models.py:427
 msgid "Black or African American"
 msgstr "黑人或非裔美国人"
 
-#: accounts/models.py:390
+#: accounts/models.py:428
 msgid "Asian"
 msgstr "亚裔"
 
-#: accounts/models.py:391
+#: accounts/models.py:429
 msgid "American Indian or Alaska Native"
 msgstr "美国印第安人或阿拉斯加原住民"
 
-#: accounts/models.py:392
+#: accounts/models.py:430
 msgid "Middle Eastern or North African"
 msgstr "中东人或北非人"
 
-#: accounts/models.py:393
+#: accounts/models.py:431
 msgid "Native Hawaiian or Other Pacific Islander"
 msgstr "夏威夷原住民或其他太平洋岛民"
 
-#: accounts/models.py:394
+#: accounts/models.py:432
 msgid "Another race, ethnicity, or origin"
 msgstr "其他种族、民族或出身"
 
-#: accounts/models.py:403 accounts/models.py:412
+#: accounts/models.py:435 accounts/models.py:444
 msgid "some or attending high school"
 msgstr "初中学历及以下"
 
-#: accounts/models.py:404 accounts/models.py:413
+#: accounts/models.py:436 accounts/models.py:445
 msgid "high school diploma or GED"
 msgstr "高中、中专学历"
 
-#: accounts/models.py:405 accounts/models.py:414
+#: accounts/models.py:437 accounts/models.py:446
 msgid "some or attending college"
 msgstr "本科或大专（未获得文凭）"
 
-#: accounts/models.py:406 accounts/models.py:415
+#: accounts/models.py:438 accounts/models.py:447
 msgid "2-year college degree"
 msgstr "大专学历"
 
-#: accounts/models.py:407 accounts/models.py:416
+#: accounts/models.py:439 accounts/models.py:448
 msgid "4-year college degree"
 msgstr "本科学历"
 
-#: accounts/models.py:408 accounts/models.py:417
+#: accounts/models.py:440 accounts/models.py:449
 msgid "some or attending graduate or professional school"
 msgstr "研究生（未获得文凭）"
 
-#: accounts/models.py:409 accounts/models.py:418
+#: accounts/models.py:441 accounts/models.py:450
 msgid "graduate or professional degree"
 msgstr "研究生学历"
 
-#: accounts/models.py:419
+#: accounts/models.py:451
 msgid "not applicable - no spouse or partner"
 msgstr "无配偶或伴侣"
 
-#: accounts/models.py:422 accounts/models.py:453
+#: accounts/models.py:454 accounts/models.py:487
 msgid "0"
 msgstr "0"
 
-#: accounts/models.py:423 accounts/models.py:450
+#: accounts/models.py:455 accounts/models.py:481
 msgid "1"
 msgstr "1"
 
-#: accounts/models.py:424 accounts/models.py:450
+#: accounts/models.py:456 accounts/models.py:482
 msgid "2"
 msgstr "2"
 
-#: accounts/models.py:425
+#: accounts/models.py:457 accounts/models.py:483
 msgid "3"
 msgstr "3"
 
-#: accounts/models.py:426
+#: accounts/models.py:458
 msgid "4"
 msgstr "4"
 
-#: accounts/models.py:427
+#: accounts/models.py:459
 msgid "5"
 msgstr "5"
 
-#: accounts/models.py:428
+#: accounts/models.py:460
 msgid "6"
 msgstr "6"
 
-#: accounts/models.py:429
+#: accounts/models.py:461
 msgid "7"
 msgstr "7"
 
-#: accounts/models.py:430
+#: accounts/models.py:462
 msgid "8"
 msgstr "8"
 
-#: accounts/models.py:431
+#: accounts/models.py:463
 msgid "9"
 msgstr "9"
 
-#: accounts/models.py:432
+#: accounts/models.py:464
 msgid "10"
 msgstr "10"
 
-#: accounts/models.py:433
+#: accounts/models.py:465
 msgid "More than 10"
 msgstr "10位以上"
 
-#: accounts/models.py:436
+#: accounts/models.py:468
 msgid "under 18"
 msgstr "18岁以下"
 
-#: accounts/models.py:437
+#: accounts/models.py:469
 msgid "18-21"
 msgstr "18-21岁"
 
-#: accounts/models.py:438
+#: accounts/models.py:470
 msgid "22-24"
 msgstr "22-24岁"
 
-#: accounts/models.py:439
+#: accounts/models.py:471
 msgid "25-29"
 msgstr "25-29岁"
 
-#: accounts/models.py:440
+#: accounts/models.py:472
 msgid "30-34"
 msgstr "30-34岁"
 
-#: accounts/models.py:441
+#: accounts/models.py:473
 msgid "35-39"
 msgstr "35-39岁"
 
-#: accounts/models.py:442
+#: accounts/models.py:474
 msgid "40-44"
 msgstr "40-44岁"
 
-#: accounts/models.py:443
+#: accounts/models.py:475
 msgid "45-49"
 msgstr "45-49岁"
 
-#: accounts/models.py:444
+#: accounts/models.py:476
 msgid "50-59"
 msgstr "50-59岁"
 
-#: accounts/models.py:445
+#: accounts/models.py:477
 msgid "60-69"
 msgstr "60-69岁"
 
-#: accounts/models.py:446
+#: accounts/models.py:478
 msgid "70 or over"
 msgstr "70岁及以上"
 
-#: accounts/models.py:450
-msgid "3 or more"
-msgstr "3位及以上"
+#: accounts/models.py:484
+msgid "Another number, or explain below"
+msgstr ""
 
-#: accounts/models.py:450
-msgid "varies"
-msgstr "不定"
-
-#: accounts/models.py:454
+#: accounts/models.py:488
 msgid "5000"
 msgstr "1万元及以下"
 
-#: accounts/models.py:455
+#: accounts/models.py:489
 msgid "10000"
 msgstr "2万元"
 
-#: accounts/models.py:456
+#: accounts/models.py:490
 msgid "15000"
 msgstr "3万元"
 
-#: accounts/models.py:457
+#: accounts/models.py:491
 msgid "20000"
 msgstr "4万元"
 
-#: accounts/models.py:458
+#: accounts/models.py:492
 msgid "30000"
 msgstr "5万元"
 
-#: accounts/models.py:459
+#: accounts/models.py:493
 msgid "40000"
 msgstr "6万元"
 
-#: accounts/models.py:460
+#: accounts/models.py:494
 msgid "50000"
 msgstr "7万元"
 
-#: accounts/models.py:461
+#: accounts/models.py:495
 msgid "60000"
 msgstr "8万元"
 
-#: accounts/models.py:462
+#: accounts/models.py:496
 msgid "70000"
 msgstr "9万元"
 
-#: accounts/models.py:463
+#: accounts/models.py:497
 msgid "80000"
 msgstr "10万元"
 
-#: accounts/models.py:464
+#: accounts/models.py:498
 msgid "90000"
 msgstr "11万元"
 
-#: accounts/models.py:465
+#: accounts/models.py:499
 msgid "100000"
 msgstr "12万元"
 
-#: accounts/models.py:466
+#: accounts/models.py:500
 msgid "110000"
 msgstr "13万元"
 
-#: accounts/models.py:467
+#: accounts/models.py:501
 msgid "120000"
 msgstr "14万元"
 
-#: accounts/models.py:468
+#: accounts/models.py:502
 msgid "130000"
 msgstr "15万元"
 
-#: accounts/models.py:469
+#: accounts/models.py:503
 msgid "140000"
 msgstr "20万元"
 
-#: accounts/models.py:470
+#: accounts/models.py:504
 msgid "150000"
 msgstr "25万元"
 
-#: accounts/models.py:471
+#: accounts/models.py:505
 msgid "160000"
 msgstr "30万元"
 
-#: accounts/models.py:472
+#: accounts/models.py:506
 msgid "170000"
 msgstr "35万元"
 
-#: accounts/models.py:473
+#: accounts/models.py:507
 msgid "180000"
 msgstr "40万元"
 
-#: accounts/models.py:474
+#: accounts/models.py:508
 msgid "190000"
 msgstr "45万元"
 
-#: accounts/models.py:475
+#: accounts/models.py:509
 msgid "over 200000"
 msgstr "50万元及以上"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "urban"
 msgstr "城市"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "suburban"
 msgstr "郊区"
 
-#: accounts/models.py:479
+#: accounts/models.py:513
 msgid "rural"
 msgstr "乡村"
 
-#: accounts/models.py:529
+#: accounts/models.py:567
 msgid "Select a State"
 msgstr "选择一个省份/自治区/直辖市/特别行政区"
 
-#: accounts/templates/accounts/_account-navigation.html:2
-#: accounts/templates/accounts/account-update.html:24
+#: accounts/models.py:717
+#, fuzzy
+#| msgid "Gan"
+msgid "and"
+msgstr "中文（赣方言）"
+
+#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/account-update.html:15
 msgid "Account Information"
 msgstr "账号信息"
 
-#: accounts/templates/accounts/_account-navigation.html:2
+#: accounts/templates/accounts/_account-navigation.html:7
 msgid "Change your login credentials and/or nickname."
 msgstr "更改您的登录信息和/或昵称。"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:10
 msgid "Demographic Survey"
 msgstr "基本信息"
 
-#: accounts/templates/accounts/_account-navigation.html:3
+#: accounts/templates/accounts/_account-navigation.html:12
 msgid "Tell us more about yourself."
 msgstr "让我们更加了解您。"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:15
 msgid "Children Information"
 msgstr "儿童信息"
 
-#: accounts/templates/accounts/_account-navigation.html:4
+#: accounts/templates/accounts/_account-navigation.html:17
 msgid "Add or edit participant information."
 msgstr "添加或编辑参与者信息。"
 
-#: accounts/templates/accounts/_account-navigation.html:5
-#: web/templates/web/participant-email-preferences.html:4
+#: accounts/templates/accounts/_account-navigation.html:21
+msgid "Continue to Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:23
+msgid "Go on to"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:29
+msgid "Find Another Study"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:31
+msgid "Find a Study Now"
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:35
+msgid "See all available studies."
+msgstr ""
+
+#: accounts/templates/accounts/_account-navigation.html:38
+#: web/templates/web/participant-email-preferences.html:6
 msgid "Email Preferences"
 msgstr "电子邮件偏好"
 
-#: accounts/templates/accounts/_account-navigation.html:5
+#: accounts/templates/accounts/_account-navigation.html:40
 msgid "Edit when you can be contacted."
 msgstr "让我们了解什么情况下可以联系您。"
 
-#: accounts/templates/accounts/account-update.html:14
-#: web/templates/web/_navigation.html:43 web/templates/web/child-update.html:16
-#: web/templates/web/children-list.html:67
-#: web/templates/web/demographic-data-update.html:78
-#: web/templates/web/participant-email-preferences.html:16
-msgid "My Account"
-msgstr "我的账号"
+#: accounts/templates/accounts/account-update.html:6
+#, fuzzy
+#| msgid "Account Information"
+msgid "Update account information"
+msgstr "账号信息"
 
-#: accounts/templates/accounts/account-update.html:37
-#: accounts/templates/accounts/account-update.html:58
-#: web/templates/web/child-update.html:46
-#: web/templates/web/demographic-data-update.html:102
-#: web/templates/web/participant-email-preferences.html:38
-msgid "Save"
-msgstr "保存"
-
-#: accounts/templates/accounts/account-update.html:45
+#: accounts/templates/accounts/account-update.html:28
 msgid "Change Your Password"
 msgstr "修改您的密码"
 
-#: accounts/templates/accounts/account-update.html:68
+#: accounts/templates/accounts/account-update.html:42
 msgid "Manage Two-Factor Authentication"
 msgstr "管理双重认证"
 
-#: accounts/templates/accounts/account-update.html:83
+#: accounts/templates/accounts/account-update.html:49
 msgid ""
 "If you'd like, you can turn two-factor authentication off here. Just enter "
 "your one-time password here, hit submit, and it'll get deleted for you!"
@@ -734,11 +801,18 @@ msgstr ""
 "如需要，您可以在此处关闭双重认证。在这里输入您的一次性密码，点击提交，双重认"
 "证就会关闭。"
 
-#: accounts/templates/accounts/account-update.html:108
+#: accounts/templates/accounts/account-update.html:54
+msgid ""
+"It looks like you were in the middle of setting up two factor "
+"authentication, but didn't complete the process. You can capture the QR code "
+"here, verify with a one-time password, and finish the process."
+msgstr ""
+
+#: accounts/templates/accounts/account-update.html:69
 msgid "Set up Two-Factor Authentication"
 msgstr "设置双重认证"
 
-#: accounts/templates/accounts/participant_detail.html:15
+#: accounts/templates/accounts/participant_detail.html:13
 msgid "All Participants"
 msgstr "所有参与者"
 
@@ -746,146 +820,63 @@ msgstr "所有参与者"
 msgid "Participant ID"
 msgstr "参与者ID"
 
-#: accounts/templates/accounts/participant_detail.html:24
-msgid "Last Active:"
-msgstr "最后访问："
-
-#: accounts/templates/accounts/participant_detail.html:25
-msgid "Participant global ID:"
-msgstr "参与者全球ID："
-
-#: accounts/templates/accounts/participant_detail.html:31
-#: web/templates/web/children-list.html:105
-msgid "Children"
-msgstr "儿童"
-
-#: accounts/templates/accounts/participant_detail.html:46
+#: accounts/templates/accounts/participant_detail.html:40
 msgid "Age"
 msgstr "年龄"
 
-#: accounts/templates/accounts/participant_detail.html:70
+#: accounts/templates/accounts/participant_detail.html:52
 msgid "Additional Info"
 msgstr "其他信息"
 
-#: accounts/templates/accounts/participant_detail.html:79
+#: accounts/templates/accounts/participant_detail.html:57
 msgid "No children profiles registered!"
 msgstr "尚未注册儿童档案!"
 
-#: accounts/templates/accounts/participant_detail.html:83
+#: accounts/templates/accounts/participant_detail.html:62
 msgid "Latest Demographic Data"
 msgstr "最新基本信息"
 
-#: accounts/templates/accounts/participant_detail.html:94
+#: accounts/templates/accounts/participant_detail.html:64
+msgid "Country"
+msgstr "国家"
+
+#: accounts/templates/accounts/participant_detail.html:68
 msgid "State"
 msgstr "省份"
 
-#: accounts/templates/accounts/participant_detail.html:102
+#: accounts/templates/accounts/participant_detail.html:72
 msgid "Area description"
 msgstr "地区描述"
 
-#: accounts/templates/accounts/participant_detail.html:110
+#: accounts/templates/accounts/participant_detail.html:76
 msgid "Languages Spoken at Home"
 msgstr "在家使用的语言"
 
-#: accounts/templates/accounts/participant_detail.html:118
+#: accounts/templates/accounts/participant_detail.html:80
 msgid "Number of Children"
 msgstr "儿童人数"
 
-#: accounts/templates/accounts/participant_detail.html:126
+#: accounts/templates/accounts/participant_detail.html:84
 msgid "Children current ages"
 msgstr "儿童的目前年龄"
 
-#: accounts/templates/accounts/participant_detail.html:134
+#: accounts/templates/accounts/participant_detail.html:90
+#, fuzzy
+#| msgid "Study Responses"
+msgid "No Response"
+msgstr "实验记录"
+
+#: accounts/templates/accounts/participant_detail.html:95
 msgid "Number of Guardians"
 msgstr "监护人人数"
 
-#: accounts/templates/accounts/participant_detail.html:142
+#: accounts/templates/accounts/participant_detail.html:99
 msgid "Explanation for Guardians:"
 msgstr "对监护人的解释"
 
-#: accounts/templates/accounts/participant_detail.html:150
+#: accounts/templates/accounts/participant_detail.html:103
 msgid "Race"
 msgstr "种族"
-
-#: exp/templates/exp/dashboard.html:16
-msgid "Dashboard"
-msgstr "概要面板"
-
-#: project/settings.py:228 studies/fields.py:68
-msgid "German"
-msgstr "德语"
-
-#: project/settings.py:229 studies/fields.py:57
-msgid "English"
-msgstr "英语"
-
-#: project/settings.py:230 studies/fields.py:101
-msgid "Spanish"
-msgstr "西班牙语"
-
-#: project/settings.py:231
-msgid "Argentinian Spanish"
-msgstr "阿根廷西班牙语"
-
-#: project/settings.py:232 studies/fields.py:66
-msgid "French"
-msgstr "法语"
-
-#: project/settings.py:233
-msgid "Canadian French"
-msgstr "加拿大法语"
-
-#: project/settings.py:234
-msgid "Hebrew"
-msgstr "希伯来语"
-
-#: project/settings.py:235 studies/fields.py:76
-msgid "Italian"
-msgstr "意大利语"
-
-#: project/settings.py:236 studies/fields.py:77
-msgid "Japanese"
-msgstr "日语"
-
-#: project/settings.py:237 studies/fields.py:82
-msgid "Korean"
-msgstr "韩语"
-
-#: project/settings.py:238
-msgid "Norwegian Bokmål"
-msgstr "挪威博克莫尔语"
-
-#: project/settings.py:239 studies/fields.py:94
-msgid "Polish"
-msgstr "波兰语"
-
-#: project/settings.py:240 studies/fields.py:95
-msgid "Portuguese"
-msgstr "葡萄牙语"
-
-#: project/settings.py:241
-msgid "Brazilian Portuguese"
-msgstr "巴西葡萄牙语"
-
-#: project/settings.py:242 studies/fields.py:96
-msgid "Romanian"
-msgstr "罗马尼亚语"
-
-#: project/settings.py:243 studies/fields.py:97
-msgid "Russian"
-msgstr "俄语"
-
-#: project/settings.py:244 studies/fields.py:107
-msgid "Turkish"
-msgstr "土耳其语"
-
-#: project/settings.py:245
-msgid "Simplified Chinese"
-msgstr "中文简体"
-
-#: project/settings.py:246 studies/fields.py:64
-msgid "Dutch"
-msgstr "荷兰语"
 
 #: studies/fields.py:7
 msgid "Autism Spectrum Disorder"
@@ -935,6 +926,10 @@ msgstr "七胞胎"
 msgid "Octuplet"
 msgstr "八胞胎"
 
+#: studies/fields.py:57
+msgid "English"
+msgstr "英语"
+
 #: studies/fields.py:58
 msgid "Amharic"
 msgstr "阿姆哈拉语"
@@ -959,13 +954,25 @@ msgstr "宿雾语"
 msgid "Chhattisgarhi"
 msgstr "恰蒂斯加里语"
 
+#: studies/fields.py:64
+msgid "Dutch"
+msgstr "荷兰语"
+
 #: studies/fields.py:65
 msgid "Egyptian Spoken Arabic"
 msgstr "埃及阿拉伯口语"
 
+#: studies/fields.py:66
+msgid "French"
+msgstr "法语"
+
 #: studies/fields.py:67
 msgid "Gan"
 msgstr "中文（赣方言）"
+
+#: studies/fields.py:68
+msgid "German"
+msgstr "德语"
 
 #: studies/fields.py:69
 msgid "Gujarati"
@@ -980,196 +987,395 @@ msgid "Hausa"
 msgstr "豪萨语"
 
 #: studies/fields.py:72
+msgid "Hebrew"
+msgstr "希伯来语"
+
+#: studies/fields.py:73
 msgid "Hindi"
 msgstr "印地语"
 
-#: studies/fields.py:73
+#: studies/fields.py:74
 msgid "Igbo"
 msgstr "伊博语"
 
-#: studies/fields.py:74
+#: studies/fields.py:75
 msgid "Indonesian"
 msgstr "印度尼西亚语"
 
-#: studies/fields.py:75
+#: studies/fields.py:76
 msgid "Iranian Persian"
 msgstr "伊朗波斯语"
 
+#: studies/fields.py:77
+msgid "Italian"
+msgstr "意大利语"
+
 #: studies/fields.py:78
+msgid "Japanese"
+msgstr "日语"
+
+#: studies/fields.py:79
 msgid "Javanese"
 msgstr "爪哇语"
 
-#: studies/fields.py:79
+#: studies/fields.py:80
 msgid "Jinyu"
 msgstr "中文（晋方言）"
 
-#: studies/fields.py:80
+#: studies/fields.py:81
 msgid "Kannada"
 msgstr "卡纳达语"
 
-#: studies/fields.py:81
+#: studies/fields.py:82
 msgid "Khmer"
 msgstr "高棉语"
 
 #: studies/fields.py:83
+msgid "Korean"
+msgstr "韩语"
+
+#: studies/fields.py:84
 msgid "Magahi"
 msgstr "马加伊语"
 
-#: studies/fields.py:84
+#: studies/fields.py:85
 msgid "Maithili"
 msgstr "迈蒂利语"
 
-#: studies/fields.py:85
+#: studies/fields.py:86
 msgid "Malay"
 msgstr "马来语"
 
-#: studies/fields.py:86
+#: studies/fields.py:87
 msgid "Malayalam"
 msgstr "马拉雅拉姆语"
 
-#: studies/fields.py:87
-msgid "Mandarin"
+#: studies/fields.py:88
+#, fuzzy
+#| msgid "Mandarin"
+msgid "Chinese (Mandarin)"
 msgstr "中文（普通话）"
 
-#: studies/fields.py:88
+#: studies/fields.py:89
 msgid "Marathi"
 msgstr "马拉地语"
 
-#: studies/fields.py:89
+#: studies/fields.py:90
 msgid "Min Nan"
 msgstr "中文（闽南方言）"
 
-#: studies/fields.py:90
+#: studies/fields.py:91
 msgid "Moroccan Spoken Arabic"
 msgstr "摩洛哥阿拉伯口语"
 
-#: studies/fields.py:91
+#: studies/fields.py:92
 msgid "Northern Pashto"
 msgstr "北普什图语"
 
-#: studies/fields.py:92
+#: studies/fields.py:93
 msgid "Northern Uzbek"
 msgstr "北乌兹别克语"
 
-#: studies/fields.py:93
+#: studies/fields.py:94
 msgid "Odia"
 msgstr "奥里亚语"
 
+#: studies/fields.py:95
+msgid "Polish"
+msgstr "波兰语"
+
+#: studies/fields.py:96
+msgid "Portuguese"
+msgstr "葡萄牙语"
+
+#: studies/fields.py:97
+msgid "Romanian"
+msgstr "罗马尼亚语"
+
 #: studies/fields.py:98
+msgid "Russian"
+msgstr "俄语"
+
+#: studies/fields.py:99
 msgid "Saraiki"
 msgstr "西莱基语"
 
-#: studies/fields.py:99
+#: studies/fields.py:100
 msgid "Sindhi"
 msgstr "信德语"
 
-#: studies/fields.py:100
+#: studies/fields.py:101
 msgid "Somali"
 msgstr "索马里语"
 
 #: studies/fields.py:102
+msgid "Spanish"
+msgstr "西班牙语"
+
+#: studies/fields.py:103
 msgid "Sunda"
 msgstr "巽他语"
 
-#: studies/fields.py:103
+#: studies/fields.py:104
 msgid "Tagalog"
 msgstr "塔加拉语"
 
-#: studies/fields.py:104
+#: studies/fields.py:105
 msgid "Tamil"
 msgstr "泰米尔语"
 
-#: studies/fields.py:105
+#: studies/fields.py:106
 msgid "Telugu"
 msgstr "泰卢固语"
 
-#: studies/fields.py:106
+#: studies/fields.py:107
 msgid "Thai"
 msgstr "泰语"
 
 #: studies/fields.py:108
+msgid "Turkish"
+msgstr "土耳其语"
+
+#: studies/fields.py:109
 msgid "Ukrainian"
 msgstr "乌克兰语"
 
-#: studies/fields.py:109
+#: studies/fields.py:110
 msgid "Urdu"
 msgstr "乌尔都语"
 
-#: studies/fields.py:110
+#: studies/fields.py:111
 msgid "Vietnamese"
 msgstr "越南语"
 
-#: studies/fields.py:111
+#: studies/fields.py:112
 msgid "Western Punjabi"
 msgstr "西旁遮普语"
 
-#: studies/fields.py:112
+#: studies/fields.py:113
 msgid "Wu"
 msgstr "中文（吴方言）"
 
-#: studies/fields.py:113
+#: studies/fields.py:114
 msgid "Xiang Chinese"
 msgstr "中文（湘方言）"
 
-#: studies/fields.py:114
+#: studies/fields.py:115
 msgid "Yoruba"
 msgstr "约鲁巴语"
 
-#: studies/fields.py:115
-msgid "Yue"
-msgstr "粤语"
+#: studies/fields.py:116
+msgid "Chinese (Cantonese)"
+msgstr ""
 
-#: studies/fields.py:123
+#: studies/fields.py:124
 msgid "Not answered"
 msgstr "未回答"
 
-#: studies/fields.py:124
+#: studies/fields.py:125
 msgid "Other"
 msgstr "其他"
 
-#: studies/fields.py:125
+#: studies/fields.py:126
 msgid "Male"
 msgstr "男"
 
-#: studies/fields.py:126
+#: studies/fields.py:127
 msgid "Female"
 msgstr "女"
 
-#: studies/models.py:113
+#: studies/models.py:143
 msgid ""
 "The Users who belong to this Lab. A user in this lab will be able to create "
 "studies associated with this Lab and can be added to this Lab's studies."
 msgstr "属于本实验室的用户。该用户可以创建或添加到附属于本实验室的研究中。"
 
-#: studies/models.py:122
+#: studies/models.py:152
 msgid "The Users who have requested to join this Lab."
 msgstr "申请加入本实验室的用户。"
 
-#: web/templates/frontpages/contact.html:15
-msgid "Technical difficulties"
-msgstr "技术故障"
+#: web/templates/registration/logged_out.html:5
+msgid "You've successfully logged out."
+msgstr "您已经成功退出。"
 
-#: web/templates/frontpages/contact.html:17
-msgid "Questions about the studies"
-msgstr "实验相关问题"
+#: web/templates/registration/login.html:6
+#: web/templates/registration/login.html:9
+msgid "Login"
+msgstr "登录"
 
-#: web/templates/frontpages/contact.html:19
-#: web/templates/frontpages/privacy.html:140
-msgid "For researchers"
-msgstr "研究人员"
+#: web/templates/registration/login.html:25
+msgid "Forgot password?"
+msgstr "忘记密码？"
 
-#: web/templates/frontpages/default.html:10
-#: web/templates/web/_navigation.html:21 web/templates/web/_navigation.html:26
-#: web/templates/web/base.html:10
-msgid "Lookit"
-msgstr "Lookit"
+#: web/templates/registration/login.html:28
+msgid "New to Children Helping Science?"
+msgstr ""
 
-#: web/templates/frontpages/default.html:53
+#: web/templates/registration/login.html:28
+msgid "Register your family!"
+msgstr "为您的家人注册"
+
+#: web/templates/registration/password_change_done.html:9
+msgid "Password changed"
+msgstr "密码已被更改"
+
+#: web/templates/registration/password_change_done.html:12
+msgid "Your password was changed."
+msgstr "您的密码已被更改。"
+
+#: web/templates/registration/password_change_form.html:12
+msgid "Documentation"
+msgstr "文件批注"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Change password"
+msgstr "修改密码"
+
+#: web/templates/registration/password_change_form.html:14
+msgid "Log out"
+msgstr "退出登录"
+
+#: web/templates/registration/password_change_form.html:18
+msgid "Home"
+msgstr "主页"
+
+#: web/templates/registration/password_change_form.html:19
+msgid "Password change"
+msgstr "修改密码"
+
+#: web/templates/registration/password_change_form.html:36
+msgid "Please correct the error below."
+msgstr "请修正以下错误。"
+
+#: web/templates/registration/password_change_form.html:38
+msgid "Please correct the errors below."
+msgstr "请修正以下错误。"
+
+#: web/templates/registration/password_change_form.html:43
+msgid ""
+"Please enter your old password, for security's sake, and then enter your new "
+"password twice so we can verify you typed it in correctly."
+msgstr ""
+"出于安全考虑，请输入您的旧密码。为了让我们确认您输入了正确的新密码，请输入两"
+"次。"
+
+#: web/templates/registration/password_change_form.html:64
+#: web/templates/registration/password_reset_confirm.html:6
+msgid "Change my password"
+msgstr "修改密码"
+
+#: web/templates/registration/password_reset_complete.html:8
+msgid "Log in"
+msgstr "登录"
+
+#: web/templates/registration/password_reset_complete.html:10
+msgid "Password reset complete"
+msgstr "密码重置完成"
+
+#: web/templates/registration/password_reset_complete.html:12
+msgid "Your password has been set.  You may go ahead and log in now."
+msgstr "您的密码已设置成功。您可以重新登录了。"
+
+#: web/templates/registration/password_reset_confirm.html:8
+msgid "Password reset confirmation"
+msgstr "密码重置确认"
+
+#: web/templates/registration/password_reset_confirm.html:11
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly."
+msgstr "为了让我们确认您输入了正确的新密码，请输入两次。"
+
+#: web/templates/registration/password_reset_confirm.html:21
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr "密码重置链接已失效，可能是因为该链接已被使用。请再次请求重置密码。"
+
+#: web/templates/registration/password_reset_done.html:6
+msgid "Password reset link sent"
+msgstr "密码重置链接已发送"
+
+#: web/templates/registration/password_reset_done.html:9
+msgid ""
+"If an account exists with the email you entered, we've emailed instructions "
+"for resetting your password and you should receive them shortly."
+msgstr ""
+"如果您输入的邮箱已在Lookit注册过，我们已经通过邮件发送了有关重置密码的说明，"
+"您很快就会收到。"
+
+#: web/templates/registration/password_reset_done.html:12
+msgid ""
+"If you don't receive an email, please check your spam folder and make sure "
+"you've entered the address you registered with. (You won't get an email "
+"unless there's already an account for that email address!)"
+msgstr ""
+"如果您没有收到电子邮件，请检查您的垃圾邮件文件夹并确保您正确输入了注册Lookit"
+"账号时使用的邮箱。 （除非该邮箱已在Lookit注册，否则您不会收到电子邮件！）"
+
+#: web/templates/registration/password_reset_email.html:3
+#, fuzzy
+#| msgid ""
+#| "You're receiving this email because you requested a password reset for "
+#| "your user account at %(site_name)s."
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at Children Helping Science."
+msgstr "您收到这封邮件是因为您要求重新设置您在%(site_name)s的用户密码。"
+
+#: web/templates/registration/password_reset_email.html:4
+msgid "Please go to the following page and choose a new password:"
+msgstr "请到以下页面选择一个新的密码："
+
+#: web/templates/registration/password_reset_email.html:8
+msgid "Your username, in case you've forgotten:"
+msgstr "您的用户名："
+
+#: web/templates/registration/password_reset_email.html:9
+msgid "Thanks for using our site!"
+msgstr "感谢您使用我们的网站!"
+
+#: web/templates/registration/password_reset_email.html:10
+msgid "The Children Helping Science team"
+msgstr ""
+
+#: web/templates/registration/password_reset_form.html:6
+msgid "Reset my password"
+msgstr "重置我的密码"
+
+#: web/templates/registration/password_reset_form.html:8
+msgid "Password reset"
+msgstr "重置密码"
+
+#: web/templates/registration/password_reset_form.html:11
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll email "
+"instructions for setting a new one."
+msgstr ""
+"忘记密码了？请在下方输入您的电子邮件地址，我们将通过电子邮件发送设置新密码的"
+"步骤。"
+
+#: web/templates/registration/password_reset_subject_1.txt:2
+#, fuzzy
+#| msgid "Password reset link sent"
+msgid "Password reset on Children Helping Science"
+msgstr "密码重置链接已发送"
+
+#: web/templates/web/_footer.html:9
+#, fuzzy
+#| msgid ""
+#| "This material is based upon work supported by the National Science "
+#| "Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
+#| "Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
+#| "NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+#| "findings, and conclusions or recommendations expressed in this material "
+#| "are those of the authors(s) and do not necessarily reflect the views of "
+#| "the National Science Foundation."
 msgid ""
 "This material is based upon work supported by the National Science "
-"Foundation (NSF) under Grants 1429216 and 1823919; the Center for Brains, "
-"Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and by an "
-"NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
+"Foundation (NSF) under Grants 1429216, 1823919, and 2209756; the Center for "
+"Brains, Minds and Machines (CBMM), funded by NSF STC award CCF-1231216, and "
+"by an NSF Graduate Research Fellowship under Grant No. 1122374. Any opinion, "
 "findings, and conclusions or recommendations expressed in this material are "
 "those of the authors(s) and do not necessarily reflect the views of the "
 "National Science Foundation."
@@ -1179,48 +1385,301 @@ msgstr ""
 "心（CBMM）所支持。本材料中所表达的任何观点、发现、结论或建议均来自作者，并不"
 "一定代表美国国家科学基金会（NSF）的观点。"
 
-#: web/templates/frontpages/default.html:60 web/templates/frontpages/home.html:48
+#: web/templates/web/_footer.html:14
 msgid "Privacy"
 msgstr "隐私"
 
-#: web/templates/frontpages/default.html:61 web/templates/frontpages/home.html:49
+#: web/templates/web/_footer.html:17
 msgid "Contact us"
 msgstr "联系我们"
 
-#: web/templates/frontpages/default.html:63
+#: web/templates/web/_footer.html:20
 msgid "Connect"
 msgstr "关注我们"
 
-#: web/templates/frontpages/faq.html:11
+#: web/templates/web/_navigation.html:3
+msgid "Logout"
+msgstr "退出登录"
+
+#: web/templates/web/_navigation.html:4
+msgid "Experimenter"
+msgstr "实验者"
+
+#: web/templates/web/_studies-by-age-group.html:10
+msgid "studies for babies (under 1)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:17
+msgid "studies for toddlers (1-2)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:26
+msgid "studies for preschoolers (3-4)"
+msgstr ""
+
+#: web/templates/web/_studies-by-age-group.html:33
+msgid "studies for school-aged kids & teens (5-17)"
+msgstr ""
+
+#: web/templates/web/base.html:16 web/templates/web/home.html:35
+msgid "Children Helping Science"
+msgstr ""
+
+#: web/templates/web/child-add.html:8 web/templates/web/children-list.html:6
+msgid "Children"
+msgstr "儿童"
+
+#: web/templates/web/child-add.html:15 web/templates/web/child-update.html:16
+#: web/templates/web/participant-email-preferences.html:9
+msgid "Cancel"
+msgstr "取消"
+
+#: web/templates/web/child-add.html:16 web/templates/web/child-add.html:26
+#: web/templates/web/children-list.html:10
+msgid "Add Child"
+msgstr "添加儿童"
+
+#: web/templates/web/child-update.html:8
+#: web/templates/web/studies-history.html:101
+msgid "Child"
+msgstr "儿童"
+
+#: web/templates/web/child-update.html:14
+msgid "Back to Children List"
+msgstr "返回儿童列表"
+
+#: web/templates/web/child-update.html:15
+msgid "Delete"
+msgstr "删除"
+
+#: web/templates/web/child-update.html:17
+#: web/templates/web/demographic-data-update.html:13
+#: web/templates/web/participant-email-preferences.html:10
+msgid "Save"
+msgstr "保存"
+
+#: web/templates/web/child-update.html:28
+msgid "Update"
+msgstr "更新"
+
+#: web/templates/web/children-list.html:9
+msgid "Update child"
+msgstr "更新儿童信息"
+
+#: web/templates/web/children-list.html:19
+msgid "Click the 'Add Child' button to add a child to your account."
+msgstr ""
+
+#: web/templates/web/children-list.html:22
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button. Click the 'Find a Study' button "
+"to view the studies available for your children."
+msgstr ""
+
+#: web/templates/web/children-list.html:26
+msgid ""
+"When you are ready, click the 'Continue to Study' button to go on to your "
+"study, '{{ request.session.study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:30
+msgid ""
+"You can edit information about the children listed in your account, or add "
+"another by clicking the 'Add Child' button."
+msgstr ""
+
+#: web/templates/web/children-list.html:33
+msgid ""
+"If the 'Continue to Study' button still isn't lighting up, the study may "
+"have become full or be recruiting a slightly different set of kids right "
+"now. You might also be missing a piece of information about your family, "
+"such as the languages you speak at home."
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"You can click the 'Demographic Survey' button to add more information about "
+"your family, 'Find Another Study' to explore more studies for your family, "
+"or "
+msgstr ""
+
+#: web/templates/web/children-list.html:36
+msgid ""
+"click here</a> to review the requirements for '{{ request.session."
+"study_name }}'."
+msgstr ""
+
+#: web/templates/web/children-list.html:44
+msgid "Name"
+msgstr "姓名"
+
+#: web/templates/web/children-list.html:64
+msgid "No child profiles registered!"
+msgstr "尚未注册儿童档案!"
+
+#: web/templates/web/contact.html:10
+msgid "Technical difficulties"
+msgstr "技术故障"
+
+#: web/templates/web/contact.html:13
+msgid ""
+"To report any technical difficulties during participation, please contact "
+"our team by email at "
+msgstr ""
+
+#: web/templates/web/contact.html:14 web/templates/web/contact.html:20
+#: web/templates/web/contact.html:29 web/templates/web/contact.html:33
+msgid "."
+msgstr ""
+
+#: web/templates/web/contact.html:17
+msgid "Questions about the studies"
+msgstr "实验相关问题"
+
+#: web/templates/web/contact.html:20
+msgid ""
+"If you have any questions or concerns about the studies, please first check "
+"our FAQ. With any additional questions, please contact us at "
+msgstr ""
+
+#: web/templates/web/contact.html:23 web/templates/web/privacy.html:161
+msgid "For researchers"
+msgstr "研究人员"
+
+#: web/templates/web/contact.html:26
+msgid ""
+"Lookit is available to all developmental researchers, and the code is "
+"entirely open- To learn more about running your own studies or contributing, "
+"please check out the "
+msgstr ""
+
+#: web/templates/web/contact.html:29 web/templates/web/faq.html:746
+#, fuzzy
+#| msgid "Documentation"
+msgid "documentation"
+msgstr "文件批注"
+
+#: web/templates/web/contact.html:32
+msgid ""
+"Several initial test studies of a prototype Lookit platform were completed "
+"in 2015; you can read about the results, and strengths and limitations of "
+"the platform, in "
+msgstr ""
+
+#: web/templates/web/contact.html:33
+msgid "these papers"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:7
+msgid "Update demographics"
+msgstr "更新基本信息"
+
+#: web/templates/web/demographic-data-update.html:21
+msgid "If the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:24
+msgid "You can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:25
+msgid "click here"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:26
+msgid "to review the requirements for"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:32
+msgid ""
+"Welcome to Children Helping Science! Before you take your first study, we "
+"are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid ""
+"Welcome to Children Helping Science! Before you continue to the main study"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:36
+msgid "we are asking you to share some information about your family."
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:40
+msgid ""
+"Use this form to share more information about your family. When you are "
+"ready to move on, you can click the \\"
+msgstr ""
+
+#: web/templates/web/demographic-data-update.html:44
+msgid ""
+"One reason we are developing Internet-based experiments is to represent a "
+"more diverse group of families in our research. Your answers to these "
+"questions will help us understand what audience we reach, as well as how "
+"factors like speaking multiple languages or having older siblings affect "
+"children's learning."
+msgstr ""
+"我们开发互联网实验的一个原因是为了让更多不同的家庭群体参与到研究中。您的回答"
+"将帮助我们了解研究接触到的受众，以及讲多种语言或有哥哥姐姐等因素会如何影响孩"
+"子的学习。"
+
+#: web/templates/web/demographic-data-update.html:47
+msgid ""
+"Even if you allow your study videos to be published for scientific or "
+"publicity purposes, your demographic information is never published in "
+"conjunction with your video."
+msgstr ""
+"即使您允许我们以科学或宣传为目的发布您的研究视频，您的基本信息也不会和视频一"
+"起发布。"
+
+#: web/templates/web/faq.html:10 web/templates/web/garden/about.html:14
 msgid "Frequently Asked Questions"
 msgstr "常见问题"
 
-#: web/templates/frontpages/faq.html:16
+#: web/templates/web/faq.html:12
 msgid "Participation"
 msgstr "参与"
 
-#: web/templates/frontpages/faq.html:20
+#: web/templates/web/faq.html:22
 msgid "What is a 'study' about cognitive development?"
 msgstr "认知发展的研究是什么？"
 
-#: web/templates/frontpages/faq.html:25
+#: web/templates/web/faq.html:30
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Cognitive development is the science "
+#| "of what kids understand and how they learn. Researchers in cognitive "
+#| "development are interested in questions like...</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li>what knowledge and abilities "
+#| "infants are born with, and what they have to learn from experience</li>\n"
+#| "                                    <li>how abilities like mathematical "
+#| "reasoning are organized and how they develop over time</li>\n"
+#| "                                    <li>what strategies children use to "
+#| "learn from the wide variety of data they observe</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>A study is meant to answer a very "
+#| "specific question about how children learn or what they know: for "
+#| "instance, 'Do three-month-olds recognize their parents' faces?'</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Cognitive development is the science of "
-"what kids understand and how they learn. Researchers in cognitive "
-"development are interested in questions like...</p>\n"
-"                                <ul>\n"
-"                                    <li>what knowledge and abilities infants "
-"are born with, and what they have to learn from experience</li>\n"
-"                                    <li>how abilities like mathematical "
-"reasoning are organized and how they develop over time</li>\n"
-"                                    <li>what strategies children use to "
-"learn from the wide variety of data they observe</li>\n"
-"                                </ul>\n"
-"                                <p>A study is meant to answer a very "
-"specific question about how children learn or what they know: for instance, "
-"'Do three-month-olds recognize their parents' faces?'</p>\n"
-"                                "
+"                <p>Cognitive development is the science of what kids "
+"understand and how they learn. Researchers in cognitive development are "
+"interested in questions like...</p>\n"
+"                <ul>\n"
+"                    <li>What knowledge and abilities infants are born with, "
+"and what they have to learn from experience</li>\n"
+"                    <li>How abilities like mathematical reasoning are "
+"organized and how they develop over time</li>\n"
+"                    <li>What strategies children use to learn from the wide "
+"variety of data they observe</li>\n"
+"                </ul>\n"
+"                <p>A study is meant to answer a very specific question about "
+"how children learn or what they know: for instance, 'Do three-month-olds "
+"recognize their parents' faces?'</p>\n"
 msgstr ""
 "\n"
 "<p>认知发展是一门关于儿童理解和学习的科学。认知发展的研究者会对诸如以下的问题"
@@ -1235,80 +1694,258 @@ msgstr ""
 "和如何学习的具体问题：比如，“三个月大的婴儿能认出他们父母的面孔吗？”</p>\n"
 "                            "
 
-#: web/templates/frontpages/faq.html:40
-msgid "How can we participate online?"
-msgstr "我们如何在线参与研究？"
+#: web/templates/web/faq.html:49
+msgid "Why participate in developmental research?"
+msgstr ""
 
-#: web/templates/frontpages/faq.html:45
+#: web/templates/web/faq.html:56
+msgid ""
+"\n"
+"                <p>Lots of reasons! Here are three:</p>\n"
+"                <ul>\n"
+"                    <li>Researchers work hard to make the studies engaging "
+"for children and families. We hope the study is fun for you and your child!</"
+"li>\n"
+"                    <li>Your work supports science. Children are the world's "
+"most powerful learners and the more we understand about how children grow "
+"and learn, the more we will understand about the human mind.</li>\n"
+"                    <li>While research studies aren't usually designed to "
+"affect outcomes for individual children, the more we understand about "
+"children, the more effective we can be in building a world where they learn "
+"and thrive. Your participation helps all of us!</li>\n"
+"                </ul>\n"
+msgstr ""
+
+#: web/templates/web/faq.html:75
+msgid "What happens when my child participates in a research study?"
+msgstr ""
+
+#: web/templates/web/faq.html:84
+#, python-format
 msgid ""
 "\n"
 "                            <p>If you have a child and would like to "
-"participate, create an account and take a look at what we have available for "
-"your child's age range. You'll need a working webcam to participate.</p>\n"
-"                                <p>When you select a study, you'll be asked "
-"to read a consent form and record yourself stating that you and your child "
-"agree to participate. Then we'll guide you through what will happen during "
-"the study. Depending on your child's age, your child may answer questions "
-"directly or we may be looking for indirect signs of what she thinks is going "
-"on--like how long she looks at a surprising outcome.</p>\n"
-"                                <p>Some portions of the study will be "
-"automatically recorded using your webcam and sent securely to the Lookit "
-"platform. Trained researchers will watch the video and record your child's "
-"responses--for instance, which way he pointed, or how long she looked at "
-"each image. We'll put these together with responses from lots of other "
-"children to learn more about how kids think!</p>\n"
-"                            "
+"participate, <a href=\"%(url_signup)s\">create an account</a>  and take a "
+"look at what we have available for your child's age range.  Some studies can "
+"be done at any time, and some involve a scheduled video chat with a "
+"university-based researcher. Most studies require a laptop/desktop with a "
+"webcam. The study description will tell you if you need any other supplies "
+"(such as a marker and paper, or a high chair for your baby to sit in.)</p>\n"
+"                            <p>Each study will begin in the same way: you "
+"and your child will learn what the research is about, and you can then "
+"decide whether or not you want to do it. In most cases you'll be asked to "
+"read a consent form and record yourself stating that you and your child "
+"agree to participate. In other cases, you may electronically sign a form. In "
+"addition to permission from their parent or guardian, older children will "
+"also be asked directly if they want to participate.</p>\n"
+"                            <p>Individual studies vary widely- we encourage "
+"you to try lots of different ones! Depending on your child's age, your child "
+"may answer questions directly or we may be looking for indirect signs of "
+"what she thinks is going on--like how long she looks at a surprising "
+"outcome. Some things that may happen in studies include:</p>\n"
+"                            <ul>\n"
+"                                <li>Looking at displays of dots or shapes "
+"that change on some dimension, while the webcam records your child's eye "
+"movements</li>\n"
+"                                <li>Hearing some familiar or unfamiliar "
+"words, while watching images that may match what the person is saying</li>\n"
+"                                <li>Listening to a story and then answering "
+"questions by speaking or pointing at the screen</li>\n"
+"                                <li>Answering short interview or survey "
+"questions</li>\n"
+"                            </ul>\n"
+"                            <p>Some portions of the study will be "
+"automatically recorded using your webcam and sent securely to Children "
+"Helping Science. Trained researchers will watch the video and record your "
+"child's responses--for instance, which way he pointed, or how long she "
+"looked at each image. We'll put these together with responses from lots of "
+"other children to learn more about how kids think!</p>\n"
 msgstr ""
-"\n"
-"<p>如果您有孩子并愿意参与研究，请注册账号并查看现有的适合您孩子年龄的研究。您"
-"需要使用一个有摄像头的电脑</p>\n"
-"        \t\t\t\t\t\t\t\t<p>当您选择了一个研究后，您需要阅读同意书，并录下您同"
-"意自己和孩子参与研究的视频。接下来，我们会告诉您研究的步骤。基于您孩子的年"
-"龄，他/她可能需要直接回答问题，或者我们会通过迹象来间接研究他/她对正在发生的"
-"事情的理解，比如他/她盯着一件意想不到的事的时长。</p>\n"
-"        \t\t\t\t\t\t\t\t<p>部分实验会被您的摄像头自动记录下来并保密发送至"
-"Lookit平台。有经验的研究者会浏览您的视频，并记录您孩子的反馈，比如他/她所指的"
-"方向或盯着图片的时长。我们会结合所有孩子的反馈来研究儿童是如何思考的。</p>\n"
-"                            "
 
-#: web/templates/frontpages/faq.html:56
-msgid "Who can create studies on Lookit?"
+#: web/templates/web/faq.html:106
+#, fuzzy
+#| msgid "Who can create studies on Lookit?"
+msgid "Who creates the studies?"
 msgstr "谁可以在Lookit上创建实验？"
 
-#: web/templates/frontpages/faq.html:61
+#: web/templates/web/faq.html:114
+#, python-format
 msgid ""
-"Any researcher with questions about how kids learn and grow can propose a "
-"Lookit study! Each institution using Lookit has to sign a contract with MIT "
-"where they agree to the <a href='/termsofuse'>Terms of Use</a> and certify "
-"that their studies will be reviewed and approved by an institutional review "
-"board. Studies are also subject to approval by Lookit. As of June 2020 we "
-"have agreements with 20 universities!"
+"\n"
+"                <p>All of the research conducted on the website is created "
+"by scientists to learn about child development, leading to articles in "
+"scientific journals. These publications can help inform other scientists, "
+"parents, educators, and policy-makers. Usually, these scientists work at "
+"colleges, universities, or hospitals. Rarely, a scientist who works at a "
+"nonprofit or a company might also do a study that fits this goal. If a study "
+"is meant to publish results in scientific journals for everyone to see "
+"(instead of just for one nonprofit or company), then it is possible it would "
+"appear on this website.</p>\n"
+"                <p>If a scientist wants to use this platform, their "
+"institution has to sign a contract with MIT where they agree to the <a "
+"href=\"%(termsofuse)s\">Terms of Use</a> and certify that their studies will "
+"be reviewed and approved by an institutional review board. Studies are also "
+"subject to review and approval by Children Helping Science. As of April "
+"2023, we have agreements with over 90 universities,  including institutions "
+"in the United States, Canada, the United Kingdom, and European Union.</p>\n"
 msgstr ""
-"任何研究儿童发展的实验人员都可以在Lookit上发起实验。所有使用Lookit的机构都需"
-"要与MIT签署协议，同意<a href=\"/termsofuse\">使用条款</a>，并保证所有实验都会"
-"被机构的审查委员会批准。截至2020年6月，我们已与20所大学签订了协议。"
 
-#: web/templates/frontpages/faq.html:69
+#: web/templates/web/faq.html:129
+msgid ""
+"Who will my child and I meet when we do a study involving a scheduled video "
+"chat?"
+msgstr ""
+
+#: web/templates/web/faq.html:137
+msgid ""
+"\n"
+"                <p>The studies hosted on our site come from universities all "
+"around the world. For studies that involve a scheduled video chat, you will "
+"meet a researcher from the lab associated with the university doing the "
+"study. These researchers work as part of a team that always includes a "
+"\"principal investigator\" -- the supervisor (usually a professor) who is in "
+"charge of the lab). Studies will be conducted by someone under the direct "
+"supervision of that principal investigator (e.g., a lab manager, research "
+"assistant, or a postdoctoral, graduate, or undergraduate researcher in "
+"training).</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:151
+msgid "Why are you running studies online instead of in person?"
+msgstr "为什么要进行线上，而不是线下实验？"
+
+#: web/templates/web/faq.html:159
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <ul>\n"
+#| "                                    <li>Make it easier for you to take "
+#| "part in research, especially for families without a stay-at-home parent</"
+#| "li>\n"
+#| "                                    <li>Work with more kids when needed--"
+#| "right now a limiting factor in designing studies is the time it takes to "
+#| "recruit participants</li>\n"
+#| "                                    <li>Draw conclusions from a more "
+#| "representative population of families--not just those who live near a "
+#| "university and are able to visit the lab during the day.\n"
+#| "                                    </li>\n"
+#| "                                    <li>Make it easier for families to "
+#| "continue participating in longitudinal studies, which may involve "
+#| "multiple testing sessions separated by months or years</li>\n"
+#| "                                    <li>Observe more natural behavior "
+#| "because children are at home rather than in an unfamiliar place</li>\n"
+#| "                                    <li>Create a system for learning "
+#| "about special populations--for instance, children with specific "
+#| "developmental disorders</li>\n"
+#| "                                    <li>Make the procedures we use in "
+#| "doing research more transparent, and make it easier to replicate our "
+#| "findings</li>\n"
+#| "                                    <li>Communicate with families about "
+#| "the research we're doing and what we can learn from it</li>\n"
+#| "                                </ul>\n"
+#| "                                "
+msgid ""
+"\n"
+"                <p>Traditionally, developmental studies happen in a quiet "
+"room in a university lab. Researchers call or email local parents to see if "
+"they'd like to take part and schedule an appointment for them to come visit "
+"the lab.</p>\n"
+"                <p>While researchers have been exploring online studies with "
+"children for several years, the COVID pandemic in 2020 forced most "
+"developmental labs to stop in-person visits entirely. Some studies will "
+"always need to take place in a lab, but some work very well online, and we "
+"have found these studies have a number of benefits for both families and "
+"scientists.</p>\n"
+"                <p>Why complement these in-lab studies with online ones? "
+"We're hoping to...</p>\n"
+"                <ul>\n"
+"                    <li>Make it easier for you to take part in research, "
+"especially for families without a stay-at-home parent</li>\n"
+"                    <li>Work with more kids when needed--right now a "
+"limiting factor in designing studies is the time it takes to recruit "
+"participants</li>\n"
+"                    <li>Draw conclusions from a more representative "
+"population of families--not just those who live near a university and are "
+"able to visit the lab during the day.</li>\n"
+"                    <li>Make it easier for families to continue "
+"participating in longitudinal studies, which may involve multiple testing "
+"sessions separated by months or years</li>\n"
+"                    <li>Observe more natural behavior because children are "
+"at home rather than in an unfamiliar place</li>\n"
+"                    <li>Create a system for learning about special "
+"populations--for instance, children with specific developmental disorders</"
+"li>\n"
+"                    <li>Make the procedures we use in doing research more "
+"transparent, and make it easier to replicate our findings</li>\n"
+"                    <li>Communicate with families about the research we're "
+"doing and what we can learn from it</li>\n"
+"                </ul>\n"
+"                "
+msgstr ""
+"\n"
+"<ul>\n"
+"        \t\t\t\t\t\t\t\t\t<li>方便您参与研究，特别是对于没有全职父母的家庭来"
+"说。</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>在需要时招募到更多的孩子--目前设计研究的一个限"
+"制因素就是寻找参与者所花费的时间。</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>从范围更广的家庭样本中得出结论--而不仅仅是那些"
+"住在大学附近并能在白天访问实验室的家庭。\n"
+"        \t\t\t\t\t\t\t\t\t</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>使家庭更容易继续参加纵向研究，其中可能涉及到以"
+"月或年为间隔的多次测试</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>可以观察到更自然的行为，因为孩子是在家里而不是"
+"在一个陌生的地方</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>建立一个研究特殊人群的系统--例如，有发展障碍的"
+"儿童</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>使我们在研究时使用的程序更加透明，并让我们的研"
+"究结果更容易被复制</li>\n"
+"        \t\t\t\t\t\t\t\t\t<li>与家庭分享我们的研究，以及我们可以从中学到什么"
+"</li>\n"
+"\t\t</ul>\n"
+"                                "
+
+#: web/templates/web/faq.html:184
 msgid "How do we provide consent to participate?"
 msgstr "参与者如何表示同意参加实验？"
 
-#: web/templates/frontpages/faq.html:74
+#: web/templates/web/faq.html:191
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Rather than having the parent or legal "
+#| "guardian sign a form, we ask that you read aloud (or sign in ASL) a "
+#| "statement of consent which is recorded using your webcam. This statement "
+#| "holds the same weight as a signed form, but should be less hassle for "
+#| "you. It also lets us verify that you understand written English and that "
+#| "you understand you're being videotaped.</p>\n"
+#| "                                <p>Researchers watch these consent videos "
+#| "on a special page of the researcher interface, and record for each one "
+#| "whether the video shows informed consent. They cannot view other video or "
+#| "download data from a session unless they have confirmed that you "
+#| "consented to participate! If they see a consent video that does NOT "
+#| "clearly demonstrate informed consent--for instance, there was a technical "
+#| "problem and there's no audio--they may contact you to check, depending on "
+#| "your email settings.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Rather than having the parent or legal "
-"guardian sign a form, we ask that you read aloud (or sign in ASL) a "
-"statement of consent which is recorded using your webcam. This statement "
+"                <p>Some studies ask you (the parent or guardian) to sign an "
+"online form after either reading about what the study involves or talking "
+"with a researcher. Other studies, especially ones that happen on our own "
+"Children Helping Science platform, ask that you read aloud (or sign in ASL) "
+"a statement of consent which is recorded using your webcam. This statement "
 "holds the same weight as a signed form, but should be less hassle for you. "
 "It also lets us verify that you understand written English and that you "
 "understand you're being videotaped.</p>\n"
-"                                <p>Researchers watch these consent videos on "
-"a special page of the researcher interface, and record for each one whether "
-"the video shows informed consent. They cannot view other video or download "
-"data from a session unless they have confirmed that you consented to "
-"participate! If they see a consent video that does NOT clearly demonstrate "
-"informed consent--for instance, there was a technical problem and there's no "
-"audio--they may contact you to check, depending on your email settings.</p>\n"
-"                                "
+"                <p>Researchers watch these consent videos on a special page "
+"of the researcher interface, and record for each one whether the video shows "
+"informed consent. They cannot view other video or download data from a "
+"session unless they have confirmed that you consented to participate! If "
+"they see a consent video that does NOT clearly demonstrate informed consent--"
+"for instance, there was a technical problem and there's no audio--they may "
+"contact you to check, depending on your email settings.</p>\n"
+"                "
 msgstr ""
 "\n"
 "<p>我们会要求家长或法定监护人用摄像头录下朗读或用手语打出同意声明的视频，而不"
@@ -1320,39 +1957,59 @@ msgstr ""
 "失），实验人员可能会根据您的邮件偏好联系您。</p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:80
-msgid "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-msgstr ""
-"https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
-
-#: web/templates/frontpages/faq.html:89
+#: web/templates/web/faq.html:215
 msgid "How is our information kept secure and confidential?"
 msgstr "Lookit是如何保护参与者隐私信息的安全的？"
 
-#: web/templates/frontpages/faq.html:94
+#: web/templates/web/faq.html:223
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>\n"
+#| "                                Researchers using Lookit agree to uphold "
+#| "a common set of standards about how data is protected and shared. For "
+#| "instance, they never publish children's names or birthdates, or "
+#| "information that could be used to calculate a birthdate.</p>\n"
+#| "                                <p>The Lookit researcher interface is "
+#| "designed with participant data protection as the top priority. For "
+#| "instance, a special interface lets researchers confirm consent videos "
+#| "before they are able to download any other data from your session. "
+#| "Research groups can control who has access to what data in a very fine-"
+#| "grained way, for instance allowing an assistant to confirm consent and "
+#| "send gift cards, but not download study data.</p>\n"
+#| "                                <p>All of your data, including video, is "
+#| "transmitted over a secure HTTPS connection to Lookit storage, and is "
+#| "encrypted at rest. We take security very seriously; in addition to making "
+#| "sure any software we use is up-to-date, cloud servers are configured "
+#| "securely, and unit tests cover checking that accessing data requires "
+#| "correct permissions, we conducted a risk assessment and detailed manual "
+#| "penetration testing with a security contractor prior to our 2020 launch.</"
+#| "p>\n"
+#| "                                <p>See also 'Who will see our video?'</"
+#| "p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>\n"
-"                                Researchers using Lookit agree to uphold a "
-"common set of standards about how data is protected and shared. For "
+"                <p>Researchers using Children Helping Science agree to "
+"uphold a common set of standards about how data is protected and shared. For "
 "instance, they never publish children's names or birthdates, or information "
 "that could be used to calculate a birthdate.</p>\n"
-"                                <p>The Lookit researcher interface is "
-"designed with participant data protection as the top priority. For instance, "
-"a special interface lets researchers confirm consent videos before they are "
-"able to download any other data from your session. Research groups can "
-"control who has access to what data in a very fine-grained way, for instance "
-"allowing an assistant to confirm consent and send gift cards, but not "
-"download study data.</p>\n"
-"                                <p>All of your data, including video, is "
-"transmitted over a secure HTTPS connection to Lookit storage, and is "
+"                <p>Our researcher interface is designed with participant "
+"data protection as the top priority. For instance, a special page lets "
+"researchers confirm consent videos before they are able to download any "
+"other data from your session. Research groups can control who has access to "
+"what data in a very fine-grained way, for instance allowing an assistant to "
+"confirm consent and send gift cards, but not download study data.</p>\n"
+"                <p>All of your data, including video, is transmitted over a "
+"secure HTTPS connection to Children Helping Science storage, and is "
 "encrypted at rest. We take security very seriously; in addition to making "
 "sure any software we use is up-to-date, cloud servers are configured "
 "securely, and unit tests cover checking that accessing data requires correct "
-"permissions, we conducted a risk assessment and detailed manual penetration "
-"testing with a security contractor prior to our 2020 launch.</p>\n"
-"                                <p>See also 'Who will see our video?'</p>\n"
-"                                "
+"permissions, we conduct a risk assessment and detailed manual penetration "
+"testing with a security contractor every two years. Our last security "
+"assessment was conducted in December 2022.</p>\n"
+"                <p>See also 'Who will see our video?'</p>\n"
+"                "
 msgstr ""
 "\n"
 "\t<p>\n"
@@ -1371,79 +2028,152 @@ msgstr ""
 "视频”。</p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:107
+#: web/templates/web/faq.html:239
 msgid "Who will see our video?"
 msgstr "谁可以浏览参与者的视频？"
 
-#: web/templates/frontpages/faq.html:112
+#: web/templates/web/faq.html:246
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Lookit staff at MIT will have access "
+#| "to your video and other data in order to improve and promote the platform "
+#| "and help with troubleshooting. The researchers running the study you "
+#| "participated in will also have access to your video and other data (like "
+#| "responses to questions during the study, and information you fill out "
+#| "when registering a child) for research purposes. They will watch the "
+#| "video segments you send to mark down information specific to the study--"
+#| "for instance, what your child said, or how long he/she looked to the left "
+#| "versus the right of the screen. This research group may be at MIT or at "
+#| "another institution. All studies run on Lookit must be approved by an "
+#| "Institutional Review Board (IRB) that ensures participants' rights and "
+#| "welfare are protected. All researchers using Lookit also agree to Terms "
+#| "of Use that govern what data they can share and what sorts of studies are "
+#| "okay to run on Lookit; these rules are sometimes stricter than their own "
+#| "institution might be.  </p>\n"
+#| "                                <p>Whether anyone else may view the video "
+#| "depends on the privacy settings you select at the end of the study. There "
+#| "are two decisions to make: whether to share your data with Databrary, and "
+#| "how to allow your video clips to be used by the researchers you have "
+#| "selected.</p>\n"
+#| "                                <p>First, we ask if you would like to "
+#| "share your data (including video) with authorized users fo the secure "
+#| "data library Databrary. Data sharing will lead to faster progress in "
+#| "research on human development and behavior. Researchers who are granted "
+#| "access to the Databrary library must agree to treat the data with the "
+#| "same high standard of care they would use in their own laboratories. "
+#| "Learn more about Databrary's <a href=\"https://databrary.org/about."
+#| "html\">mission</a> or the <a href=\"https://databrary.org/access/"
+#| "responsibilities/investigators.html\">requirements for authorized users</"
+#| "a>.</p>\n"
+#| "                                <p>Next, we ask what types of uses of "
+#| "your video are okay with you.</p>\n"
+#| "                                <ul>\n"
+#| "                                    <li><strong>Private</strong> This "
+#| "privacy level ensures that your video clips will be viewed only by "
+#| "authorized scientists (Lookit staff, the research group running the study "
+#| "and, if you have opted to share your data with Databrary, authorized "
+#| "Databrary users.) They will view the videos to record information about "
+#| "what your child did during the study--for instance, looking for 9 seconds "
+#| "at one image and 7 seconds at another image.</li>\n"
+#| "                                    <li><strong>Scientific and "
+#| "educational</strong> This privacy level gives permission to share your "
+#| "video clips with other researchers or students for scientific or "
+#| "educational purposes. For example, researchers might show a video clip in "
+#| "a talk at a scientific conference or an undergraduate class about "
+#| "cognitive development, or include an image or video in a scientific "
+#| "paper. In some circumstances, video or images may be available online, "
+#| "for instance as supplemental material in a scientific paper. Sharing "
+#| "videos with other researchers helps other groups trust and build on our "
+#| "work.</li>\n"
+#| "                                    <li><strong>Publicity</strong> This "
+#| "privacy level is for families who would be excited to see their child "
+#| "featured on the Lookit website or in the news! Selecting this privacy "
+#| "level gives permission to use your video clips to communicate about "
+#| "developmental studies and the Lookit platform with the public. For "
+#| "instance, we might post a short video clip on the Lookit website, on our "
+#| "Facebook page, or in a press release. Your video will never be used for "
+#| "commercial purposes.</li>\n"
+#| "                                </ul>\n"
+#| "                                <p>If for some reason you do not select a "
+#| "privacy level, we treat the data as 'Private' and do not share with "
+#| "Databrary. Participants also have the option to withdraw all video "
+#| "besides consent at the end of the study if necessary (for instance, "
+#| "because someone was discussing state secrets in the background), and in "
+#| "this case it is automatically deleted. Privacy settings for completed "
+#| "sessions cannot automatically be changed retroactively. If you have any "
+#| "questions or concerns about privacy, please contact our team at <a "
+#| "href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Lookit staff at MIT will have access to "
-"your video and other data in order to improve and promote the platform and "
-"help with troubleshooting. The researchers running the study you "
-"participated in will also have access to your video and other data (like "
-"responses to questions during the study, and information you fill out when "
-"registering a child) for research purposes. They will watch the video "
-"segments you send to mark down information specific to the study--for "
-"instance, what your child said, or how long he/she looked to the left versus "
-"the right of the screen. This research group may be at MIT or at another "
-"institution. All studies run on Lookit must be approved by an Institutional "
-"Review Board (IRB) that ensures participants' rights and welfare are "
-"protected. All researchers using Lookit also agree to Terms of Use that "
+"                <p>When you participate in a video recorded study on our "
+"platform, Children Helping Science staff at MIT will have access to your "
+"video and other data in order to improve and promote the platform and help "
+"with troubleshooting. The researchers running the study you participated in "
+"will also have access to your video and other data (like responses to "
+"questions during the study, and information you fill out when registering a "
+"child) for research purposes. They will watch the video segments you send to "
+"mark down information specific to the study--for instance, what your child "
+"said, or how long he/she looked to the left versus the right of the screen. "
+"This research group may be at MIT or at another institution. All studies run "
+"on Children Helping Science must be approved by an Institutional Review "
+"Board (IRB) that ensures participants' rights and welfare are protected. All "
+"researchers using Children Helping Science also agree to Terms of Use that "
 "govern what data they can share and what sorts of studies are okay to run on "
-"Lookit; these rules are sometimes stricter than their own institution might "
-"be.  </p>\n"
-"                                <p>Whether anyone else may view the video "
-"depends on the privacy settings you select at the end of the study. There "
-"are two decisions to make: whether to share your data with Databrary, and "
-"how to allow your video clips to be used by the researchers you have "
-"selected.</p>\n"
-"                                <p>First, we ask if you would like to share "
-"your data (including video) with authorized users fo the secure data library "
+"Children Helping Science; these rules are sometimes stricter than their own "
+"institution might be.  </p>\n"
+"                <p>Whether anyone else may view the video depends on the "
+"privacy settings you select at the end of the study. There are two decisions "
+"to make: whether to share your data with Databrary, and how to allow your "
+"video clips to be used by the researchers you have selected.</p>\n"
+"                <p>First, we ask if you would like to share your data "
+"(including video) with authorized users fo the secure data library "
 "Databrary. Data sharing will lead to faster progress in research on human "
 "development and behavior. Researchers who are granted access to the "
 "Databrary library must agree to treat the data with the same high standard "
 "of care they would use in their own laboratories. Learn more about "
-"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> "
-"or the <a href=\"https://databrary.org/access/responsibilities/investigators."
-"html\">requirements for authorized users</a>.</p>\n"
-"                                <p>Next, we ask what types of uses of your "
-"video are okay with you.</p>\n"
-"                                <ul>\n"
-"                                    <li><strong>Private</strong> This "
-"privacy level ensures that your video clips will be viewed only by "
-"authorized scientists (Lookit staff, the research group running the study "
-"and, if you have opted to share your data with Databrary, authorized "
-"Databrary users.) They will view the videos to record information about what "
-"your child did during the study--for instance, looking for 9 seconds at one "
-"image and 7 seconds at another image.</li>\n"
-"                                    <li><strong>Scientific and educational</"
-"strong> This privacy level gives permission to share your video clips with "
-"other researchers or students for scientific or educational purposes. For "
-"example, researchers might show a video clip in a talk at a scientific "
-"conference or an undergraduate class about cognitive development, or include "
-"an image or video in a scientific paper. In some circumstances, video or "
-"images may be available online, for instance as supplemental material in a "
-"scientific paper. Sharing videos with other researchers helps other groups "
-"trust and build on our work.</li>\n"
-"                                    <li><strong>Publicity</strong> This "
-"privacy level is for families who would be excited to see their child "
-"featured on the Lookit website or in the news! Selecting this privacy level "
-"gives permission to use your video clips to communicate about developmental "
-"studies and the Lookit platform with the public. For instance, we might post "
-"a short video clip on the Lookit website, on our Facebook page, or in a "
-"press release. Your video will never be used for commercial purposes.</li>\n"
-"                                </ul>\n"
-"                                <p>If for some reason you do not select a "
-"privacy level, we treat the data as 'Private' and do not share with "
-"Databrary. Participants also have the option to withdraw all video besides "
-"consent at the end of the study if necessary (for instance, because someone "
-"was discussing state secrets in the background), and in this case it is "
-"automatically deleted. Privacy settings for completed sessions cannot "
-"automatically be changed retroactively. If you have any questions or "
-"concerns about privacy, please contact our team at <a href=\"mailto:"
-"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
-"                                "
+"Databrary's <a href=\"https://databrary.org/about.html\">mission</a> or the "
+"<a href=\"https://databrary.org/about/agreement.html\">requirements for "
+"authorized users</a>.</p>\n"
+"                <p>Next, we ask what types of uses of your video are okay "
+"with you.</p>\n"
+"                <ul>\n"
+"                    <li><strong>Private</strong> This privacy level ensures "
+"that your video clips will be viewed only by authorized scientists (Children "
+"Helping Science staff, the research group running the study and, if you have "
+"opted to share your data with Databrary, authorized Databrary users.) They "
+"will view the videos to record information about what your child did during "
+"the study--for instance, looking for 9 seconds at one image and 7 seconds at "
+"another image.</li>\n"
+"                    <li><strong>Scientific and educational</strong> This "
+"privacy level gives permission to share your video clips with other "
+"researchers or students for scientific or educational purposes. For example, "
+"researchers might show a video clip in a talk at a scientific conference or "
+"an undergraduate class about cognitive development, or include an image or "
+"video in a scientific paper. In some circumstances, video or images may be "
+"available online, for instance as supplemental material in a scientific "
+"paper. Sharing videos with other researchers helps other groups trust and "
+"build on our work.</li>\n"
+"                    <li><strong>Publicity</strong> This privacy level is for "
+"families who would be excited to see their child featured on the Children "
+"Helping Science website or in the news! Selecting this privacy level gives "
+"permission to use your video clips to communicate about developmental "
+"studies and the Children Helping Science platform with the public. For "
+"instance, we might post a short video clip on the Children Helping Science "
+"website, on our Facebook page, or in a press release. Your video will never "
+"be used for commercial purposes.</li>\n"
+"                </ul>\n"
+"                <p>If for some reason you do not select a privacy level, we "
+"treat the data as 'Private' and do not share with Databrary. Participants "
+"also have the option to withdraw all video besides consent at the end of the "
+"study if necessary (for instance, because someone was discussing state "
+"secrets in the background), and in this case it is automatically deleted. "
+"Privacy settings for completed sessions cannot automatically be changed "
+"retroactively. If you have any questions or concerns about privacy, please "
+"contact our team at <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
 msgstr ""
 "\n"
 "<p>为了完善平台和排除故障，在MIT的Lookit工作人员将会有权限访问您的视频和其他"
@@ -1484,15 +2214,15 @@ msgstr ""
 "为 \"非公开\"，不会与Databrary共享。如果有必要，参与者也可以选择在研究结束时"
 "撤回除同意声明之外的所有视频（例如，因为有人在讨论个人隐私），在这种情况下，"
 "您的视频会被自动删除。在您完成实验后，您设置的隐私级别无法再自行修改。如果您"
-"有任何关于隐私的问题或疑虑，请联系我们的团队<a href=\"mailto:lookit@mit.edu"
-"\">lookit@mit.edu</a>。</p>\n"
+"有任何关于隐私的问题或疑虑，请联系我们的团队<a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a>。</p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:130
+#: web/templates/web/faq.html:269
 msgid "What information do researchers use from our video?"
 msgstr "研究人员会使用我的视频中的什么信息？"
 
-#: web/templates/frontpages/faq.html:136
+#: web/templates/web/faq.html:278
 msgid ""
 "For children under about two years old, we usually design our studies to let "
 "their eyes do the talking! We're interested in where on the screen your "
@@ -1506,7 +2236,7 @@ msgstr ""
 "子）可以帮助我们了解您的孩子向右或向左看时的样子，以便我们可以对视频的其余部"
 "分进行编码。"
 
-#: web/templates/frontpages/faq.html:143
+#: web/templates/web/faq.html:290
 msgid ""
 "Here's an example of a few children watching our calibration video--it's "
 "easy to see that they look to one side and then the other."
@@ -1514,7 +2244,7 @@ msgstr ""
 "下面是几个孩子观看我们校准视频的例子--可以很明显地看到，他们先看一边，再看另"
 "一边。"
 
-#: web/templates/frontpages/faq.html:149
+#: web/templates/web/faq.html:302
 msgid ""
 "Your child's decisions about where to look can give us lots of information "
 "about what he or she understands. Here are some of the techniques labs use "
@@ -1523,36 +2253,62 @@ msgstr ""
 "你的孩子注视的位置可以给我们提供很多他或她所理解的信息。以下是实验室用来了解"
 "更多关于孩子学习方法的一些手段。"
 
-#: web/templates/frontpages/faq.html:150
+#: web/templates/web/faq.html:304
 msgid "Habituation"
 msgstr "习惯化"
 
-#: web/templates/frontpages/faq.html:151
+#: web/templates/web/faq.html:305
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>In a habituation study, we first show "
+#| "infants many examples of one type of object or event, and they lose "
+#| "interest over time. Infants typically look for a long time at the first "
+#| "pictures, but then they start to look away more quickly. Once their "
+#| "looking times are much less than they were initially, we show either a "
+#| "picture from a new category or a new picture from the familiar category. "
+#| "If infants now look longer to the novel example, we can tell that they "
+#| "understood--and got bored of--the category we showed initially.</p>\n"
+#| "                                <p>Habituation requires waiting for each "
+#| "individual infant to achieve some threshold of \"boredness\"--for "
+#| "instance, looking half as long at a picture as he or she did initially. "
+#| "Sometimes this is impractical, and we use familiarization instead. In a "
+#| "familiarization study, we show all babies the same number of examples, "
+#| "and then see how interested they are in the familiar versus a new "
+#| "category. Younger infants and those who have seen few examples tend to "
+#| "show a familiarity preference--they look longer at images similar to what "
+#| "they have seen before. Older infants and those who have seen many "
+#| "examples tend to show a novelty preference--they look longer at images "
+#| "that are different from the ones they saw before. You probably notice the "
+#| "same phenomenon when you hear a new song on the radio: initially you "
+#| "don't recognize it; after it's played several times you may like it and "
+#| "sing along; after it's played hundreds of times you would choose to "
+#| "listen to anything else.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>In a habituation study, we first show "
-"infants many examples of one type of object or event, and they lose interest "
-"over time. Infants typically look for a long time at the first pictures, but "
-"then they start to look away more quickly. Once their looking times are much "
-"less than they were initially, we show either a picture from a new category "
-"or a new picture from the familiar category. If infants now look longer to "
-"the novel example, we can tell that they understood--and got bored of--the "
-"category we showed initially.</p>\n"
-"                                <p>Habituation requires waiting for each "
-"individual infant to achieve some threshold of \"boredness\"--for instance, "
-"looking half as long at a picture as he or she did initially. Sometimes this "
-"is impractical, and we use familiarization instead. In a familiarization "
-"study, we show all babies the same number of examples, and then see how "
-"interested they are in the familiar versus a new category. Younger infants "
-"and those who have seen few examples tend to show a familiarity preference--"
-"they look longer at images similar to what they have seen before. Older "
-"infants and those who have seen many examples tend to show a novelty "
-"preference--they look longer at images that are different from the ones they "
-"saw before. You probably notice the same phenomenon when you hear a new song "
-"on the radio: initially you don't recognize it; after it's played several "
-"times you may like it and sing along; after it's played hundreds of times "
-"you would choose to listen to anything else.</p>\n"
-"                                "
+"                <p>In a habituation study, we first show infants many "
+"examples of one type of object or event, and they lose interest over time. "
+"Infants typically look for a long time at the first pictures, but then they "
+"start to look away more quickly. Once their looking times are much less than "
+"they were initially, we show either a picture from a new category or a new "
+"picture from the familiar category. If infants now look longer to the novel "
+"example, we can tell that they understood--and got bored of--the category we "
+"showed initially.</p> <p>Habituation requires waiting for each individual "
+"infant to achieve some threshold of \"boredness\"--for instance, looking "
+"half as long at a picture as he or she did initially. Sometimes this is "
+"impractical, and we use familiarization instead. In a familiarization study, "
+"we show all babies the same number of examples, and then see how interested "
+"they are in the familiar versus a new category. Younger infants and those "
+"who have seen few examples tend to show a familiarity preference--they look "
+"longer at images similar to what they have seen before. Older infants and "
+"those who have seen many examples tend to show a novelty preference--they "
+"look longer at images that are different from the ones they saw before. You "
+"probably notice the same phenomenon when you hear a new song on the radio: "
+"initially you don't recognize it; after it's played several times you may "
+"like it and sing along; after it's played hundreds of times you would choose "
+"to listen to anything else.</p>\n"
+"                "
 msgstr ""
 "\n"
 "\t<p>在运用习惯化的研究中，我们会先给婴儿看许多同一类事物的图片，随着时间的推"
@@ -1571,11 +2327,11 @@ msgstr ""
 "您会选择去听其他的歌。</p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:156
+#: web/templates/web/faq.html:308
 msgid "Violation of expectation"
 msgstr "期望悖反"
 
-#: web/templates/frontpages/faq.html:157
+#: web/templates/web/faq.html:310
 msgid ""
 "Infants and children already have rich expectations about how events work. "
 "Children (and adults for that matter) tend to look longer at things they "
@@ -1586,11 +2342,11 @@ msgstr ""
 "惊讶的事物更久，所以在某些情况下，我们可以把他们的注视时长作为衡量他们有多惊"
 "讶的标准。"
 
-#: web/templates/frontpages/faq.html:158
+#: web/templates/web/faq.html:312
 msgid "Preferential looking"
 msgstr "选择性注视"
 
-#: web/templates/frontpages/faq.html:159
+#: web/templates/web/faq.html:314
 msgid ""
 "Even when they seem to be passive observers, children are making lots of "
 "decisions about where to look and what to pay attention to. In this "
@@ -1606,11 +2362,11 @@ msgstr ""
 "面的视频显示，当被要求 \"寻找拍手声 \"时，一个参与者看向了她的左方（她正在看"
 "的视频显示在上方）。"
 
-#: web/templates/frontpages/faq.html:165
+#: web/templates/web/faq.html:325
 msgid "Predictive looking"
 msgstr "预测性注视"
 
-#: web/templates/frontpages/faq.html:166
+#: web/templates/web/faq.html:327
 msgid ""
 "Children can often make sophisticated predictions about what they expect to "
 "see or hear next. One way we can see those predictions in young children is "
@@ -1629,7 +2385,7 @@ msgstr ""
 "后，我们可以通过观察孩子们听到一个音节时看向哪里，来了解他们是否学会了这些关"
 "系，以及他们是如何将它们延伸的。"
 
-#: web/templates/frontpages/faq.html:168
+#: web/templates/web/faq.html:330
 msgid ""
 "Older children may simply be able to answer spoken questions about what they "
 "think is happening. For instance, in a recent study, two women called an "
@@ -1640,7 +2396,7 @@ msgstr ""
 "中，两个人给一个物体分别起了不同的虚构名字，孩子们会被问到哪个才是该物体的正"
 "确名称。"
 
-#: web/templates/frontpages/faq.html:174
+#: web/templates/web/faq.html:342
 msgid ""
 "Another way we can learn about how older children (and adults) think is to "
 "measure their reaction times. For instance, we might ask you to help your "
@@ -1652,95 +2408,13 @@ msgstr ""
 "如，我们会让您帮助孩子学会在出现圆圈时按一个键，出现正方形时按另一个键，然后"
 "看看影响他们按键速度的因素。"
 
-#: web/templates/frontpages/faq.html:181
-msgid "Why are you running studies online instead of in person?"
-msgstr "为什么要进行线上，而不是线下实验？"
-
-#: web/templates/frontpages/faq.html:186
-msgid ""
-"Traditionally, developmental studies happen in a quiet room in a university "
-"lab. Researchers call or email local parents to see if they'd like to take "
-"part and schedule an appointment for them to come visit the lab. Why "
-"complement these in-lab studies with online ones? We're hoping to..."
-msgstr ""
-"一般来说，发展研究是在大学实验室的一个安静的房间里进行的。研究人员会给当地的"
-"家长打电话或发邮件，询问他们是否愿意参加，并安排访问实验室的时间。那为什么还"
-"要用线上研究来补充呢？我们希望"
-
-#: web/templates/frontpages/faq.html:187
-msgid ""
-"\n"
-"                                <ul>\n"
-"                                    <li>Make it easier for you to take part "
-"in research, especially for families without a stay-at-home parent</li>\n"
-"                                    <li>Work with more kids when needed--"
-"right now a limiting factor in designing studies is the time it takes to "
-"recruit participants</li>\n"
-"                                    <li>Draw conclusions from a more "
-"representative population of families--not just those who live near a "
-"university and are able to visit the lab during the day.\n"
-"                                    </li>\n"
-"                                    <li>Make it easier for families to "
-"continue participating in longitudinal studies, which may involve multiple "
-"testing sessions separated by months or years</li>\n"
-"                                    <li>Observe more natural behavior "
-"because children are at home rather than in an unfamiliar place</li>\n"
-"                                    <li>Create a system for learning about "
-"special populations--for instance, children with specific developmental "
-"disorders</li>\n"
-"                                    <li>Make the procedures we use in doing "
-"research more transparent, and make it easier to replicate our findings</"
-"li>\n"
-"                                    <li>Communicate with families about the "
-"research we're doing and what we can learn from it</li>\n"
-"                                </ul>\n"
-"                                "
-msgstr ""
-"\n"
-"<ul>\n"
-"        \t\t\t\t\t\t\t\t\t<li>方便您参与研究，特别是对于没有全职父母的家庭来"
-"说。</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>在需要时招募到更多的孩子--目前设计研究的一个限"
-"制因素就是寻找参与者所花费的时间。</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>从范围更广的家庭样本中得出结论--而不仅仅是那些"
-"住在大学附近并能在白天访问实验室的家庭。\n"
-"        \t\t\t\t\t\t\t\t\t</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>使家庭更容易继续参加纵向研究，其中可能涉及到以"
-"月或年为间隔的多次测试</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>可以观察到更自然的行为，因为孩子是在家里而不是"
-"在一个陌生的地方</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>建立一个研究特殊人群的系统--例如，有发展障碍的"
-"儿童</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>使我们在研究时使用的程序更加透明，并让我们的研"
-"究结果更容易被复制</li>\n"
-"        \t\t\t\t\t\t\t\t\t<li>与家庭分享我们的研究，以及我们可以从中学到什么"
-"</li>\n"
-"\t\t</ul>\n"
-"                                "
-
-#: web/templates/frontpages/faq.html:206
-msgid "When will we see the results of the study?"
-msgstr "我们什么时候能看到研究结果？"
-
-#: web/templates/frontpages/faq.html:211
-msgid ""
-"The process of publishing a scientific study, from starting data collection "
-"to seeing the paper in a journal, can take several years. You can check the "
-"Lookit home page for updates on papers, or set your communication "
-"preferences to be notified when we have results from studies you "
-"participated in."
-msgstr ""
-"发表一项科学研究，从开始收集数据到在期刊上看到论文，这个过程可能需要几年时"
-"间。您可以查看Lookit主页，了解论文的更新情况，或者设置您的邮件偏好，当您参与"
-"的研究结果有更新时，您会收到通知。"
-
-#: web/templates/frontpages/faq.html:218
+#: web/templates/web/faq.html:355
 msgid ""
 "My child wasn't paying attention, or we were interrupted. Can we try the "
 "study again?"
 msgstr "我的孩子在研究中走神，或者我们被打断了。我们可以重新开始实验吗？"
 
-#: web/templates/frontpages/faq.html:223
+#: web/templates/web/faq.html:364
 msgid ""
 "Certainly--thanks for your dedication! You may see a warning that you have "
 "already participated in the study when you go to try it again, but you can "
@@ -1751,13 +2425,13 @@ msgstr ""
 "了这项研究，但您可以忽略它。您不需要告诉我们您曾经做过这项研究，我们会有您之"
 "前的参与记录。"
 
-#: web/templates/frontpages/faq.html:230
+#: web/templates/web/faq.html:377
 msgid ""
 "My child is outside the age range. Can he/she still participate in this "
 "study?"
 msgstr "我的孩子不在年龄范围内，他/她还能参加这项研究吗？"
 
-#: web/templates/frontpages/faq.html:235
+#: web/templates/web/faq.html:386
 msgid ""
 "Sure! We may not be able to use his or her data in our research directly, "
 "but if you're curious you're welcome to try the study anyway. (Sometimes big "
@@ -1769,11 +2443,11 @@ msgstr ""
 "兴趣，欢迎您来尝试。（有时候，哥哥姐姐也很想试试！）然而，如果您的孩子低于研"
 "究的最低年龄，我们鼓励您等到孩子达到规定年龄再参与，以便我们能够使用数据。"
 
-#: web/templates/frontpages/faq.html:242
+#: web/templates/web/faq.html:399
 msgid "My child was born prematurely. Should we use his/her adjusted age?"
 msgstr "我的孩子是早产儿。我们应该用他/她的矫正年龄吗？"
 
-#: web/templates/frontpages/faq.html:247
+#: web/templates/web/faq.html:408
 msgid ""
 "For study eligibility, we usually use the child's chronological age (time "
 "since birth), even for premature babies. If adjusted age is important for a "
@@ -1782,13 +2456,13 @@ msgstr ""
 "就参与资格而言，我们通常使用儿童的实际年龄（出生后的时间），即使是早产儿也是"
 "如此。如果矫正年龄对某项研究很重要，我们会在参与资格中明确说明。"
 
-#: web/templates/frontpages/faq.html:254
+#: web/templates/web/faq.html:421
 msgid ""
 "Our family speaks a language other than English at home. Can my child "
 "participate?"
 msgstr "我们家不用英语，我的孩子还可以参加吗？"
 
-#: web/templates/frontpages/faq.html:259
+#: web/templates/web/faq.html:430
 msgid ""
 "Sure! Right now, instructions for children and parents are written only in "
 "English, so some of them may be confusing to a child who does not hear "
@@ -1803,26 +2477,38 @@ msgstr ""
 "子翻译。如果某项研究需要知道您的孩子是否会说英语以外的其他语言，我们会特别询"
 "问。您也可以在基本信息中注明您的孩子会说或正在学习的语言。"
 
-#: web/templates/frontpages/faq.html:266
+#: web/templates/web/faq.html:443
 msgid ""
 "My child has been diagnosed with a developmental disorder or has special "
 "needs. Can he/she still participate?"
 msgstr "我的孩子被诊断出患有发展障碍或有特殊需要，他/她还能参加吗？"
 
-#: web/templates/frontpages/faq.html:271
+#: web/templates/web/faq.html:451
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>Of course! We're interested in how all "
+#| "children learn and grow. If you'd like, you can make a note of any "
+#| "developmental disorders in the comments section at the end of the study. "
+#| "We are excited that in the future, online studies may help more families "
+#| "participate in research to better understand their own children's "
+#| "diagnoses.</p>\n"
+#| "                                <p>One note: most of our studies include "
+#| "both images and sound, and may be hard to understand if your child is "
+#| "blind or deaf. If you can, please feel free to help out by describing "
+#| "images or signing.</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>Of course! We're interested in how all "
-"children learn and grow. If you'd like, you can make a note of any "
-"developmental disorders in the comments section at the end of the study. We "
-"are excited that in the future, online studies may help more families "
-"participate in research to better understand their own children's diagnoses."
-"</p>\n"
-"                                <p>One note: most of our studies include "
-"both images and sound, and may be hard to understand if your child is blind "
-"or deaf. If you can, please feel free to help out by describing images or "
-"signing.</p>\n"
-"                                "
+"                <p>Of course! We're interested in how all children learn and "
+"grow. If you'd like, you can make a note of any developmental disorders in "
+"the comments section at the end of the study. We are excited that in the "
+"future, online studies may help more families participate in research to "
+"better understand their own children's diagnoses.</p>\n"
+"                <p>One note: most of our studies include both images and "
+"sound, and may be hard to understand if your child is blind or deaf. If you "
+"can, please feel free to help out by describing images or signing.</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>当然可以！我们关心所有的孩子是如何学习和成"
@@ -1833,13 +2519,13 @@ msgstr ""
 "帮助我们给孩子用语言或手语描述内容。</p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:281
+#: web/templates/web/faq.html:466
 msgid ""
 "I have multiple children in the age range for a study. Can they participate "
 "together?"
 msgstr "我有多个同年龄段的孩子可以参加一项研究。他们能一起同时参与吗？"
 
-#: web/templates/frontpages/faq.html:286
+#: web/templates/web/faq.html:475
 msgid ""
 "If possible, we ask that each child participate separately. When children "
 "participate together they generally influence each other. That's a "
@@ -1849,24 +2535,38 @@ msgstr ""
 "如果可能的话，我们要求每个孩子分别参加。当孩子们一起参与时，他们经常会互相影"
 "响。这是一个有趣的课题，但通常不是我们研究的重点。"
 
-#: web/templates/frontpages/faq.html:293
+#: web/templates/web/faq.html:488
 msgid "But I've heard that young children should avoid 'screen time.'"
 msgstr "但我听说，幼儿应该减少看屏幕的时间。"
 
-#: web/templates/frontpages/faq.html:298
+#: web/templates/web/faq.html:496
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                                <p>We agree with the American Academy of "
+#| "Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
+#| "e20162591\" target=\"_blank\">advice</a> that children learn best from "
+#| "people, not screens! However, our studies are not intended to educate "
+#| "children, but to learn from them.</p>\n"
+#| "                                <p>As part of a child's limited screen "
+#| "time, we hope that our studies will foster family conversation and "
+#| "engagement with science that offsets the few minutes spent watching a "
+#| "video instead of playing. And we do \"walk the walk\"--our own young "
+#| "children provide lots of feedback on our studies!</p>\n"
+#| "                                "
 msgid ""
 "\n"
-"                                <p>We agree with the American Academy of "
-"Pediatrics <a href=\"https://pediatrics.aappublications.org/content/138/5/"
-"e20162591\" target=\"_blank\">advice</a> that children learn best from "
+"                <p>We agree with the American Academy of Pediatrics <a "
+"href=\"https://pediatrics.aappublications.org/content/138/5/e20162591\" "
+"target=\"_blank\" rel=\"noopener\">advice</a> that children learn best from "
 "people, not screens! However, our studies are not intended to educate "
 "children, but to learn from them.</p>\n"
-"                                <p>As part of a child's limited screen time, "
-"we hope that our studies will foster family conversation and engagement with "
-"science that offsets the few minutes spent watching a video instead of "
-"playing. And we do \"walk the walk\"--our own young children provide lots of "
-"feedback on our studies!</p>\n"
-"                                "
+"                <p>As part of a child's limited screen time, we hope that "
+"our studies will foster family conversation and engagement with science that "
+"offsets the few minutes spent watching a video instead of playing. And we do "
+"\"walk the walk\"--our own young children provide lots of feedback on our "
+"studies!</p>\n"
+"                "
 msgstr ""
 "\n"
 "                                <p>我们同意美国儿科学会<a href=\"https://"
@@ -1877,11 +2577,11 @@ msgstr ""
 "来促进家庭沟通和提高科学参与度。</p>\n"
 "                                "
 
-#: web/templates/frontpages/faq.html:308
+#: web/templates/web/faq.html:510
 msgid "Will we be paid for our participation?"
 msgstr "我们参与研究会拿到报酬吗？"
 
-#: web/templates/frontpages/faq.html:313
+#: web/templates/web/faq.html:518
 msgid ""
 "Some research groups provide gift cards or other compensation for completing "
 "their studies, and others rely on volunteers. (This often depends on the "
@@ -1891,205 +2591,556 @@ msgstr ""
 "有些研究小组为完成研究的参与者提供礼品卡或其他报酬，有些则是无偿的。(这通常取"
 "决于进行研究的大学的规定。)这些信息将在研究简介上列出。"
 
-#: web/templates/frontpages/faq.html:320
-msgid "Can I get my child's results?"
-msgstr " 我可以拿到我的孩子的研究结果吗？"
+#: web/templates/web/faq.html:531
+msgid ""
+"I want to review the studies I have participated in, or I have a concern and "
+"want to contact the researchers."
+msgstr ""
 
-#: web/templates/frontpages/faq.html:325
-#, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "                                <p>For some studies, yes! Usually, "
-#| "developmental researchers only interpret children's abilities and "
-#| "developmental trends at a group level, and the individual data collected "
-#| "just isn't very interpretable. But for \"Your baby, the physicist\" and "
-#| "other longitudinal studies (where you come back for more than one "
-#| "session), we can sometimes collect enough data to give you a report of "
-#| "your child's responses after you complete all the sessions.</p>\n"
-#| "                                <p>Please note that none of the measures "
-#| "we collect are diagnostic! For instance, while we hope you'll be "
-#| "interested to learn that your child looked 70%% of the time at videos "
-#| "where things fell up versus falling down, we won't be able to tell you "
-#| "whether this means your child is going to be especially good at physics.</"
-#| "p>\n"
-#| "                                <p>If you're interested in getting "
-#| "individual results right away, please see our <a "
-#| "href='resources'>Resources</a> section for fun at-home activities you can "
-#| "try with your child.</p>\n"
-#| "                                "
+#: web/templates/web/faq.html:540
+msgid ""
+"Each study on Children Helping Science is run by a separate team of "
+"researchers. To find contact information for a specific study, visit your"
+msgstr ""
+
+#: web/templates/web/faq.html:542
+msgid ""
+"page. On this page you can also see information about when you participated "
+"in a study, and for studies that run here on our platform, watch your "
+"child's video from the session!"
+msgstr ""
+
+#: web/templates/web/faq.html:545
+msgid ""
+"If you have a more general question, want to report something to the "
+"Children Helping Science team, or need help reaching the researcher team, "
+"please contact us at"
+msgstr ""
+
+#: web/templates/web/faq.html:559
+msgid "Can I learn the results of the research my child does?"
+msgstr ""
+
+#: web/templates/web/faq.html:567
+#, python-format
+msgid ""
+" <p>You should expect to get an explanation about the purpose of every study "
+"you participate in when you consent to the study. At the end of the study, "
+"especially when it is a video chat, you should have a chance to ask any "
+"questions you like.</p> <p>In general though, the goal of research studies "
+"is to learn about children in general, not any particular child. Thus, the "
+"information we get is usually not appropriate for making diagnoses or "
+"assessing the performance of individuals. For instance, while it might be "
+"interesting to learn that your child looked 70%% of the time at videos where "
+"things fell up versus falling down today, we won't be able to tell you "
+"whether this means your child is going to be especially good at physics.</"
+"p>\n"
+"                <p>If you're interested in getting individual results right "
+"away, please see our <a href='resources'>Resources</a> section for fun at-"
+"home activities you can try with your child.</p>\n"
+"                <p>Researchers usually aim to share the general results of "
+"studies in scientific journals (e.g., “The majority of three-year-olds chose "
+"option A; the majority of five-year-olds chose option B.\"). You can click "
+"<a href = \"https://childrenhelpingscience.com/publications\">here</a> to "
+"see some examples of scientific research published with data collected "
+"online with children.</p>\n"
+"                <p>There can be a long lag between conducting a study and "
+"publication -- your five-year-olds might be eight-year-olds before the "
+"results are in press! So in addition to scientific publications, many of the "
+"labs that post studies on this website have ways for parents to sign up to "
+"receive updates. You can also set your communication preferences to be "
+"notified by Children Helping Science when we have results from studies you "
+"participated in.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:582
+msgid "I love this. How do I share this site?"
+msgstr ""
+
+#: web/templates/web/faq.html:590
+#, python-format
 msgid ""
 "\n"
-"                                <p>For some studies, yes! Usually, "
-"developmental researchers only interpret children's abilities and "
-"developmental trends at a group level, and the individual data collected "
-"just isn't very interpretable. But for \"Your baby, the physicist\" and "
-"other longitudinal studies (where you come back for more than one session), "
-"we can sometimes collect enough data to give you a report of your child's "
-"responses after you complete all the sessions.</p>\n"
-"                                <p>Please note that none of the measures we "
-"collect are diagnostic! For instance, while we hope you'll be interested to "
-"learn that your child looked 70%% of the time at videos where things fell up "
-"versus falling down, we won't be able to tell you whether this means your "
-"child is going to be especially good at physics.</p>\n"
-"                                <p>If you're interested in getting "
-"individual results right away, please see our <a href='resources'>Resources</"
-"a> section for fun at-home activities you can try with your child.</p>\n"
-"                                "
+"                <p>Become a parent ambassador! One of the biggest challenges "
+"in developmental research is reaching families like you. With more children, "
+"we can also answer more sophisticated questions -- including questions about "
+"individual differences, the ways many different factors can interact to "
+"affect outcomes. Families like yours can help us make our science more "
+"representative and more reliable. </p>\n"
+"                <p>If you like what you are doing, please share this website "
+"(<a href=\"%(url_home)s\">https://www.childrenhelpingscience.com</a>), with "
+"our sincere thanks. Research on child development would be impossible "
+"without the support of parents like you.</p>\n"
+"                "
 msgstr ""
-"\n"
-"                                <p>对于一些研究，您可以拿到自己孩子的研究结"
-"果。通常情况下，科学家只能在群体水平上解释孩子的能力和发展趋势，而收集到的个"
-"体数据并不能很好地被分析。但对于“Your baby, the physicist”和其他纵向研究（您"
-"的孩子会在不同年龄段多次参与），若我们能收集到足够的个体数据，在整个实验结束"
-"后，您将可以收到一份孩子的实验报告。</p>\n"
-"        \t\t\t\t\t\t\t    <p>请注意，我们收集的所有数据都没有诊断意义! 例如，"
-"虽然我们希望您有兴趣了解您的孩子在70%的时间里都在看物体运动的视频，但我们无法"
-"告诉您这是否意味着您的孩子会特别擅长物理。</p>\n"
-"        \t\t\t\t\t\t\t\t<p>如果您有兴趣立即获得个人结果，请查看我们的<a href="
-"\"/resources\">资料库</a>部分，了解您可以与孩子一起尝试的有趣的家庭活动。</"
-"p>\n"
-"                                "
 
-#: web/templates/frontpages/faq.html:335
+#: web/templates/web/faq.html:605
+msgid "What is the Parent Researcher Collaborative (PaRC)?"
+msgstr ""
+
+#: web/templates/web/faq.html:613
+msgid ""
+"\n"
+"                <p>If you are a parent or guardian who has participated with "
+"your child in a study on this website, or a university-based researcher who "
+"has posted a study on this website, then we consider you a member of the "
+"Parent Researcher Collaborative!</p>\n"
+"                <p>If you are asking who runs this website, the answer is "
+"that we are a group of scientists who decided it would be nice for there to "
+"be one place online where families and researchers could go to connect with "
+"each other to support research into child development! The new Children "
+"Helping Science website is a collaboration between two previous platforms, "
+"Lookit and (an earlier version of) Children Helping Science. Lookit was "
+"founded by <a href = \"https://kimberscott.github.io/\">Kim Scott</a> and <a "
+"href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, and is now lead by "
+"Executive Director <a href = \"http://www.melissaklinestruhl.com/\">Melissa "
+"Kline Struhl</a>.  The original Children Helping Science website was created "
+"by <a href = \"https://projects.iq.harvard.edu/ccdlab\">Elizabeth Bonawitz</"
+"a> at Harvard, <a href = \"http://sll.stanford.edu/\">Hyowon Gweon</a> at "
+"Stanford, <a href = \"https://compdevlab.yale.edu/\">Julian Jara-Ettinger</"
+"a> at Yale, <a href = \"https://www.utdallas.edu/thinklab/\">Candice Mills</"
+"a> at UT Dallas, <a href = \"http://eccl.mit.edu/\">Laura Schulz</a> at MIT, "
+"and <a href = \"https://www.minerva.kgi.edu/people/mark-sheskin-phd/\">Mark "
+"Sheskin</a> at Minerva University.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:627
+msgid "How can I contact you?"
+msgstr ""
+
+#: web/templates/web/faq.html:634
+msgid ""
+"\n"
+"                <p>For information about individual studies, please see the "
+"\"study details\" page, which will always include contact information for "
+"the lab running that study. </p>\n"
+"                <p>If you want to get in touch with the researchers "
+"organizing this website, you can reach us by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                <p>To report any technical difficulties during "
+"participation, please contact our team by email at <a href=\"mailto:"
+"lookit@mit.edu\">lookit@mit.edu</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:643
 msgid "Technical"
 msgstr "技术问题"
 
-#: web/templates/frontpages/faq.html:339
+#: web/templates/web/faq.html:652
 msgid "What browsers are supported?"
 msgstr "Lookit可以在什么浏览器上运行？"
 
-#: web/templates/frontpages/faq.html:344
+#: web/templates/web/faq.html:660
+#, fuzzy
+#| msgid ""
+#| "Lookit supports recent versions of Chrome and Firefox. We are not "
+#| "currently able to support Internet Explorer or Safari."
 msgid ""
-"Lookit supports recent versions of Chrome and Firefox. We are not currently "
-"able to support Internet Explorer or Safari."
+"Children Helping Science officially supports recent versions of Chrome and "
+"Firefox. In particular, the Lookit engine is not currently able to support "
+"Internet Explorer or Safari."
 msgstr ""
 "Lookit支持最新版本的谷歌（Chrome）和火狐（Firefox）浏览器，但目前无法支持微软"
 "（IE）或苹果（Safari）浏览器。"
 
-#: web/templates/frontpages/faq.html:351
+#: web/templates/web/faq.html:672
 msgid "Can we do a study on my phone or tablet?"
 msgstr "我们可以在手机或平板电脑上参与实验吗？"
 
-#: web/templates/frontpages/faq.html:357
+#: web/templates/web/faq.html:679
+#, fuzzy
+#| msgid ""
+#| "Not yet! Because we're measuring kids' looking patterns, we need a "
+#| "reasonably stable view of their eyes and a big enough screen that we can "
+#| "tell whether they're looking at the left or the right side of it. We're "
+#| "excited about the potential for touchscreen studies that allow us to "
+#| "observe infants and toddlers exploring, though!"
 msgid ""
-"Not yet! Because we're measuring kids' looking patterns, we need a "
-"reasonably stable view of their eyes and a big enough screen that we can "
-"tell whether they're looking at the left or the right side of it. We're "
-"excited about the potential for touchscreen studies that allow us to observe "
-"infants and toddlers exploring, though!"
+"\n"
+"                <p>Most studies require a laptop or desktop with a webcam. "
+"Because we're measuring kids' looking patterns, we need a reasonably stable "
+"view of their eyes and a big enough screen that we can tell whether they're "
+"looking at the left or the right side of it. We're excited about the "
+"potential for touchscreen studies that allow us to observe infants and "
+"toddlers exploring, though!</p>\n"
+"                <p>Some studies, especially surveys meant for older children "
+"and teens, may work on your phone or tablet - the study description should "
+"mention this if so.</p>\n"
+"                "
 msgstr ""
 "暂时还不能。由于我们要测量孩子们的观察模式，我们需要一个相对稳定的视角以及一"
 "个足够大的屏幕，以便我们能够判断他们是在看左边还是右边。不过，我们很期待触摸"
 "屏研究的进步，因为它可以让我们观察婴幼儿的探索过程。"
 
-#: web/templates/frontpages/home.html:11
-msgid "the online child lab"
-msgstr "线上儿童实验平台"
-
-#: web/templates/frontpages/home.html:12
-msgid "A project of the MIT Early Childhood Cognition Lab"
-msgstr "麻省理工学院早期儿童认知实验室项目"
-
-#: web/templates/frontpages/home.html:22
-msgid "Bringing science home"
-msgstr "将科学融入生活"
-
-#: web/templates/frontpages/home.html:23
-msgid ""
-"Here at MIT's Early Childhood Cognition Lab, we're trying a new approach in "
-"developmental psychology: bringing the experiments to you."
+#: web/templates/web/faq.html:693
+msgid "My study isn't working, what can I do?"
 msgstr ""
-"麻省理工学院早期儿童认知实验室正在尝试一种研究发展心理学的新途径：将实验直接"
-"带到您的面前。"
 
-#: web/templates/frontpages/home.html:29
-msgid "Help us understand how your child thinks"
-msgstr "帮助我们了解您的孩子如何思考"
-
-#: web/templates/frontpages/home.html:30
+#: web/templates/web/faq.html:700
 msgid ""
-"Your family can contribute to research about how children learn by doing fun "
-"activities together, right in your web browser."
-msgstr "您的家庭可以直接在网上一起做些有趣的活动来为儿童学习研究作出贡献。"
-
-#: web/templates/frontpages/home.html:36
-msgid "Participate whenever and wherever"
-msgstr "随时随地参与"
-
-#: web/templates/frontpages/home.html:37
-msgid ""
-"Log in or create an account at the top right to get started! You can "
-"participate with your child from any computer with a webcam."
+"\n"
+"                <p>If you are trying to participate in a study and having "
+"difficulties, please start by contacting the researchers who made that "
+"specific study.  If you still need help, you can also reach the Children "
+"Helping Science team for help at <a href=\"mailto:lookit-tech@mit."
+"edu\">lookit-tech@mit.edu</a>.</p>\n"
+"                <p>If you are a researcher working on creating a study, you "
+"can find help in our <a href=\"https://lookit.readthedocs.io/en/develop/"
+"index.html\">documentation</a>, and in our <a href = \"https://docs.google."
+"com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-Q/"
+"viewform\">Slack community</a>.</p>\n"
+"                "
 msgstr ""
-"请在右上方注册或登录。您可以使用任何有摄像头的电脑来与您的孩子一起参与研究。"
 
-#: web/templates/frontpages/privacy.html:11
+#: web/templates/web/faq.html:714
+#, fuzzy
+#| msgid "What state do you live in?"
+msgid "What security measures do you implement?"
+msgstr "您居住在哪个省份/自治区/直辖市/特别行政区？"
+
+#: web/templates/web/faq.html:721
+msgid ""
+"\n"
+"                <p>Here at Children Helping Science we are very concerned "
+"about protecting your and your children's data, and our software is designed "
+"to take advantage of up-to-date security measures. You can read a bit about "
+"how we do this in our <a href = \"https://lookit.readthedocs.io/en/develop/"
+"community-irb-and-legal-information.html#sub-processors-and-information-"
+"about-gdpr-compliance-dpas\">documentation</a>, and an updated HECVAT is "
+"available by emailing <a href=\"mailto:lookit@mit.edu\">lookit@mit.edu</a>.</"
+"p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:728
+#, fuzzy
+#| msgid "For researchers"
+msgid "For Researchers"
+msgstr "研究人员"
+
+#: web/templates/web/faq.html:737
+msgid "How can I list my study?"
+msgstr ""
+
+#: web/templates/web/faq.html:745
+msgid "Visit our"
+msgstr ""
+
+#: web/templates/web/faq.html:747
+msgid ""
+"for a complete guide to posting your studies on Children Helping Science!"
+msgstr ""
+
+#: web/templates/web/faq.html:749
+msgid ""
+"\n"
+"                <p>In order to list your study on this website, you first "
+"will need to have your institution sign a contract with MIT where they agree "
+"to the <a href=\"https://lookit.mit.edu/termsofuse\">Terms of Use</a> and "
+"certify that their studies will be reviewed and approved by an institutional "
+"review board. You will also need to edit your IRB protocol to include online "
+"testing, or submit a new protocol for your proposed online study.</p>\n"
+"                <p>As of April 2023, we have agreements with over 90 "
+"universities, including institutions in the United States, Canada, the "
+"United Kingdom, and European Union. Please email <a href=\"mailto:lookit@mit."
+"edu\">lookit@mit.edu</a> if you are not sure whether your institution "
+"already has an agreement, or if you need any help at all getting your "
+"paperwork in order.</p>\n"
+"                <p>While you are completing these steps, you can get started "
+"on Children Helping Science by creating a lab account, creating your first "
+"study, and getting it peer reviewed by our researcher community. A step-by-"
+"step guide to getting started is available <a href=\"https://lookit."
+"readthedocs.io/en/develop/researchers-start-here.html\">here</a>.</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/faq.html:765
+msgid ""
+"Where can I discuss best practices for online research with other "
+"researchers?"
+msgstr ""
+
+#: web/templates/web/faq.html:773
+#, python-format
+msgid ""
+"\n"
+"                <p>Children Helping Science has a <a href = \"https://docs."
+"google.com/forms/d/e/1FAIpQLScI2h7G6aUSJb-I3fGHw2nB8HcuaomuNLiwta2CXhGGF2ZL-"
+"Q/viewform\">Slack community</a> for researchers to ask for help, conduct "
+"peer review, and discuss online research methods.</p>\n"
+"                <p>The Society for Research in Child Development also has a "
+"<a href = \"https://commons.srcd.org/communities/community-home/digestviewer/"
+"viewthread?CommunityKey=bd3d326e-b7db-49bf-"
+"abbb-73642ac0576c&GroupId=109&MessageKey=0871d623-bd97-48c5-"
+"b8e4-54ecda9de9d8&ReturnUrl=%%2Fcommunities%%2Fcommunity-"
+"home%%2Fdigestviewer%%3Fcommunitykey%%3Dbd3d326e-b7db-49bf-"
+"abbb-73642ac0576c%%26tab%%3Ddigestviewer&tab=digestviewer\">discussion "
+"forum</a> you might check out!</p>\n"
+"                "
+msgstr ""
+
+#: web/templates/web/garden/about.html:13
+#, fuzzy
+#| msgid "What is your age?"
+msgid "What is Project Garden?"
+msgstr "您的年龄是？"
+
+#: web/templates/web/garden/home.html:14
+msgid "Welcome to"
+msgstr ""
+
+#: web/templates/web/garden/participate.html:16
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "How to Participate"
+msgstr "请登录后参与"
+
+#: web/templates/web/garden/scientists.html:13
+#, fuzzy
+#| msgid "The Scientists"
+msgid "Meet the GARDEN Scientists"
+msgstr "科学家团队"
+
+#: web/templates/web/home.html:15
+msgid "ChildrenHelpingScience and Lookit have merged - click"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "here"
+msgstr ""
+
+#: web/templates/web/home.html:16
+msgid "to make an account or explore studies below!"
+msgstr ""
+
+#: web/templates/web/home.html:18
+msgid "ChildrenHelpingScience and Lookit have merged!"
+msgstr ""
+
+#: web/templates/web/home.html:36
+msgid "Powered by Lookit"
+msgstr ""
+
+#: web/templates/web/home.html:38
+msgid "Fun for Families, Serious for Science"
+msgstr ""
+
+#: web/templates/web/home.html:41
+#, fuzzy
+#| msgid "Participation"
+msgid "Participate in a Study"
+msgstr "参与"
+
+#: web/templates/web/home.html:52
+msgid "Help Science"
+msgstr ""
+
+#: web/templates/web/home.html:54
+msgid ""
+"This website has studies you and your child can participate in from your "
+"home, brought to you by researchers from universities around the world!"
+msgstr ""
+
+#: web/templates/web/home.html:59
+#, fuzzy
+#| msgid "Home"
+msgid "From Home"
+msgstr "主页"
+
+#: web/templates/web/home.html:61
+msgid ""
+"You and your child use your computer to participate. Some studies can also "
+"be done on a tablet or phone."
+msgstr ""
+
+#: web/templates/web/home.html:66
+msgid "With Fun Activities"
+msgstr ""
+
+#: web/templates/web/home.html:68
+msgid ""
+"Many studies are either short games, or listening to a story and answering "
+"questions about it. Some are available at any time, and others are a "
+"scheduled video chat with a researcher."
+msgstr ""
+
+#: web/templates/web/home.html:73
+msgid "Join researchers from these schools, and many more!"
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid ""
+"Interested in participating in a project with many studies? Learn more about "
+msgstr ""
+
+#: web/templates/web/home.html:85
+msgid "Project GARDEN"
+msgstr ""
+
+#: web/templates/web/home.html:88
+msgid ""
+"In this series of studies, your child will help an animated fox named Fen "
+"find the “GARDEN Library” while playing games to help Children Helping "
+"Science understand children's development from many different angles!"
+msgstr ""
+
+#: web/templates/web/home.html:91
+msgid "See our current studies for different age groups:"
+msgstr ""
+
+#: web/templates/web/participant-email-preferences.html:19
+msgid "I would like to be contacted when:"
+msgstr "我愿意在以下情况收到通知："
+
+#: web/templates/web/participant-signup.html:7
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Sign up to participate"
+msgstr "请登录后参与"
+
+#: web/templates/web/participant-signup.html:11
+msgid "Create Account"
+msgstr "创建账号"
+
+#: web/templates/web/participant-signup.html:13
+msgid "Create Participant Account"
+msgstr "创建参与者账号"
+
+#: web/templates/web/participant-signup.html:16
+msgid ""
+"Ready to participate in a study with Children Helping Science? Create a "
+"family account here!"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:18
+#, fuzzy
+#| msgid "To register as a researcher, please use"
+msgid "To make a researcher account, please use"
+msgstr "要注册为研究人员，请使用"
+
+#: web/templates/web/participant-signup.html:20
+msgid "this registration form"
+msgstr ""
+
+#: web/templates/web/participant-signup.html:21
+msgid "instead."
+msgstr ""
+
+#: web/templates/web/participant-signup.html:28
+msgid ""
+"By clicking 'Create Account', I agree that I have read and accepted the "
+msgstr "点击 \"创建账号\"，即表示我已经阅读并接受以下条款 "
+
+#: web/templates/web/participant-signup.html:28
+msgid "Privacy Statement"
+msgstr "隐私声明"
+
+#: web/templates/web/privacy.html:9
 msgid "Privacy statement"
 msgstr "隐私条款"
 
-#: web/templates/frontpages/privacy.html:17
+#: web/templates/web/privacy.html:11
 msgid "Introduction"
 msgstr "简介"
 
-#: web/templates/frontpages/privacy.html:18
+#: web/templates/web/privacy.html:14
+#, fuzzy
+#| msgid ""
+#| "Lookit is committed to supporting the privacy of individuals who enroll "
+#| "on our Platform to conduct\n"
+#| "                research or serve as research subjects. This Privacy "
+#| "Statement explains how we handle and use the\n"
+#| "                personal information we collect about our researchers and "
+#| "research participant community."
 msgid ""
 "Lookit is committed to supporting the privacy of individuals who enroll on "
 "our Platform to conduct\n"
-"                research or serve as research subjects. This Privacy "
-"Statement explains how we handle and use the\n"
-"                personal information we collect about our researchers and "
-"research participant community."
+"        research or serve as research subjects. This Privacy Statement "
+"explains how we handle and use the\n"
+"    personal information we collect about our researchers and research "
+"participant community."
 msgstr ""
 "Lookit致力于支持使用我们平台的研究人员和参与者的个人隐私。本隐私条款解释了我"
 "们如何处理和使用收集到的个人信息。"
 
-#: web/templates/frontpages/privacy.html:22
+#: web/templates/web/privacy.html:19
 msgid "For participants"
 msgstr "参与者"
 
-#: web/templates/frontpages/privacy.html:24
+#: web/templates/web/privacy.html:22
+#, fuzzy
+#| msgid ""
+#| "Lookit is a platform that many different researchers use to conduct "
+#| "studies about how children learn and\n"
+#| "                develop. It is run by the MIT Early Childhood Cognition "
+#| "Lab, which has access to all of the data\n"
+#| "                collected on Lookit. Researchers using Lookit to conduct "
+#| "studies only access your personal information\n"
+#| "                if you choose to participate in their study."
 msgid ""
 "Lookit is a platform that many different researchers use to conduct studies "
 "about how children learn and\n"
-"                develop. It is run by the MIT Early Childhood Cognition Lab, "
-"which has access to all of the data\n"
-"                collected on Lookit. Researchers using Lookit to conduct "
-"studies only access your personal information\n"
-"                if you choose to participate in their study."
+"        develop. It is run by the MIT Early Childhood Cognition Lab, which "
+"has access to all of the data\n"
+"        collected on Lookit. Researchers using Lookit to conduct studies "
+"only access your personal information\n"
+"    if you choose to participate in their study."
 msgstr ""
 "Lookit是一个众多科学家用来研究儿童学习和发展的平台。它由麻省理工学院儿童早期"
 "认知实验室运营，该实验室可以访问Lookit上收集的所有数据。使用Lookit的研究人员"
 "只有在您选择参与他们的研究时才能访问您的个人信息。"
 
-#: web/templates/frontpages/privacy.html:29
-#: web/templates/frontpages/privacy.html:142
+#: web/templates/web/privacy.html:28 web/templates/web/privacy.html:162
 msgid "What personal information we collect"
 msgstr "我们会收集什么个人信息"
 
-#: web/templates/frontpages/privacy.html:31
+#: web/templates/web/privacy.html:30
 msgid "We collect the following kinds of personal information:"
 msgstr "我们会收集以下几类个人信息："
 
-#: web/templates/frontpages/privacy.html:32
+#: web/templates/web/privacy.html:33
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Account data: basic contact information that may "
+#| "include your email address, nickname, mailing\n"
+#| "                    address, and contact preferences.</li>\n"
+#| "                <li>Child data: basic biographical information about your "
+#| "child(ren), including nickname, date of birth,\n"
+#| "                    and gestational age at birth.</li>\n"
+#| "                <li>Demographic data: background and biographical "
+#| "information such as your native language, race, age,\n"
+#| "                    educational background, and family history of "
+#| "particular medical conditions.</li>\n"
+#| "                <li>Study data: responses collected during particular "
+#| "studies conducted on Lookit, including webcam\n"
+#| "                    video of your family participating in the study, text "
+#| "entered in forms, the particular images that\n"
+#| "                    were shown, the timing of progression through the "
+#| "study, etc.</li>\n"
+#| "            </ul>"
 msgid ""
 "<ul>\n"
-"                <li>Account data: basic contact information that may include "
-"your email address, nickname, mailing\n"
-"                    address, and contact preferences.</li>\n"
-"                <li>Child data: basic biographical information about your "
+"        <li>Account data: basic contact information that may include your "
+"email address, nickname, mailing\n"
+"            address, and contact preferences.</li>\n"
+"        <li>Child data: basic biographical information about your "
 "child(ren), including nickname, date of birth,\n"
-"                    and gestational age at birth.</li>\n"
-"                <li>Demographic data: background and biographical "
-"information such as your native language, race, age,\n"
-"                    educational background, and family history of particular "
-"medical conditions.</li>\n"
-"                <li>Study data: responses collected during particular "
-"studies conducted on Lookit, including webcam\n"
-"                    video of your family participating in the study, text "
-"entered in forms, the particular images that\n"
-"                    were shown, the timing of progression through the study, "
-"etc.</li>\n"
-"            </ul>"
+"            and gestational age at birth.</li>\n"
+"        <li>Demographic data: background and biographical information such "
+"as your native language, race, age,\n"
+"            educational background, and family history of particular medical "
+"conditions.</li>\n"
+"        <li>Study data: responses collected during particular studies "
+"conducted on Lookit, including webcam\n"
+"            video of your family participating in the study, text entered in "
+"forms, the particular images that\n"
+"            were shown, the timing of progression through the study, etc.</"
+"li>\n"
+"        </ul>"
 msgstr ""
 "<ul>\n"
 "<li>用户信息：基本联系方式，可能包括您的电子邮件地址、昵称、邮寄地址和联系偏"
@@ -2100,43 +3151,60 @@ msgstr ""
 "频、问卷中输入的文字、显示的特定图像、研究进展的时间等。</li>\n"
 "</ul>"
 
-#: web/templates/frontpages/privacy.html:44
-#: web/templates/frontpages/privacy.html:147
+#: web/templates/web/privacy.html:45 web/templates/web/privacy.html:169
 msgid "How we collect personal information about you"
 msgstr "我们如何收集您的个人信息"
 
-#: web/templates/frontpages/privacy.html:46
+#: web/templates/web/privacy.html:48
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is the information you "
+#| "provide to us when registering\n"
+#| "                for a Lookit account, registering your children, updating "
+#| "your account or your children’s profiles,\n"
+#| "                completing or updating surveys, or participating in "
+#| "individual Lookit studies."
 msgid ""
 "The information we collect and maintain about you is the information you "
 "provide to us when registering\n"
-"                for a Lookit account, registering your children, updating "
-"your account or your children’s profiles,\n"
-"                completing or updating surveys, or participating in "
-"individual Lookit studies."
+"        for a Lookit account, registering your children, updating your "
+"account or your children’s profiles,\n"
+"        completing or updating surveys, or participating in individual "
+"Lookit studies."
 msgstr ""
 "我们收集和维护您在注册或更新您的Lookit账户或孩子的资料、完成或更新问卷，或参"
 "与某个研究时向我们提供的信息。"
 
-#: web/templates/frontpages/privacy.html:50
-#: web/templates/frontpages/privacy.html:167
+#: web/templates/web/privacy.html:53 web/templates/web/privacy.html:194
 msgid "When we share your personal information"
 msgstr "我们何时会分享您的个人信息"
 
-#: web/templates/frontpages/privacy.html:52
+#: web/templates/web/privacy.html:56
 msgid ""
 "When you participate in a Lookit study, we share the following information "
 "with the research group conducting the study:"
 msgstr "当您参与Lookit研究时，我们会与进行研究的团队分享以下信息："
 
-#: web/templates/frontpages/privacy.html:54
+#: web/templates/web/privacy.html:60
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>Your account data </li>\n"
+#| "                <li>The child data for the child who is participating</"
+#| "li>\n"
+#| "                <li>Your demographic data</i>\n"
+#| "                <li>The study data for this particular study session</"
+#| "li>\n"
+#| "            </ul>"
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>Your account data </li>\n"
-"                <li>The child data for the child who is participating</li>\n"
-"                <li>Your demographic data</i>\n"
-"                <li>The study data for this particular study session</li>\n"
-"            </ul>"
+"        <ul>\n"
+"            <li>Your account data</li>\n"
+"            <li>The child data for the child who is participating</li>\n"
+"            <li>Your demographic data</i>\n"
+"            <li>The study data for this particular study session</li>\n"
+"        </ul>"
 msgstr ""
 "\n"
 "<ul> \n"
@@ -2146,7 +3214,7 @@ msgstr ""
 "<li>此项研究的实验数据</li>\n"
 "            </ul>"
 
-#: web/templates/frontpages/privacy.html:61
+#: web/templates/web/privacy.html:68
 msgid ""
 "Your email address is not shared directly with the research group, although "
 "they can contact you via Lookit in accordance with your contact preferences."
@@ -2154,54 +3222,80 @@ msgstr ""
 "我们不会直接与研究团队共享您的电子邮件地址，但他们可以根据您的电子邮件偏好通"
 "过Lookit与您联系。"
 
-#: web/templates/frontpages/privacy.html:63
+#: web/templates/web/privacy.html:71
+#, fuzzy
+#| msgid ""
+#| "Researchers may publish the results of a study, including individual "
+#| "responses. However, although they\n"
+#| "                may publish the ages of participants, they may not "
+#| "publish participant birthdates (or information that\n"
+#| "                could be used to calculate birthdates)."
 msgid ""
 "Researchers may publish the results of a study, including individual "
 "responses. However, although they\n"
-"                may publish the ages of participants, they may not publish "
+"        may publish the ages of participants, they may not publish "
 "participant birthdates (or information that\n"
-"                could be used to calculate birthdates)."
+"    could be used to calculate birthdates)."
 msgstr ""
 "研究人员可以发表一项研究的结果，包括个人的反馈。然而，虽然他们可以公布参与者"
 "的年龄，但不得公布其出生日期（或可用于计算出生日期的信息）。"
 
-#: web/templates/frontpages/privacy.html:67
+#: web/templates/web/privacy.html:76
+#, fuzzy
+#| msgid ""
+#| "We and/or the researchers responsible for a study may share video of your "
+#| "family’s participation for\n"
+#| "                scientific, educational, and/or publicity purposes, but "
+#| "only if you choose at the conclusion of a study\n"
+#| "                to allow such usage. Researchers may also share your "
+#| "video and other data with Databrary if you choose\n"
+#| "                at the conclusion of a study to allow that. We don’t "
+#| "publish video of participants such that it can be\n"
+#| "                linked to individual demographic data (e.g., household "
+#| "income or number of parents/guardians), and\n"
+#| "                researchers must also agree not to do so in order to use "
+#| "Lookit."
 msgid ""
 "We and/or the researchers responsible for a study may share video of your "
 "family’s participation for\n"
-"                scientific, educational, and/or publicity purposes, but only "
-"if you choose at the conclusion of a study\n"
-"                to allow such usage. Researchers may also share your video "
-"and other data with Databrary if you choose\n"
-"                at the conclusion of a study to allow that. We don’t publish "
-"video of participants such that it can be\n"
-"                linked to individual demographic data (e.g., household "
-"income or number of parents/guardians), and\n"
-"                researchers must also agree not to do so in order to use "
-"Lookit."
+"        scientific, educational, and/or publicity purposes, but only if you "
+"choose at the conclusion of a study\n"
+"        to allow such usage. Researchers may also share your video and other "
+"data with Databrary if you choose\n"
+"        at the conclusion of a study to allow that. We don’t publish video "
+"of participants such that it can be\n"
+"        linked to individual demographic data (e.g., household income or "
+"number of parents/guardians), and\n"
+"    researchers must also agree not to do so in order to use Lookit."
 msgstr ""
 "我们和/或研究团队可能会出于科学、教育、宣传的目的，分享您的家庭参与的视频，但"
 "前提是您在研究结束时许可这种用途。如果您选择同意，研究人员也可以与Databrary分"
 "享您的视频和其他数据。我们不会在参与者视频中泄露个人基本信息（如家庭收入或父"
 "母/监护人数量），研究人员也必须同意此条款才能使用Lookit。"
 
-#: web/templates/frontpages/privacy.html:74
+#: web/templates/web/privacy.html:84
+#, fuzzy
+#| msgid ""
+#| "We don’t share, sell, publish, or otherwise disclose your contact "
+#| "information (email and/or mailing\n"
+#| "                address) to anyone but the researchers involved in a "
+#| "study. Researchers must also agree not to disclose\n"
+#| "                your contact information in order to use Lookit."
 msgid ""
 "We don’t share, sell, publish, or otherwise disclose your contact "
 "information (email and/or mailing\n"
-"                address) to anyone but the researchers involved in a study. "
+"        address) to anyone but the researchers involved in a study. "
 "Researchers must also agree not to disclose\n"
-"                your contact information in order to use Lookit."
+"        your contact information in order to use Lookit."
 msgstr ""
 "除了参与研究的团队外，我们不会将您的联系信息（电子邮件或邮寄地址）分享、出"
 "售、出版或以其他方式透露给任何人。研究人员也必须同意此条款才能使用Lookit。"
 
-#: web/templates/frontpages/privacy.html:78
-#: web/templates/frontpages/privacy.html:152
+#: web/templates/web/privacy.html:89 web/templates/web/privacy.html:176
 msgid "How we use your personal information"
 msgstr "我们如何使用您的个人信息"
 
-#: web/templates/frontpages/privacy.html:80
+#: web/templates/web/privacy.html:92
 msgid ""
 "We may use your personal information (account, child, demographic, and study "
 "data) for a variety of purposes, including to:"
@@ -2209,35 +3303,63 @@ msgstr ""
 " 我们可能会将您的个人信息（账户、儿童、家庭背景和实验数据）用于多种目的，包"
 "括： "
 
-#: web/templates/frontpages/privacy.html:81
+#: web/templates/web/privacy.html:94
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Provide you with the research studies you have "
+#| "enrolled in, and information about which studies your\n"
+#| "                    children are eligible for</li>\n"
+#| "                <li>Send you information about studies you may be "
+#| "interested in, reminders to participate in multi-part\n"
+#| "                    studies, and/or results of studies you have "
+#| "participated in, subject to your contact preferences\n"
+#| "                </li>\n"
+#| "                <li>Improve the Lookit platform: e.g., detect and fix "
+#| "technical problems or identify new features that\n"
+#| "                    would be helpful</li>\n"
+#| "                <li>Develop data analysis tools for Lookit researchers </"
+#| "li>\n"
+#| "                <li>Provide technical support to study researchers</li>\n"
+#| "                <li>Assess the quality of data collected on the platform "
+#| "(e.g., how well an observer can tell which\n"
+#| "                    direction children are looking)</li>\n"
+#| "                <li>Evaluate recruitment and family engagement efforts (e."
+#| "g., see how many participants come from rural\n"
+#| "                    vs. urban areas)</li>\n"
+#| "                <li>Recruit participants or researchers to use Lookit (e."
+#| "g., sharing a short video clip of your child\n"
+#| "                    having fun – ONLY if you have chosen to allow use of "
+#| "the video for publicity)</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research studies you have enrolled "
-"in, and information about which studies your\n"
-"                    children are eligible for</li>\n"
-"                <li>Send you information about studies you may be interested "
-"in, reminders to participate in multi-part\n"
-"                    studies, and/or results of studies you have participated "
-"in, subject to your contact preferences\n"
-"                </li>\n"
-"                <li>Improve the Lookit platform: e.g., detect and fix "
-"technical problems or identify new features that\n"
-"                    would be helpful</li>\n"
-"                <li>Develop data analysis tools for Lookit researchers </"
-"li>\n"
-"                <li>Provide technical support to study researchers</li>\n"
-"                <li>Assess the quality of data collected on the platform (e."
-"g., how well an observer can tell which\n"
-"                    direction children are looking)</li>\n"
-"                <li>Evaluate recruitment and family engagement efforts (e."
-"g., see how many participants come from rural\n"
-"                    vs. urban areas)</li>\n"
-"                <li>Recruit participants or researchers to use Lookit (e.g., "
-"sharing a short video clip of your child\n"
-"                    having fun – ONLY if you have chosen to allow use of the "
-"video for publicity)</li>\n"
-"            </ul>\n"
-"            "
+"        <li>Provide you with the research studies you have enrolled in, and "
+"information about which studies your\n"
+"            children are eligible for</li>\n"
+"        <li>Send you information about studies you may be interested in, "
+"reminders to participate in multi-part\n"
+"            studies, and/or results of studies you have participated in, "
+"subject to your contact preferences\n"
+"        </li>\n"
+"        <li>Improve the Lookit platform: e.g., detect and fix technical "
+"problems or identify new features that\n"
+"            would be helpful</li>\n"
+"        <li>Develop data analysis tools for Lookit researchers</li>\n"
+"        <li>Provide technical support to study researchers</li>\n"
+"        <li>Assess the quality of data collected on the platform (e.g., how "
+"well an observer can tell which\n"
+"            direction children are looking)</li>\n"
+"        <li>Evaluate recruitment and family engagement efforts (e.g., see "
+"how many participants come from rural\n"
+"            vs. urban areas)</li>\n"
+"        <li>Recruit participants or researchers to use Lookit (e.g., sharing "
+"a short video clip of your child\n"
+"            having fun – ONLY if you have chosen to allow use of the video "
+"for publicity)</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "<li>向您提供您的孩子已参加、以及有资格参加的研究信息。</li>\n"
@@ -2253,40 +3375,62 @@ msgstr ""
 "孩子玩得很开心的视频）</li>\n"
 "</ul>"
 
-#: web/templates/frontpages/privacy.html:100
+#: web/templates/web/privacy.html:113
+#, fuzzy
+#| msgid ""
+#| "Researchers use the data collected in their studies to address particular "
+#| "scientific questions. It may\n"
+#| "                also turn out that data collected for one study can help "
+#| "to answer a related question later on. If\n"
+#| "                researchers are using any additional information about "
+#| "you in their study, beyond what is collected on\n"
+#| "                Lookit – for instance, if you are participating in a "
+#| "follow-up online session for an in-person study –\n"
+#| "                they must tell you that in the study consent form."
 msgid ""
 "Researchers use the data collected in their studies to address particular "
 "scientific questions. It may\n"
-"                also turn out that data collected for one study can help to "
+"            also turn out that data collected for one study can help to "
 "answer a related question later on. If\n"
-"                researchers are using any additional information about you "
-"in their study, beyond what is collected on\n"
-"                Lookit – for instance, if you are participating in a follow-"
-"up online session for an in-person study –\n"
-"                they must tell you that in the study consent form."
+"            researchers are using any additional information about you in "
+"their study, beyond what is collected on\n"
+"            Lookit – for instance, if you are participating in a follow-up "
+"online session for an in-person study –\n"
+"            they must tell you that in the study consent form."
 msgstr ""
 "研究人员利用实验中收集到的数据来解决特定的科学问题。这些数据也可能有助于回答"
 "之后的相关问题。如果研究人员在实验中需使用从Lookit平台以外收集到的信息（例"
 "如，您在Lookit上参与了一个线下研究的后续实验），他们必须在研究同意书中告诉"
 "您。"
 
-#: web/templates/frontpages/privacy.html:106
+#: web/templates/web/privacy.html:120
 msgid ""
 "There are some basic rules about how personal information may be used that "
 "all Lookit researchers agree to, including:"
 msgstr "所有Lookit研究人员都需同意以下关于如何使用个人信息的基本准则："
 
-#: web/templates/frontpages/privacy.html:107
+#: web/templates/web/privacy.html:122
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "            <ul>\n"
+#| "                <li>They may not use usernames, child nicknames, or "
+#| "contact information as a subject of research.</li>\n"
+#| "                <li>They may contact families by postal mail only in "
+#| "order to send compensation for study participation\n"
+#| "                    or materials needed for participation.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "\n"
-"            <ul>\n"
-"                <li>They may not use usernames, child nicknames, or contact "
+"        <ul>\n"
+"            <li>They may not use usernames, child nicknames, or contact "
 "information as a subject of research.</li>\n"
-"                <li>They may contact families by postal mail only in order "
-"to send compensation for study participation\n"
-"                    or materials needed for participation.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>They may contact families by postal mail only in order to "
+"send compensation for study participation\n"
+"                or materials needed for participation.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "\n"
 "<ul>\n"
@@ -2295,25 +3439,30 @@ msgstr ""
 "</ul>\n"
 "            "
 
-#: web/templates/frontpages/privacy.html:114
-#: web/templates/frontpages/privacy.html:163
+#: web/templates/web/privacy.html:130 web/templates/web/privacy.html:189
+#, fuzzy
+#| msgid ""
+#| "If you have concerns about any of these purposes, or how we communicate "
+#| "with you, please contact us at\n"
+#| "                dataprotection@mit.edu. We will always respect a request "
+#| "by you to stop processing your personal\n"
+#| "                information (subject to our legal obligations)."
 msgid ""
 "If you have concerns about any of these purposes, or how we communicate with "
 "you, please contact us at\n"
-"                dataprotection@mit.edu. We will always respect a request by "
-"you to stop processing your personal\n"
-"                information (subject to our legal obligations)."
+"        dataprotection@mit.edu. We will always respect a request by you to "
+"stop processing your personal\n"
+"        information (subject to our legal obligations)."
 msgstr ""
 "如果您对这些个人信息使用目的或我们与您的沟通方式有任何疑虑，请通过 "
 "dataprotection@mit.edu 联系我们。根据法律义务，我们将始终尊重您提出的停止使用"
 "个人信息的请求。"
 
-#: web/templates/frontpages/privacy.html:118
-#: web/templates/frontpages/privacy.html:171
+#: web/templates/web/privacy.html:135 web/templates/web/privacy.html:198
 msgid "How your information is stored and secured"
 msgstr "您的信息是如何被存储和保护的"
 
-#: web/templates/frontpages/privacy.html:120
+#: web/templates/web/privacy.html:138
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2338,23 +3487,23 @@ msgstr "您的信息是如何被存储和保护的"
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection, "
-"and all video data is encrypted at rest on\n"
-"                the storage systems used by Lookit to provide data to "
-"researchers. Researchers are responsible for their\n"
-"                own secure storage of data once they obtain it from Lookit. "
-"You should be aware, however, that since the\n"
-"                internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be accessed,\n"
-"                disclosed, altered, or destroyed by breach of any of our "
-"physical, technical, or managerial safeguards.\n"
-"                It's your responsibility to protect the security of your "
-"account details, including your username and\n"
-"                password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection, and all "
+"video data is encrypted at rest on\n"
+"        the storage systems used by Lookit to provide data to researchers. "
+"Researchers are responsible for their\n"
+"        own secure storage of data once they obtain it from Lookit. You "
+"should be aware, however, that since the\n"
+"        internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be accessed,\n"
+"        disclosed, altered, or destroyed by breach of any of our physical, "
+"technical, or managerial safeguards.\n"
+"        It's your responsibility to protect the security of your account "
+"details, including your username and\n"
+"        password."
 msgstr ""
 "为了保护您的个人信息，我们已经实施了行业标准的安全保障措施。我们还根据行业规"
 "定，定期监管我们的系统，以防止可能的漏洞和攻击。只有经过认证并拥有特定权限的"
@@ -2363,51 +3512,74 @@ msgstr ""
 "或管理保障措施被访问、曝光、更改或破坏。您有责任保护您的账户信息的安全，包括"
 "您的用户名和密码。"
 
-#: web/templates/frontpages/privacy.html:131
-#: web/templates/frontpages/privacy.html:182
+#: web/templates/web/privacy.html:150 web/templates/web/privacy.html:211
 msgid "How long we keep your personal information"
 msgstr "我们将保留您的个人信息多长时间"
 
-#: web/templates/frontpages/privacy.html:133
+#: web/templates/web/privacy.html:153
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you wish\n"
+#| "                to remove your account, we will retain a core set of "
+#| "information about you to fulfill administrative\n"
+#| "                tasks and legal obligations. If you have participated in "
+#| "Lookit studies, the personal information\n"
+#| "                already shared with those researchers may not generally "
+#| "be ‘taken back,’ as it is part of a scientific\n"
+#| "                dataset and removing your data could affect already "
+#| "published findings."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you wish\n"
-"                to remove your account, we will retain a core set of "
-"information about you to fulfill administrative\n"
-"                tasks and legal obligations. If you have participated in "
-"Lookit studies, the personal information\n"
-"                already shared with those researchers may not generally be "
-"‘taken back,’ as it is part of a scientific\n"
-"                dataset and removing your data could affect already "
-"published findings."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you wish\n"
+"        to remove your account, we will retain a core set of information "
+"about you to fulfill administrative\n"
+"        tasks and legal obligations. If you have participated in Lookit "
+"studies, the personal information\n"
+"        already shared with those researchers may not generally be ‘taken "
+"back,’ as it is part of a scientific\n"
+"    dataset and removing your data could affect already published findings."
 msgstr ""
 "我们认为Lookit与科研界的关系是永久的。这意味着直到您告诉我们希望不再联系之"
 "前，我们都会为您保留记录。如果您不再希望收到Lookit的消息，我们将保留一套您的"
 "核心信息，以履行行政和法律义务。"
 
-#: web/templates/frontpages/privacy.html:144
+#: web/templates/web/privacy.html:165
+#, fuzzy
+#| msgid ""
+#| "We may collect basic biographic/contact information about you and your "
+#| "representative organization,\n"
+#| "                including name, title, business addresses, phone numbers, "
+#| "and email addresses."
 msgid ""
 "We may collect basic biographic/contact information about you and your "
 "representative organization,\n"
-"                including name, title, business addresses, phone numbers, "
-"and email addresses."
+"    including name, title, business addresses, phone numbers, and email "
+"addresses."
 msgstr ""
 "我们可能会收集您和您代表机构的基本信息，包括姓名、职务、机构地址、电话号码和"
 "电子邮件地址。"
 
-#: web/templates/frontpages/privacy.html:149
+#: web/templates/web/privacy.html:172
+#, fuzzy
+#| msgid ""
+#| "The information we collect and maintain about you is that which you have "
+#| "provided to us when registering\n"
+#| "                to use Lookit, updating your profile, or creating or "
+#| "editing a study."
 msgid ""
 "The information we collect and maintain about you is that which you have "
 "provided to us when registering\n"
-"                to use Lookit, updating your profile, or creating or editing "
-"a study."
+"        to use Lookit, updating your profile, or creating or editing a study."
 msgstr ""
 "我们收集和维护的是您在注册使用Lookit、更新个人资料，或创建、编辑研究时提供给"
 "我们的信息。"
 
-#: web/templates/frontpages/privacy.html:154
+#: web/templates/web/privacy.html:179
 msgid ""
 "We use your personal information for a number of legitimate purposes, "
 "including the performance of contractual obligations. Specifically, we use "
@@ -2416,18 +3588,30 @@ msgstr ""
 "我们将出于正当目的使用您的个人信息，包括履行合同义务。具体而言，我们使用您的"
 "个人信息是为了："
 
-#: web/templates/frontpages/privacy.html:155
+#: web/templates/web/privacy.html:181
+#, fuzzy
+#| msgid ""
+#| "<ul>\n"
+#| "                <li>Provide you with the research services for which you "
+#| "have enrolled. </li>\n"
+#| "                <li>Perform administrative tasks and for internal record "
+#| "keeping purposes.</li>\n"
+#| "                <li>Create and analyze aggregated (fully anonymized) "
+#| "information about our users for statistical\n"
+#| "                    research purposes in support of our mission.</li>\n"
+#| "            </ul>\n"
+#| "            "
 msgid ""
 "<ul>\n"
-"                <li>Provide you with the research services for which you "
-"have enrolled. </li>\n"
-"                <li>Perform administrative tasks and for internal record "
-"keeping purposes.</li>\n"
-"                <li>Create and analyze aggregated (fully anonymized) "
-"information about our users for statistical\n"
-"                    research purposes in support of our mission.</li>\n"
-"            </ul>\n"
-"            "
+"            <li>Provide you with the research services for which you have "
+"enrolled.</li>\n"
+"            <li>Perform administrative tasks and for internal record keeping "
+"purposes.</li>\n"
+"            <li>Create and analyze aggregated (fully anonymized) information "
+"about our users for statistical\n"
+"                research purposes in support of our mission.</li>\n"
+"        </ul>\n"
+"        "
 msgstr ""
 "<ul>\n"
 "<li> 为您提供相应的研究服务。<li>\n"
@@ -2436,11 +3620,11 @@ msgstr ""
 "命。<li>\n"
 "<ul>"
 
-#: web/templates/frontpages/privacy.html:169
+#: web/templates/web/privacy.html:196
 msgid "We do not share your personal information with any third parties."
 msgstr "我们不会与第三方分享您的任何信息。"
 
-#: web/templates/frontpages/privacy.html:173
+#: web/templates/web/privacy.html:201
 #, fuzzy, python-format
 #| msgid ""
 #| "We have implemented industry-standard security safeguards designed to "
@@ -2461,19 +3645,19 @@ msgstr "我们不会与第三方分享您的任何信息。"
 msgid ""
 "We have implemented industry-standard security safeguards designed to "
 "protect the personal information\n"
-"                that you may provide. We also periodically monitor our "
-"system for possible vulnerabilities and attacks,\n"
-"                consistent with industry standards. Only authenticated users "
-"with specific permissions may access the\n"
-"                data. All data is transmitted via a secure https connection. "
-"You should be aware, however, that since\n"
-"                the internet is not a 100%% secure environment, there’s no "
-"guarantee that information may not be\n"
-"                accessed, disclosed, altered, or destroyed by breach of any "
-"of our physical, technical, or managerial\n"
-"                safeguards. It's your responsibility to protect the security "
-"of your account details, including your\n"
-"                username and password."
+"        that you may provide. We also periodically monitor our system for "
+"possible vulnerabilities and attacks,\n"
+"        consistent with industry standards. Only authenticated users with "
+"specific permissions may access the\n"
+"        data. All data is transmitted via a secure https connection. You "
+"should be aware, however, that since\n"
+"        the internet is not a 100%% secure environment, there’s no guarantee "
+"that information may not be\n"
+"        accessed, disclosed, altered, or destroyed by breach of any of our "
+"physical, technical, or managerial\n"
+"        safeguards. It's your responsibility to protect the security of your "
+"account details, including your\n"
+"        username and password."
 msgstr ""
 "为了保护您的个人信息，我们已经实施了行业标准的安全保障措施。我们还根据行业规"
 "定，定期监管我们的系统，以防止可能的漏洞和攻击。只有经过认证并拥有特定权限的"
@@ -2482,62 +3666,99 @@ msgstr ""
 "或管理保障措施被访问、曝光、更改或破坏。您有责任保护您的账户信息的安全，包括"
 "您的用户名和密码。"
 
-#: web/templates/frontpages/privacy.html:184
+#: web/templates/web/privacy.html:214
+#, fuzzy
+#| msgid ""
+#| "We consider our relationship with our research community to be lifelong. "
+#| "This means that we will maintain\n"
+#| "                a record for you until such time as you tell us that you "
+#| "no longer wish us to keep in touch. If you no\n"
+#| "                longer wish to hear from Lookit, we will retain a core "
+#| "set of information about you to fulfill\n"
+#| "                administrative tasks and legal obligations."
 msgid ""
 "We consider our relationship with our research community to be lifelong. "
 "This means that we will maintain\n"
-"                a record for you until such time as you tell us that you no "
-"longer wish us to keep in touch. If you no\n"
-"                longer wish to hear from Lookit, we will retain a core set "
-"of information about you to fulfill\n"
-"                administrative tasks and legal obligations."
+"        a record for you until such time as you tell us that you no longer "
+"wish us to keep in touch. If you no\n"
+"        longer wish to hear from Lookit, we will retain a core set of "
+"information about you to fulfill\n"
+"        administrative tasks and legal obligations."
 msgstr ""
 "我们认为Lookit与科研界的关系是永久的。这意味着直到您告诉我们希望不再联系之"
 "前，我们都会为您保留记录。如果您不再希望收到Lookit的消息，我们将保留一套您的"
 "核心信息，以履行行政和法律义务。"
 
-#: web/templates/frontpages/privacy.html:189
+#: web/templates/web/privacy.html:220
 msgid "For everyone"
 msgstr "所有用户"
 
-#: web/templates/frontpages/privacy.html:191
+#: web/templates/web/privacy.html:221
 msgid "Rights for individuals in the European Economic Area"
 msgstr "欧洲经济区个人的权利"
 
-#: web/templates/frontpages/privacy.html:192
+#: web/templates/web/privacy.html:224
+#, fuzzy
+#| msgid ""
+#| "You have the right in certain circumstances to (1) access your personal "
+#| "information; (2) to correct or\n"
+#| "                erase information; (3) restrict processing; and (4) "
+#| "object to communications, direct marketing, or\n"
+#| "                profiling. To the extent applicable, the EU’s General "
+#| "Data Protection Regulation provides further\n"
+#| "                information about your rights. You also have the right to "
+#| "lodge complaints with your national or\n"
+#| "                regional data protection authority."
 msgid ""
 "You have the right in certain circumstances to (1) access your personal "
 "information; (2) to correct or\n"
-"                erase information; (3) restrict processing; and (4) object "
-"to communications, direct marketing, or\n"
-"                profiling. To the extent applicable, the EU’s General Data "
+"        erase information; (3) restrict processing; and (4) object to "
+"communications, direct marketing, or\n"
+"        profiling. To the extent applicable, the EU’s General Data "
 "Protection Regulation provides further\n"
-"                information about your rights. You also have the right to "
-"lodge complaints with your national or\n"
-"                regional data protection authority."
+"        information about your rights. You also have the right to lodge "
+"complaints with your national or\n"
+"        regional data protection authority."
 msgstr ""
 "在某些情况下，您有权：(1)访问您的个人信息；(2)更正或删除信息；(3)限制信息处"
 "理；以及(4)拒绝通信、直接营销或个人信息分析。在适用的范围内，欧盟的《通用数据"
 "保护条例》将进一步提供有关您权利的信息。您还有权向您所在国家或地区的数据保护"
 "机构提出投诉。"
 
-#: web/templates/frontpages/privacy.html:198
+#: web/templates/web/privacy.html:231
+#, fuzzy
+#| msgid ""
+#| "If you are inclined to exercise these rights, we request an opportunity "
+#| "to discuss with you any concerns\n"
+#| "                you may have. To protect the personal information we "
+#| "hold, we may also request further information to\n"
+#| "                verify your identify when exercising these rights. Upon a "
+#| "request to erase information, we will maintain\n"
+#| "                a core set of personal data to ensure we do not contact "
+#| "you inadvertently in the future, as well as any\n"
+#| "                information necessary for archival purposes. We may also "
+#| "need to retain some financial information for\n"
+#| "                legal purposes, including US IRS compliance. In the event "
+#| "of an actual or threatened legal claim, we may\n"
+#| "                retain your information for purposes of establishing, "
+#| "defending against or exercising our rights with\n"
+#| "                respect to such claim."
 msgid ""
 "If you are inclined to exercise these rights, we request an opportunity to "
 "discuss with you any concerns\n"
-"                you may have. To protect the personal information we hold, "
-"we may also request further information to\n"
-"                verify your identify when exercising these rights. Upon a "
-"request to erase information, we will maintain\n"
-"                a core set of personal data to ensure we do not contact you "
+"        you may have. To protect the personal information we hold, we may "
+"also request further information to\n"
+"        verify your identify when exercising these rights. Upon a request to "
+"erase information, we will maintain\n"
+"        a core set of personal data to ensure we do not contact you "
 "inadvertently in the future, as well as any\n"
-"                information necessary for archival purposes. We may also "
-"need to retain some financial information for\n"
-"                legal purposes, including US IRS compliance. In the event of "
-"an actual or threatened legal claim, we may\n"
-"                retain your information for purposes of establishing, "
-"defending against or exercising our rights with\n"
-"                respect to such claim."
+"        information necessary for archival purposes. We may also need to "
+"retain some financial information for\n"
+"        legal purposes, including US IRS compliance. In the event of an "
+"actual or threatened legal claim, we may\n"
+"        retain your information for purposes of establishing, defending "
+"against or exercising our rights with\n"
+"        respect to such claim."
 msgstr ""
 "如果您需要行使这些权利，我们希望与您讨论可能存在的任何疑虑。为了保护我们所持"
 "有的个人信息，在您行使这些权利时，我们也可能会要求您提供进一步的信息，以核实"
@@ -2546,524 +3767,182 @@ msgstr ""
 "国税局的规定。在发生实际或威胁性的法律索赔时，我们可能会保留您的信息，以确"
 "立、维护或行使我们与该索赔有关的权利。"
 
-#: web/templates/frontpages/privacy.html:207
+#: web/templates/web/privacy.html:241
+#, fuzzy
+#| msgid ""
+#| "By providing information directly to Lookit, you consent to the transfer "
+#| "of your personal information\n"
+#| "                outside of the European Economic Area to the United "
+#| "States. You understand that the current laws and\n"
+#| "                regulations of the United States may not provide the same "
+#| "level of protection as the data and privacy\n"
+#| "                laws and regulations of the EEA."
 msgid ""
 "By providing information directly to Lookit, you consent to the transfer of "
 "your personal information\n"
-"                outside of the European Economic Area to the United States. "
-"You understand that the current laws and\n"
-"                regulations of the United States may not provide the same "
-"level of protection as the data and privacy\n"
-"                laws and regulations of the EEA."
+"        outside of the European Economic Area to the United States. You "
+"understand that the current laws and\n"
+"        regulations of the United States may not provide the same level of "
+"protection as the data and privacy\n"
+"        laws and regulations of the EEA."
 msgstr ""
 "直接向Lookit提供信息，即表示您同意将您的个人信息从欧洲经济区传输到美国。您需"
 "要注意的是，美国现行的法律和法规可能无法提供与欧洲经济区的数据和隐私法律法规"
 "相同水平的保护。"
 
-#: web/templates/frontpages/privacy.html:212
+#: web/templates/web/privacy.html:246
 msgid ""
 "You are under no statutory or contractual obligation to provide any personal "
 "data to us."
 msgstr "您没有法定或合同义务向我们提供任何个人数据。"
 
-#: web/templates/frontpages/privacy.html:214
+#: web/templates/web/privacy.html:248
 msgid "Additional Information"
 msgstr "其他信息"
 
-#: web/templates/frontpages/privacy.html:216
+#: web/templates/web/privacy.html:251
+#, fuzzy
+#| msgid ""
+#| "We may change this Privacy Statement from time to time. If we make any "
+#| "significant changes in the way we\n"
+#| "                treat your personal information we will make this clear "
+#| "on our website or by contacting you directly."
 msgid ""
 "We may change this Privacy Statement from time to time. If we make any "
 "significant changes in the way we\n"
-"                treat your personal information we will make this clear on "
-"our website or by contacting you directly."
+"        treat your personal information we will make this clear on our "
+"website or by contacting you directly."
 msgstr ""
 "我们可能会不时地更改本隐私声明。如果我们处理您的个人信息的方式有任何重大变"
 "化，我们将在网站上明确说明或与您直接联系。"
 
-#: web/templates/frontpages/privacy.html:220
+#: web/templates/web/privacy.html:255
 msgid ""
 "The controller for your personal information is MIT. We can be contacted at "
 "dataprotection@mit.edu."
 msgstr "您个人信息的管理方是MIT。请通过 dataprotection@mit.edu 与我们联系。"
 
-#: web/templates/frontpages/privacy.html:222
+#: web/templates/web/privacy.html:257
 msgid "This policy was last updated in June 2018."
 msgstr "此声明最近更新于2018年6月。"
 
-#: web/templates/frontpages/scientists.html:27
-msgid "Meet the Lookit team"
-msgstr "Lookit团队"
-
-#: web/templates/frontpages/scientists.html:33
-msgid "Core Team"
-msgstr "核心成员"
-
-#: web/templates/frontpages/scientists.html:38
-msgid ""
-"Rico is Lookit's lead software engineer, working on planning and adding "
-"features for both participants and researchers."
-msgstr "Rico是Lookit的首席软件工程师，负责为参与者和研究人员规划和添加功能。"
-
-#: web/templates/frontpages/scientists.html:43
-msgid ""
-"Laura is the PI of the Early Childhood Cognition Lab. She conducts research "
-"about how children arrive at a common-sense understanding of the physical "
-"and social world through exploration and instruction."
+#: web/templates/web/resources.html:14
+msgid "Find a developmental lab near you"
 msgstr ""
-"Laura是儿童早期认知实验室的首席研究员。她研究儿童是如何通过探索和引导来理解物"
-"理和社会世界的常识。"
 
-#: web/templates/frontpages/scientists.html:49
-msgid ""
-"Kim started Lookit as a graduate student, and now runs the project as a "
-"research scientist in the Early Childhood Cognition Lab. Her three children "
-"frequently provide feedback on studies."
+#: web/templates/web/scientists.html:10
+msgid "Meet the Children Helping Science team"
 msgstr ""
-"Kim在研究生时期就开始了Lookit的研究，现在作为研究科学家在儿童早期认知实验室管"
-"理这个项目。她的三个孩子经常为实验提供反馈。"
 
-#: web/templates/frontpages/scientists.html:54
+#: web/templates/web/scientists/affiliated-universities-and-researchers.html:3
 msgid ""
-"Mark organizes the Lookit Working Groups, which are groups of researchers "
-"working to improve Lookit in a variety of ways."
+"As of March 2023, there are over 950 researchers in our community, and over "
+"90 universities affiliated with Lookit/Children Helping Science, including:"
 msgstr ""
-"Mark负责管理Lookit工作组。工作组是由研究人员组成的，致力于以各种方式完善"
-"Lookit。"
 
-#: web/templates/registration/logged_out.html:6
-msgid "You've successfully logged out."
-msgstr "您已经成功退出。"
-
-#: web/templates/registration/login.html:8
-#: web/templates/web/studies-history.html:9
-#: web/templates/web/studies-list.html:9 web/templates/web/study-detail.html:22
-msgid "Your login credentials didn't work. Please try again."
-msgstr "您的登录信息无效。请再次尝试。"
-
-#: web/templates/registration/login.html:18
-#: web/templates/registration/login.html:25
-#: web/templates/web/_navigation.html:50
-msgid "Login"
-msgstr "登录"
-
-#: web/templates/registration/login.html:34
-msgid "Forgot password?"
-msgstr "忘记密码？"
-
-#: web/templates/registration/login.html:36
-msgid "New to Lookit?"
-msgstr "Lookit新用户？"
-
-#: web/templates/registration/login.html:36
-msgid "Register your family!"
-msgstr "为您的家人注册"
-
-#: web/templates/registration/password_change_done.html:11
-msgid "Password changed"
-msgstr "密码已被更改"
-
-#: web/templates/registration/password_change_done.html:15
-msgid "Your password was changed."
-msgstr "您的密码已被更改。"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Documentation"
-msgstr "文件批注"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Change password"
-msgstr "修改密码"
-
-#: web/templates/registration/password_change_form.html:4
-msgid "Log out"
-msgstr "退出登录"
-
-#: web/templates/registration/password_change_form.html:7
-#: web/templates/web/home.html:3 web/templates/web/home.html:7
-msgid "Home"
-msgstr "主页"
-
-#: web/templates/registration/password_change_form.html:8
-msgid "Password change"
-msgstr "修改密码"
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the error below."
-msgstr "请修正以下错误。"
-
-#: web/templates/registration/password_change_form.html:21
-msgid "Please correct the errors below."
-msgstr "请修正以下错误。"
-
-#: web/templates/registration/password_change_form.html:26
-msgid ""
-"Please enter your old password, for security's sake, and then enter your new "
-"password twice so we can verify you typed it in correctly."
-msgstr ""
-"出于安全考虑，请输入您的旧密码。为了让我们确认您输入了正确的新密码，请输入两"
-"次。"
-
-#: web/templates/registration/password_change_form.html:54
-#: web/templates/registration/password_reset_confirm.html:31
-msgid "Change my password"
-msgstr "修改密码"
-
-#: web/templates/registration/password_reset_complete.html:11
-msgid "Password reset complete"
-msgstr "密码重置完成"
-
-#: web/templates/registration/password_reset_complete.html:15
-msgid "Your password has been set.  You may go ahead and log in now."
-msgstr "您的密码已设置成功。您可以重新登录了。"
-
-#: web/templates/registration/password_reset_complete.html:17
-msgid "Log in"
-msgstr "登录"
-
-#: web/templates/registration/password_reset_confirm.html:11
-msgid "Password reset confirmation"
-msgstr "密码重置确认"
-
-#: web/templates/registration/password_reset_confirm.html:17
-msgid ""
-"Please enter your new password twice so we can verify you typed it in "
-"correctly."
-msgstr "为了让我们确认您输入了正确的新密码，请输入两次。"
-
-#: web/templates/registration/password_reset_confirm.html:23
-msgid "New password:"
-msgstr "新密码："
-
-#: web/templates/registration/password_reset_confirm.html:28
-msgid "Confirm password:"
-msgstr "确认密码："
-
-#: web/templates/registration/password_reset_confirm.html:37
-msgid ""
-"The password reset link was invalid, possibly because it has already been "
-"used.  Please request a new password reset."
-msgstr "密码重置链接已失效，可能是因为该链接已被使用。请再次请求重置密码。"
-
-#: web/templates/registration/password_reset_done.html:11
-msgid "Password reset link sent"
-msgstr "密码重置链接已发送"
-
-#: web/templates/registration/password_reset_done.html:15
-msgid ""
-"If an account exists with the email you entered, we've emailed instructions "
-"for resetting your password and you should receive them shortly."
-msgstr ""
-"如果您输入的邮箱已在Lookit注册过，我们已经通过邮件发送了有关重置密码的说明，"
-"您很快就会收到。"
-
-#: web/templates/registration/password_reset_done.html:17
-msgid ""
-"If you don't receive an email, please check your spam folder and make sure "
-"you've entered the address you registered with. (You won't get an email "
-"unless there's already an account for that email address!)"
-msgstr ""
-"如果您没有收到电子邮件，请检查您的垃圾邮件文件夹并确保您正确输入了注册Lookit"
-"账号时使用的邮箱。 （除非该邮箱已在Lookit注册，否则您不会收到电子邮件！）"
-
-#: web/templates/registration/password_reset_email.html:2
-#, python-format
-msgid ""
-"You're receiving this email because you requested a password reset for your "
-"user account at %(site_name)s."
-msgstr "您收到这封邮件是因为您要求重新设置您在%(site_name)s的用户密码。"
-
-#: web/templates/registration/password_reset_email.html:4
-msgid "Please go to the following page and choose a new password:"
-msgstr "请到以下页面选择一个新的密码："
-
-#: web/templates/registration/password_reset_email.html:8
-msgid "Your username, in case you've forgotten:"
-msgstr "您的用户名："
-
-#: web/templates/registration/password_reset_email.html:10
-msgid "Thanks for using our site!"
-msgstr "感谢您使用我们的网站!"
-
-#: web/templates/registration/password_reset_email.html:12
-#, fuzzy, python-format
-#| msgid "The %(site_name)s team"
-msgid "The %(site_name)s team"
-msgstr "%(site_name)的团队"
-
-#: web/templates/registration/password_reset_form.html:11
-msgid "Password reset"
-msgstr "重置密码"
-
-#: web/templates/registration/password_reset_form.html:15
-msgid ""
-"Forgotten your password? Enter your email address below, and we'll email "
-"instructions for setting a new one."
-msgstr ""
-"忘记密码了？请在下方输入您的电子邮件地址，我们将通过电子邮件发送设置新密码的"
-"步骤。"
-
-#: web/templates/registration/password_reset_form.html:21
-msgid "Email address:"
-msgstr "电子邮件地址："
-
-#: web/templates/registration/password_reset_form.html:24
-msgid "Reset my password"
-msgstr "重置我的密码"
-
-#: web/templates/web/_navigation.html:22
-msgid "Experimenter"
-msgstr "实验者"
-
-#: web/templates/web/_navigation.html:33 web/templates/web/studies-list.html:4
-msgid "Studies"
-msgstr "研究"
-
-#: web/templates/web/_navigation.html:34
-msgid "FAQ"
-msgstr "常见问题解答"
-
-#: web/templates/web/_navigation.html:35
-msgid "The Scientists"
-msgstr "科学家团队"
-
-#: web/templates/web/_navigation.html:36
-msgid "Resources"
-msgstr "相关资源"
-
-#: web/templates/web/_navigation.html:45
-msgid "Hi"
-msgstr "你好"
-
-#: web/templates/web/_navigation.html:47
-msgid "Logout"
-msgstr "退出登录"
-
-#: web/templates/web/_navigation.html:49
-msgid "Sign up"
-msgstr "创建账号"
-
-#: web/templates/web/child-update.html:4
-#: web/templates/web/studies-history.html:116
-msgid "Child"
-msgstr "儿童"
-
-#: web/templates/web/child-update.html:26
-msgid "Back to Children List"
-msgstr "返回儿童列表"
-
-#: web/templates/web/child-update.html:31
-msgid "Update"
-msgstr "更新"
-
-#: web/templates/web/child-update.html:41
-msgid "Delete"
-msgstr "删除"
-
-#: web/templates/web/child-update.html:44
-#: web/templates/web/children-list.html:92
-#: web/templates/web/demographic-data-update.html:100
-#: web/templates/web/participant-email-preferences.html:36
-msgid "Cancel"
-msgstr "取消"
-
-#: web/templates/web/children-list.html:40
-msgid "Empty birthday"
-msgstr "清空生日"
-
-#: web/templates/web/children-list.html:47
-msgid " day"
-msgstr "天"
-
-#: web/templates/web/children-list.html:47
-msgid " days"
-msgstr "天"
-
-#: web/templates/web/children-list.html:49
-msgid " month"
-msgstr "月"
-
-#: web/templates/web/children-list.html:49
-msgid " months"
-msgstr "月"
-
-#: web/templates/web/children-list.html:51
-msgid " year"
-msgstr "岁"
-
-#: web/templates/web/children-list.html:51
-msgid " years"
-msgstr "岁"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-#: web/templates/web/children-list.html:82
-#: web/templates/web/children-list.html:94
-msgid "Add Child"
-msgstr "添加儿童"
-
-#: web/templates/web/children-list.html:61
-#: web/templates/web/children-list.html:77
-msgid "Hide Form"
-msgstr "隐藏表格"
-
-#: web/templates/web/children-list.html:111
-msgid "Name"
-msgstr "姓名"
-
-#: web/templates/web/children-list.html:121
-msgid "Update child"
-msgstr "更新儿童信息"
-
-#: web/templates/web/children-list.html:128
-msgid "No child profiles registered!"
-msgstr "尚未注册儿童档案!"
-
-#: web/templates/web/demographic-data-update.html:4
-msgid "Update demographics"
-msgstr "更新基本信息"
-
-#: web/templates/web/demographic-data-update.html:89
-msgid ""
-"One reason we are developing Internet-based experiments is to represent a "
-"more diverse group of families in our research. Your answers to these "
-"questions will help us understand what audience we reach, as well as how "
-"factors like speaking multiple languages or having older siblings affect "
-"children's learning."
-msgstr ""
-"我们开发互联网实验的一个原因是为了让更多不同的家庭群体参与到研究中。您的回答"
-"将帮助我们了解研究接触到的受众，以及讲多种语言或有哥哥姐姐等因素会如何影响孩"
-"子的学习。"
-
-#: web/templates/web/demographic-data-update.html:90
-msgid ""
-"Even if you allow your study videos to be published for scientific or "
-"publicity purposes, your demographic information is never published in "
-"conjunction with your video."
-msgstr ""
-"即使您允许我们以科学或宣传为目的发布您的研究视频，您的基本信息也不会和视频一"
-"起发布。"
-
-#: web/templates/web/participant-email-preferences.html:27
-msgid "I would like to be contacted when:"
-msgstr "我愿意在以下情况收到通知："
-
-#: web/templates/web/participant-signup.html:18
-msgid "Create Participant Account"
-msgstr "创建参与者账号"
-
-#: web/templates/web/participant-signup.html:22
-msgid "Create a family account to start participating in Lookit studies!"
-msgstr "创建一个家庭帐户即可开始参与Lookit研究！"
-
-#: web/templates/web/participant-signup.html:31
-msgid ""
-"By clicking 'Create Account', I agree that I have read and accepted the "
-msgstr "点击 \"创建账号\"，即表示我已经阅读并接受以下条款 "
-
-#: web/templates/web/participant-signup.html:31
-msgid "Privacy Statement"
-msgstr "隐私声明"
-
-#: web/templates/web/participant-signup.html:34
-msgid "Create Account"
-msgstr "创建账号"
-
-#: web/templates/web/studies-history.html:4
-#: web/templates/web/studies-history.html:27
+#: web/templates/web/studies-history.html:8
 msgid "Past Studies"
 msgstr "参与过的研究"
 
-#: web/templates/web/studies-history.html:16
-#: web/templates/web/studies-list.html:16
+#: web/templates/web/studies-history.html:15
+#, fuzzy
+#| msgid "Video"
+msgid "Next Video"
+msgstr "视频"
+
+#: web/templates/web/studies-history.html:31
 msgid ""
-"Your account doesn't have access to this page. To proceed, please login with "
-"an account that has access."
-msgstr "您的账号没有权限访问此页面。如需继续，请使用有访问权限的账号登录。"
+"Lookit studies run here on our platform, and usually include a video of your "
+"session! "
+msgstr ""
 
-#: web/templates/web/studies-history.html:18
-#: web/templates/web/studies-list.html:18
-msgid "Please login to see this page."
-msgstr "请登录后查看本页面。"
-
-#: web/templates/web/studies-history.html:34
-#: web/templates/web/studies-list.html:38
-msgid "Current studies"
-msgstr "当前的研究"
-
-#: web/templates/web/studies-history.html:37
-#: web/templates/web/studies-list.html:41
-msgid "Your past studies"
-msgstr "您参与过的研究"
-
-#: web/templates/web/studies-history.html:50
-msgid "Here you can view your studies and see comments left by researchers:"
+#: web/templates/web/studies-history.html:33
+#, fuzzy
+#| msgid "Here you can view your studies and see comments left by researchers:"
+msgid ""
+"You can find information about your previous study sessions, watch these "
+"videos, and see comments left by researchers below."
 msgstr "您可以在此页面浏览参与过的研究，并查看研究人员留下的评论。"
 
-#: web/templates/web/studies-history.html:67
+#: web/templates/web/studies-history.html:36
+msgid ""
+"External studies happen at other websites, and are listed below after you "
+"click the &quot;Participate Now&quot; button to follow a link. "
+msgstr ""
+
+#: web/templates/web/studies-history.html:38
+msgid ""
+"You can find information on the studies you have accessed and contact "
+"information for the researchers on a specific study below."
+msgstr ""
+
+#: web/templates/web/studies-history.html:49
 msgid "Study Thumbnail"
 msgstr "研究封面"
 
-#: web/templates/web/studies-history.html:79
-msgid "Eligibility:"
+#: web/templates/web/studies-history.html:55
+#, fuzzy
+#| msgid "Eligibility:"
+msgid "Eligibility"
 msgstr "参与资格："
 
-#: web/templates/web/studies-history.html:80
-msgid "Contact:"
+#: web/templates/web/studies-history.html:59
+#, fuzzy
+#| msgid "Contact:"
+msgid "Contact"
 msgstr "联系方式："
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:63
 msgid "Still collecting data?"
 msgstr "是否还在招募？"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:65
 msgid "Yes"
 msgstr "是"
 
-#: web/templates/web/studies-history.html:81
+#: web/templates/web/studies-history.html:67
 msgid "No"
 msgstr "否"
 
-#: web/templates/web/studies-history.html:82
-msgid "Compensation: "
-msgstr "报酬： "
+#: web/templates/web/studies-history.html:72
+#: web/templates/web/study-detail.html:79
+msgid "Compensation"
+msgstr "报酬"
 
-#: web/templates/web/studies-history.html:87
+#: web/templates/web/studies-history.html:78
 msgid "Study Responses"
 msgstr "实验记录"
 
-#: web/templates/web/studies-history.html:107
-msgid "Video"
-msgstr "视频"
-
-#: web/templates/web/studies-history.html:118
+#: web/templates/web/studies-history.html:105
+#: web/templates/web/studies-history.html:109
 msgid "Date"
 msgstr "日期"
 
-#: web/templates/web/studies-history.html:120
+#: web/templates/web/studies-history.html:114
 msgid "Consent status"
 msgstr "同意书批准状态"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:116
 msgid "Approved"
 msgstr "已批准"
 
-#: web/templates/web/studies-history.html:123
+#: web/templates/web/studies-history.html:117
 msgid "Your consent video was reviewed by a researcher and is valid."
 msgstr "您的同意书视频经研究人员审核是有效的。"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:119
 msgid "Pending"
 msgstr "处理中"
 
-#: web/templates/web/studies-history.html:125
+#: web/templates/web/studies-history.html:120
 msgid "Your consent video has not yet been reviewed by a researcher."
 msgstr "您的同意书视频还未被研究人员审核。"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:122
 msgid "Invalid"
 msgstr "无效"
 
-#: web/templates/web/studies-history.html:127
+#: web/templates/web/studies-history.html:123
 msgid ""
 "There was a technical problem with your consent video, or it did not show "
 "you reading the consent statement out loud. Your other data from this "
@@ -3072,200 +3951,260 @@ msgstr ""
 "您的同意书视频出现了技术问题，或没有记录到您朗读出声明。因此研究人员不会查看"
 "或使用您在本实验中提交的其他数据。"
 
-#: web/templates/web/studies-history.html:129
+#: web/templates/web/studies-history.html:125
 msgid "No information about consent video review status."
 msgstr "没有关于同意书视频批准状态的信息"
 
-#: web/templates/web/studies-history.html:133
+#: web/templates/web/studies-history.html:131
 msgid "Feedback"
 msgstr "反馈"
 
-#: web/templates/web/studies-history.html:139
-msgid "None"
-msgstr "无"
-
-#: web/templates/web/studies-history.html:154
-msgid "You have not yet participated in any studies."
+#: web/templates/web/studies-history.html:145
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any Lookit studies."
 msgstr "您尚未参与任何研究。"
 
-#: web/templates/web/studies-list.html:32
-msgid "Current Studies"
-msgstr "当前的研究"
+#: web/templates/web/studies-history.html:147
+#, fuzzy
+#| msgid "You have not yet participated in any studies."
+msgid "You have not yet participated in any external studies."
+msgstr "您尚未参与任何研究。"
 
-#: web/templates/web/studies-list.html:53
-msgid ""
-"Please note you'll need a laptop or desktop computer (not a mobile device) "
-"running Chrome or Firefox to participate."
+#: web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "研究"
+
+#: web/templates/web/studies-list.html:24
+msgid "Log in to find studies just right for your child!"
 msgstr ""
-"请注意，您需要一台能运行谷歌或火狐浏览器的笔记本电脑或台式电脑（非移动设备）"
-"才能参加。"
 
-#: web/templates/web/studies-list.html:80
-msgid "See details"
-msgstr "查看详细信息"
-
-#: web/templates/web/studies-list.html:87
-msgid "We are not running any studies at this time!"
-msgstr "我们目前没有进行任何研究!"
-
-#: web/templates/web/studies-list.html:93
-msgid ""
-"Looking for more ways to contribute to research from home? Check out <a href="
-"\"https://childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
-"noopener\">Children Helping Science</a> for even more studies!"
+#: web/templates/web/studies-list.html:29
+msgid "Clear"
 msgstr ""
-"您想要寻找更多在家参与研究的机会吗？请查看 <a href=\"https://"
-"childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer noopener"
-"\">Children Helping Science</a>，了解更多研究内容。"
 
-#: web/templates/web/study-detail.html:53
-msgid "days"
-msgstr "天"
+#: web/templates/web/studies-list.html:62
+msgid "No studies found."
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " until "
-msgstr " 直到 "
+#: web/templates/web/studies-list.html:67
+msgid ""
+"Want to learn more about research with babies & children? Check out the "
+msgstr ""
 
-#: web/templates/web/study-detail.html:53
-msgid " when "
-msgstr " 什么时候 "
+#: web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "相关资源"
 
-#: web/templates/web/study-detail.html:93
-msgid "Study overview"
-msgstr "研究概述"
+#: web/templates/web/studies-list.html:71
+msgid "page for activities to try at home and developmental labs near you!"
+msgstr ""
 
-#: web/templates/web/study-detail.html:96
-msgid "Back to list"
-msgstr "返回列表"
-
-#: web/templates/web/study-detail.html:112
-msgid "Eligibility criteria"
-msgstr "参与资格"
-
-#: web/templates/web/study-detail.html:116
-msgid "Duration"
-msgstr "时长"
-
-#: web/templates/web/study-detail.html:121
-msgid "Compensation"
-msgstr "报酬"
-
-#: web/templates/web/study-detail.html:126
-msgid "What happens"
-msgstr "实验步骤"
-
-#: web/templates/web/study-detail.html:130
-msgid "What we're studying"
-msgstr "实验目的"
-
-#: web/templates/web/study-detail.html:134
-msgid "This study is conducted by"
-msgstr "研究负责人："
-
-#: web/templates/web/study-detail.html:138
-msgid "Would you like to participate in this study?"
-msgstr "您是否愿意参加这项研究？"
-
-#: web/templates/web/study-detail.html:140
-msgid "Log in to participate"
-msgstr "请登录后参与"
-
-#: web/templates/web/study-detail.html:142
-msgid "Add child profile to "
-msgstr "将儿童档案添加到 "
-
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:17
 msgid "preview"
 msgstr "预览"
 
-#: web/templates/web/study-detail.html:142
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:18
 msgid "participate"
 msgstr "参与"
 
-#: web/templates/web/study-detail.html:144
+#: web/templates/web/study-detail.html:19
+msgid "now"
+msgstr "现在"
+
+#: web/templates/web/study-detail.html:20
+msgid "Build experiment runner to preview"
+msgstr "创建实验运行器来预览"
+
+#: web/templates/web/study-detail.html:21
+#, fuzzy
+#| msgid "Log in to participate"
+msgid "Schedule a time to participate"
+msgstr "请登录后参与"
+
+#: web/templates/web/study-detail.html:22
+msgid "Add child profile to "
+msgstr "将儿童档案添加到 "
+
+#: web/templates/web/study-detail.html:23
 msgid "Complete demographic survey to "
 msgstr "完成基本信息以  "
 
-#: web/templates/web/study-detail.html:148
+#: web/templates/web/study-detail.html:54
+#, fuzzy
+#| msgid "Participate"
+msgid "Who Can Participate"
+msgstr "参加"
+
+#: web/templates/web/study-detail.html:60
+#, fuzzy
+#| msgid "What happens"
+msgid "What Happens"
+msgstr "实验步骤"
+
+#: web/templates/web/study-detail.html:66
+#, fuzzy
+#| msgid "What we're studying"
+msgid "What We're Studying"
+msgstr "实验目的"
+
+#: web/templates/web/study-detail.html:72
+msgid "Duration"
+msgstr "时长"
+
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:88
+#, fuzzy, python-format
+#| msgid "This study is conducted by"
+msgid "This study is conducted by %(contact)s."
+msgstr "研究负责人："
+
+#: web/templates/web/study-detail.html:96
+msgid "Would you like to participate in this study?"
+msgstr "您是否愿意参加这项研究？"
+
+#: web/templates/web/study-detail.html:108
 msgid "Select a child:"
 msgstr "选择一个孩子："
 
-#: web/templates/web/study-detail.html:150
+#: web/templates/web/study-detail.html:119
 msgid "None Selected"
 msgstr "未选择"
 
-#: web/templates/web/study-detail.html:161
+#: web/templates/web/study-detail.html:132
+#, fuzzy
+#| msgid ""
+#| "Your child is still younger than the recommended age range for this "
+#| "study. If you can wait <span id='wait-until'>until</span> he or she is "
+#| "old enough, we'll be able to use the collected data in our research!"
 msgid ""
 "Your child is still younger than the recommended age range for this study. "
-"If you can wait <span id='wait-until'>until</span> he or she is old enough, "
-"we'll be able to use the collected data in our research!"
+"If you can wait until he or she is old enough, the researchers will be able "
+"to compensate you and use the collected data in their research!"
 msgstr ""
 "您的孩子比这项研究建议的年龄范围要小。如果您能等待<span id='wait-until'>直到"
 "</span>他或她满足年龄要求再来参加，我们将能在研究中使用您孩子的数据。"
 
-#: web/templates/web/study-detail.html:162
+#: web/templates/web/study-detail.html:135
+#, fuzzy
+#| msgid ""
+#| "Your child is older than the recommended age range for this study. You're "
+#| "welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research."
 msgid ""
 "Your child is older than the recommended age range for this study. You're "
-"welcome to try the study anyway, but we won't be able to use the collected "
-"data in our research."
+"welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use the collected data in their research."
 msgstr ""
 "您的孩子已经超过了这项研究建议的年龄范围。我们仍欢迎您尝试它，但我们不能将收"
 "集到的数据用于此研究。"
 
-#: web/templates/web/study-detail.html:163
+#. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
+#: web/templates/web/study-detail.html:139
+#, fuzzy, python-format
+#| msgid ""
+#| "Your child does not meet the eligibility criteria listed for this study. "
+#| "You're welcome to try the study anyway, but we won't be able to use the "
+#| "collected data in our research. Please contact the study researchers"
 msgid ""
 "Your child does not meet the eligibility criteria listed for this study. "
-"You're welcome to try the study anyway, but we won't be able to use the "
-"collected data in our research. Please contact the study researchers"
+"You're welcome to try the study anyway, but researchers may not be able to "
+"compensate you or use your data. Please review the “Who can participate” "
+"information for this study and contact the study researchers (%(contact)s) "
+"if you feel this is in error."
 msgstr ""
 "您的孩子不符合本研究的参与资格。我们仍欢迎您尝试他，但我们不能将收集到的数据"
 "用于此研究。请联系研究负责人"
 
-#: web/templates/web/study-detail.html:165
-msgid "Build experiment runner to preview"
-msgstr "创建实验运行器来预览"
-
-#: web/templates/web/study-detail.html:167
-msgid "Participate"
-msgstr "参加"
-
-#: web/templates/web/study-detail.html:167
-msgid "now"
-msgstr "现在"
-
-#: web/templates/web/study-detail.html:168
+#: web/templates/web/study-detail.html:153
 msgid ""
 "For an easy way to see what happens as you update your study protocol, "
 "bookmark the URL the button above sends you to."
 msgstr "请将上方按钮显示的网址加入书签，以便预览您更新后的研究。"
 
-#: web/views.py:63
+#: web/templates/web/study-detail.html:157
+msgid ""
+"This study runs on another website, and clicking to participate will take "
+"you to that link."
+msgstr ""
+
+#: web/templates/web/study-detail.html:159
+msgid ""
+"It will also make it possible for the researchers of this study to contact "
+"you, and will share your child's profile information with the researchers."
+msgstr ""
+
+#: web/templates/web/study-detail.html:162
+msgid "This study runs here on the Lookit platform."
+msgstr ""
+
+#: web/templates/web/study-detail.html:164
+msgid ""
+"Clicking to participate will make it possible for the researchers of this "
+"study to contact you, and will share your child's profile information with "
+"the researchers."
+msgstr ""
+
+#: web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "创建账号"
+
+#: web/templatetags/web_extras.py:191
+#, fuzzy
+#| msgid ""
+#| "Please note you'll need a laptop or desktop computer (not a mobile "
+#| "device) running Chrome or Firefox to participate."
+msgid ""
+"Use the tabs above to see activities you can do right now, or scheduled "
+"activities you can sign up for.\n"
+"\n"
+"Please note you'll need a laptop or desktop computer (not a mobile device) "
+"running Chrome or Firefox to participate, unless a specific study says "
+"otherwise."
+msgstr ""
+"请注意，您需要一台能运行谷歌或火狐浏览器的笔记本电脑或台式电脑（非移动设备）"
+"才能参加。"
+
+#: web/templatetags/web_extras.py:195
+msgid ""
+"You and your child can participate in these studies right now by choosing a "
+"study and then clicking \"Participate.\" Please note you'll need a laptop or "
+"desktop computer (not a mobile device) running Chrome or Firefox to "
+"participate, unless a specific study says otherwise."
+msgstr ""
+
+#: web/templatetags/web_extras.py:199
+msgid ""
+"You and your child can participate in these studies by scheduling a time to "
+"meet with a researcher (usually over video conferencing). Choose a study and "
+"then click \"Participate\" to sign up for a study session in the future."
+msgstr ""
+
+#: web/views.py:114
 msgid "Participant created."
 msgstr "参与者已创建。"
 
-#: web/views.py:88
+#: web/views.py:157
 msgid "Demographic data saved."
 msgstr "基本信息已保存。"
 
-#: web/views.py:156
+#: web/views.py:223
 msgid "Child added."
 msgstr "儿童档案已添加。"
 
-#: web/views.py:192
+#: web/views.py:264
 msgid "Child deleted."
 msgstr "儿童档案已删除。"
 
-#: web/views.py:194
+#: web/views.py:266
 msgid "Child updated."
 msgstr "儿童档案已更新。"
 
-#: web/views.py:217
+#: web/views.py:294
 msgid "Email preferences saved."
 msgstr "电子邮件偏好已保存。"
 
-#: web/views.py:311
+#: web/views.py:699
 #, python-brace-format
 msgid ""
 "The study {study.name} is not currently collecting data - the study is "
@@ -3275,11 +4214,394 @@ msgstr ""
 "{study.name}研究当前未在收集数据（研究已完成或已暂停）。若您认为这是一个错误"
 "信息，请联系{study.contact_info}"
 
+#~ msgid ""
+#~ "Your password can’t be too similar to your other personal information."
+#~ msgstr "您的密码不能与您的个人信息过于相似。"
+
+#~ msgid "Your password must contain at least 16 characters."
+#~ msgstr "您的密码必须至少包含16个字符。"
+
+#~ msgid "Your password can’t be a commonly used password."
+#~ msgstr "您的密码不能为常见密码。"
+
+#~ msgid "Your password can’t be entirely numeric."
+#~ msgstr "您的密码不能全是数字。"
+
+#~ msgid "What category(ies) does your family identify as?"
+#~ msgstr "您认为您的家庭属于哪种类别？"
+
+#~ msgid "Numerical answers only - a rough guess is fine!"
+#~ msgstr "仅填写数字（可估计）"
+
+#~ msgid "What language(s) does your family speak at home?"
+#~ msgstr "您的家庭在家中使用什么语言？"
+
+#~ msgid "What is the highest level of education your spouse has completed?"
+#~ msgstr "您的配偶获得的最高学历是什么？"
+
+#~ msgid "About how many children's books are there in your home?"
+#~ msgstr "您家中大约有多少本儿童读物？"
+
+#~ msgid ""
+#~ "If the answer varies due to shared custody arrangements or travel, please "
+#~ "enter the number of parents/guardians your children are usually living "
+#~ "with or explain."
+#~ msgstr ""
+#~ "如果监护人数量会因共同监护或旅行而有变动，请输入和您孩子平时一同居住的父"
+#~ "母/监护人人数或做额外解释。"
+
+#~ msgid "other"
+#~ msgstr "其他"
+
+#~ msgid "3 or more"
+#~ msgstr "3位及以上"
+
+#~ msgid "varies"
+#~ msgstr "不定"
+
+#~ msgid "My Account"
+#~ msgstr "我的账号"
+
+#~ msgid "Last Active:"
+#~ msgstr "最后访问："
+
+#~ msgid "Participant global ID:"
+#~ msgstr "参与者全球ID："
+
+#~ msgid "Dashboard"
+#~ msgstr "概要面板"
+
+#~ msgid "Argentinian Spanish"
+#~ msgstr "阿根廷西班牙语"
+
+#~ msgid "Canadian French"
+#~ msgstr "加拿大法语"
+
+#~ msgid "Norwegian Bokmål"
+#~ msgstr "挪威博克莫尔语"
+
+#~ msgid "Brazilian Portuguese"
+#~ msgstr "巴西葡萄牙语"
+
+#~ msgid "Simplified Chinese"
+#~ msgstr "中文简体"
+
+#~ msgid "Yue"
+#~ msgstr "粤语"
+
+#~ msgid "Lookit"
+#~ msgstr "Lookit"
+
+#~ msgid "How can we participate online?"
+#~ msgstr "我们如何在线参与研究？"
+
+#~ msgid ""
+#~ "\n"
+#~ "                            <p>If you have a child and would like to "
+#~ "participate, create an account and take a look at what we have available "
+#~ "for your child's age range. You'll need a working webcam to participate.</"
+#~ "p>\n"
+#~ "                                <p>When you select a study, you'll be "
+#~ "asked to read a consent form and record yourself stating that you and "
+#~ "your child agree to participate. Then we'll guide you through what will "
+#~ "happen during the study. Depending on your child's age, your child may "
+#~ "answer questions directly or we may be looking for indirect signs of what "
+#~ "she thinks is going on--like how long she looks at a surprising outcome.</"
+#~ "p>\n"
+#~ "                                <p>Some portions of the study will be "
+#~ "automatically recorded using your webcam and sent securely to the Lookit "
+#~ "platform. Trained researchers will watch the video and record your "
+#~ "child's responses--for instance, which way he pointed, or how long she "
+#~ "looked at each image. We'll put these together with responses from lots "
+#~ "of other children to learn more about how kids think!</p>\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ "<p>如果您有孩子并愿意参与研究，请注册账号并查看现有的适合您孩子年龄的研"
+#~ "究。您需要使用一个有摄像头的电脑</p>\n"
+#~ "        \t\t\t\t\t\t\t\t<p>当您选择了一个研究后，您需要阅读同意书，并录下"
+#~ "您同意自己和孩子参与研究的视频。接下来，我们会告诉您研究的步骤。基于您孩子"
+#~ "的年龄，他/她可能需要直接回答问题，或者我们会通过迹象来间接研究他/她对正在"
+#~ "发生的事情的理解，比如他/她盯着一件意想不到的事的时长。</p>\n"
+#~ "        \t\t\t\t\t\t\t\t<p>部分实验会被您的摄像头自动记录下来并保密发送至"
+#~ "Lookit平台。有经验的研究者会浏览您的视频，并记录您孩子的反馈，比如他/她所"
+#~ "指的方向或盯着图片的时长。我们会结合所有孩子的反馈来研究儿童是如何思考的。"
+#~ "</p>\n"
+#~ "                            "
+
+#~ msgid ""
+#~ "Any researcher with questions about how kids learn and grow can propose a "
+#~ "Lookit study! Each institution using Lookit has to sign a contract with "
+#~ "MIT where they agree to the <a href='/termsofuse'>Terms of Use</a> and "
+#~ "certify that their studies will be reviewed and approved by an "
+#~ "institutional review board. Studies are also subject to approval by "
+#~ "Lookit. As of June 2020 we have agreements with 20 universities!"
+#~ msgstr ""
+#~ "任何研究儿童发展的实验人员都可以在Lookit上发起实验。所有使用Lookit的机构都"
+#~ "需要与MIT签署协议，同意<a href=\"/termsofuse\">使用条款</a>，并保证所有实"
+#~ "验都会被机构的审查委员会批准。截至2020年6月，我们已与20所大学签订了协议。"
+
+#~ msgid ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+#~ msgstr ""
+#~ "https://storage.googleapis.com/lookit-staging/static/videos/consent.mp4"
+
+#~ msgid ""
+#~ "Traditionally, developmental studies happen in a quiet room in a "
+#~ "university lab. Researchers call or email local parents to see if they'd "
+#~ "like to take part and schedule an appointment for them to come visit the "
+#~ "lab. Why complement these in-lab studies with online ones? We're hoping "
+#~ "to..."
+#~ msgstr ""
+#~ "一般来说，发展研究是在大学实验室的一个安静的房间里进行的。研究人员会给当地"
+#~ "的家长打电话或发邮件，询问他们是否愿意参加，并安排访问实验室的时间。那为什"
+#~ "么还要用线上研究来补充呢？我们希望"
+
+#~ msgid "When will we see the results of the study?"
+#~ msgstr "我们什么时候能看到研究结果？"
+
+#~ msgid ""
+#~ "The process of publishing a scientific study, from starting data "
+#~ "collection to seeing the paper in a journal, can take several years. You "
+#~ "can check the Lookit home page for updates on papers, or set your "
+#~ "communication preferences to be notified when we have results from "
+#~ "studies you participated in."
+#~ msgstr ""
+#~ "发表一项科学研究，从开始收集数据到在期刊上看到论文，这个过程可能需要几年时"
+#~ "间。您可以查看Lookit主页，了解论文的更新情况，或者设置您的邮件偏好，当您参"
+#~ "与的研究结果有更新时，您会收到通知。"
+
+#~ msgid "Can I get my child's results?"
+#~ msgstr " 我可以拿到我的孩子的研究结果吗？"
+
+#, fuzzy, python-format
+#~| msgid ""
+#~| "\n"
+#~| "                                <p>For some studies, yes! Usually, "
+#~| "developmental researchers only interpret children's abilities and "
+#~| "developmental trends at a group level, and the individual data collected "
+#~| "just isn't very interpretable. But for \"Your baby, the physicist\" and "
+#~| "other longitudinal studies (where you come back for more than one "
+#~| "session), we can sometimes collect enough data to give you a report of "
+#~| "your child's responses after you complete all the sessions.</p>\n"
+#~| "                                <p>Please note that none of the measures "
+#~| "we collect are diagnostic! For instance, while we hope you'll be "
+#~| "interested to learn that your child looked 70%% of the time at videos "
+#~| "where things fell up versus falling down, we won't be able to tell you "
+#~| "whether this means your child is going to be especially good at physics."
+#~| "</p>\n"
+#~| "                                <p>If you're interested in getting "
+#~| "individual results right away, please see our <a "
+#~| "href='resources'>Resources</a> section for fun at-home activities you "
+#~| "can try with your child.</p>\n"
+#~| "                                "
+#~ msgid ""
+#~ "\n"
+#~ "                                <p>For some studies, yes! Usually, "
+#~ "developmental researchers only interpret children's abilities and "
+#~ "developmental trends at a group level, and the individual data collected "
+#~ "just isn't very interpretable. But for \"Your baby, the physicist\" and "
+#~ "other longitudinal studies (where you come back for more than one "
+#~ "session), we can sometimes collect enough data to give you a report of "
+#~ "your child's responses after you complete all the sessions.</p>\n"
+#~ "                                <p>Please note that none of the measures "
+#~ "we collect are diagnostic! For instance, while we hope you'll be "
+#~ "interested to learn that your child looked 70%% of the time at videos "
+#~ "where things fell up versus falling down, we won't be able to tell you "
+#~ "whether this means your child is going to be especially good at physics.</"
+#~ "p>\n"
+#~ "                                <p>If you're interested in getting "
+#~ "individual results right away, please see our <a "
+#~ "href='resources'>Resources</a> section for fun at-home activities you can "
+#~ "try with your child.</p>\n"
+#~ "                                "
+#~ msgstr ""
+#~ "\n"
+#~ "                                <p>对于一些研究，您可以拿到自己孩子的研究"
+#~ "结果。通常情况下，科学家只能在群体水平上解释孩子的能力和发展趋势，而收集到"
+#~ "的个体数据并不能很好地被分析。但对于“Your baby, the physicist”和其他纵向研"
+#~ "究（您的孩子会在不同年龄段多次参与），若我们能收集到足够的个体数据，在整个"
+#~ "实验结束后，您将可以收到一份孩子的实验报告。</p>\n"
+#~ "        \t\t\t\t\t\t\t    <p>请注意，我们收集的所有数据都没有诊断意义! 例"
+#~ "如，虽然我们希望您有兴趣了解您的孩子在70%的时间里都在看物体运动的视频，但"
+#~ "我们无法告诉您这是否意味着您的孩子会特别擅长物理。</p>\n"
+#~ "        \t\t\t\t\t\t\t\t<p>如果您有兴趣立即获得个人结果，请查看我们的<a "
+#~ "href=\"/resources\">资料库</a>部分，了解您可以与孩子一起尝试的有趣的家庭活"
+#~ "动。</p>\n"
+#~ "                                "
+
+#~ msgid "the online child lab"
+#~ msgstr "线上儿童实验平台"
+
+#~ msgid "A project of the MIT Early Childhood Cognition Lab"
+#~ msgstr "麻省理工学院早期儿童认知实验室项目"
+
+#~ msgid "Bringing science home"
+#~ msgstr "将科学融入生活"
+
+#~ msgid ""
+#~ "Here at MIT's Early Childhood Cognition Lab, we're trying a new approach "
+#~ "in developmental psychology: bringing the experiments to you."
+#~ msgstr ""
+#~ "麻省理工学院早期儿童认知实验室正在尝试一种研究发展心理学的新途径：将实验直"
+#~ "接带到您的面前。"
+
+#~ msgid "Help us understand how your child thinks"
+#~ msgstr "帮助我们了解您的孩子如何思考"
+
+#~ msgid ""
+#~ "Your family can contribute to research about how children learn by doing "
+#~ "fun activities together, right in your web browser."
+#~ msgstr "您的家庭可以直接在网上一起做些有趣的活动来为儿童学习研究作出贡献。"
+
+#~ msgid "Participate whenever and wherever"
+#~ msgstr "随时随地参与"
+
+#~ msgid ""
+#~ "Log in or create an account at the top right to get started! You can "
+#~ "participate with your child from any computer with a webcam."
+#~ msgstr ""
+#~ "请在右上方注册或登录。您可以使用任何有摄像头的电脑来与您的孩子一起参与研"
+#~ "究。"
+
+#~ msgid "Core Team"
+#~ msgstr "核心成员"
+
+#~ msgid ""
+#~ "Rico is Lookit's lead software engineer, working on planning and adding "
+#~ "features for both participants and researchers."
+#~ msgstr ""
+#~ "Rico是Lookit的首席软件工程师，负责为参与者和研究人员规划和添加功能。"
+
+#~ msgid ""
+#~ "Laura is the PI of the Early Childhood Cognition Lab. She conducts "
+#~ "research about how children arrive at a common-sense understanding of the "
+#~ "physical and social world through exploration and instruction."
+#~ msgstr ""
+#~ "Laura是儿童早期认知实验室的首席研究员。她研究儿童是如何通过探索和引导来理"
+#~ "解物理和社会世界的常识。"
+
+#~ msgid ""
+#~ "Kim started Lookit as a graduate student, and now runs the project as a "
+#~ "research scientist in the Early Childhood Cognition Lab. Her three "
+#~ "children frequently provide feedback on studies."
+#~ msgstr ""
+#~ "Kim在研究生时期就开始了Lookit的研究，现在作为研究科学家在儿童早期认知实验"
+#~ "室管理这个项目。她的三个孩子经常为实验提供反馈。"
+
+#~ msgid ""
+#~ "Mark organizes the Lookit Working Groups, which are groups of researchers "
+#~ "working to improve Lookit in a variety of ways."
+#~ msgstr ""
+#~ "Mark负责管理Lookit工作组。工作组是由研究人员组成的，致力于以各种方式完善"
+#~ "Lookit。"
+
+#~ msgid "Your login credentials didn't work. Please try again."
+#~ msgstr "您的登录信息无效。请再次尝试。"
+
+#~ msgid "New to Lookit?"
+#~ msgstr "Lookit新用户？"
+
+#~ msgid "New password:"
+#~ msgstr "新密码："
+
+#~ msgid "Confirm password:"
+#~ msgstr "确认密码："
+
+#, fuzzy, python-format
+#~| msgid "The %(site_name)s team"
+#~ msgid "The %(site_name)s team"
+#~ msgstr "%(site_name)的团队"
+
+#~ msgid "Email address:"
+#~ msgstr "电子邮件地址："
+
+#~ msgid "FAQ"
+#~ msgstr "常见问题解答"
+
+#~ msgid "Hi"
+#~ msgstr "你好"
+
+#~ msgid "Empty birthday"
+#~ msgstr "清空生日"
+
+#~ msgid " day"
+#~ msgstr "天"
+
+#~ msgid " days"
+#~ msgstr "天"
+
+#~ msgid " month"
+#~ msgstr "月"
+
+#~ msgid " months"
+#~ msgstr "月"
+
+#~ msgid " year"
+#~ msgstr "岁"
+
+#~ msgid " years"
+#~ msgstr "岁"
+
+#~ msgid "Hide Form"
+#~ msgstr "隐藏表格"
+
+#~ msgid "Create a family account to start participating in Lookit studies!"
+#~ msgstr "创建一个家庭帐户即可开始参与Lookit研究！"
+
+#~ msgid ""
+#~ "Your account doesn't have access to this page. To proceed, please login "
+#~ "with an account that has access."
+#~ msgstr "您的账号没有权限访问此页面。如需继续，请使用有访问权限的账号登录。"
+
+#~ msgid "Please login to see this page."
+#~ msgstr "请登录后查看本页面。"
+
+#~ msgid "Compensation: "
+#~ msgstr "报酬： "
+
+#~ msgid "None"
+#~ msgstr "无"
+
+#~ msgid "Current Studies"
+#~ msgstr "当前的研究"
+
+#~ msgid "See details"
+#~ msgstr "查看详细信息"
+
+#~ msgid "We are not running any studies at this time!"
+#~ msgstr "我们目前没有进行任何研究!"
+
+#~ msgid ""
+#~ "Looking for more ways to contribute to research from home? Check out <a "
+#~ "href=\"https://childrenhelpingscience.com/\" target=\"_blank\" "
+#~ "rel=\"noreferrer noopener\">Children Helping Science</a> for even more "
+#~ "studies!"
+#~ msgstr ""
+#~ "您想要寻找更多在家参与研究的机会吗？请查看 <a href=\"https://"
+#~ "childrenhelpingscience.com/\" target=\"_blank\" rel=\"noreferrer "
+#~ "noopener\">Children Helping Science</a>，了解更多研究内容。"
+
+#~ msgid "days"
+#~ msgstr "天"
+
+#~ msgid " until "
+#~ msgstr " 直到 "
+
+#~ msgid " when "
+#~ msgstr " 什么时候 "
+
+#~ msgid "Study overview"
+#~ msgstr "研究概述"
+
+#~ msgid "Back to list"
+#~ msgstr "返回列表"
+
+#~ msgid "Eligibility criteria"
+#~ msgstr "参与资格"
+
 #~ msgid "Alumni &amp; Collaborators"
 #~ msgstr "过往成员 &amp; 合作者"
-
-#~ msgid "To register as a researcher, please use"
-#~ msgstr "要注册为研究人员，请使用"
 
 #~ msgid "this form"
 #~ msgstr "这份表格"

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -135,7 +135,10 @@
                             {% trans "Your child is older than the recommended age range for this study. You're welcome to try the study anyway, but researchers may not be able to compensate you or use the collected data in their research." %}
                         </p>
                         <p class="text-danger mb-0 mt-3 d-none" id="criteria-not-met">
-                            {% blocktranslate with contact=study.contact_info %} Your child does not meet the eligibility criteria listed for this study. You're welcome to try the study anyway, but researchers may not be able to compensate you or use your data. Please review the “Who can participate” information for this study and contact the study researchers ({{ contact }}) if you feel this is in error. {% endblocktranslate %}
+                            {# Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted. #}
+                            {% blocktranslate trimmed with contact=study.contact_info %}
+                                Your child does not meet the eligibility criteria listed for this study. You're welcome to try the study anyway, but researchers may not be able to compensate you or use your data. Please review the “Who can participate” information for this study and contact the study researchers ({{ contact }}) if you feel this is in error.
+                            {% endblocktranslate %}
                         </p>
                         {% if preview_mode and object.needs_to_be_built %}
                             {% bootstrap_button build_runner href=build_runner_url button_class=btn_secondary_classes id="participate-button" %}

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -83,7 +83,12 @@
                     {% endif %}
                 </table>
                 <p class="pb-0">
-                    <em class="mt-3 mb-0 text-center text-muted">{% trans "This study is conducted by" %} {{ object.contact_info }}</em>
+                    <em class="mt-3 mb-0 text-center text-muted">
+                        {# Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted. #}
+                        {% blocktranslate trimmed with contact=study.contact_info %}
+                            This study is conducted by {{ contact }}.
+                        {% endblocktranslate %}
+                    </em>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Fixes #1373

This PR does the following:
- Updates all translation .po files. These are out-of-date (all last updated in 2021?) and therefore are missing some text translations and include some translations that are no longer used. 
- Parameterizes the contact information in this case: 
  > trans "This study is conducted by " + contact
  
  so that the `contact` text is passed into the translation string as an argument. Now the translation is written as:
  > "This study is conducted by %(contact)s."
  
  This allows the translator to move the 'contact' text to a different part of the sentence, which is a requirement for the Hungarian translation.
- Updates all translation text for the "This study is conducted by" string to include the new 'contact' argument in the translation. In all cases, the 'contact' argument was added to the end of the existing translation (to match the translation prior to parameterization). E.g. `"Este estudio es realizado por"` is now `"Este estudio es realizado por %(contact)s."`
- Adds some comments for translators to help them handle translations that contain arguments.

**Developer workflow notes**

Updating all of the .po files on `develop` and `master` should not cause problems for the site. Translations of the site will be missing some translations regardless of whether or not we update these files - when this happens, the English text is used. And having the most up-to-date versions on our `develop` branch should make it easier for outside contributors and translators to grab the most recent .po files, check for missing translations, and submit their updates via PRs. But I'm open to other suggestions if anyone sees a problem with this workflow.