### PR TITLE
Fix nav button translations

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1209,6 +1209,7 @@ msgstr "Sie haben sich erfolgreich abgemeldet."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Anmeldung"
 
@@ -1417,12 +1418,50 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Ausloggen"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Zuhause"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Experimentator"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studien"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "FAQ"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Die Wissenschaftler"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressourcen"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Mein Konto"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Frühere Studien"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Ausloggen"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Anmelden"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3235,10 +3274,6 @@ msgstr "Sie haben bisher an keiner Studie teilgenommen."
 msgid "You have not yet participated in any external studies."
 msgstr "Sie haben bisher an keiner Studie teilgenommen."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Studien"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3255,10 +3290,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Ressourcen"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3324,6 +3355,7 @@ msgstr "Dauer"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Diese Studie wird durchgeführt von %(contact)s."
 
@@ -3420,10 +3452,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Anmelden"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3537,9 +3565,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "variiert"
 
-#~ msgid "My Account"
-#~ msgstr "Mein Konto"
-
 #~ msgid "Last Active:"
 #~ msgstr "Letzte Aktivität:"
 
@@ -3584,9 +3609,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "E-Mail-Addresse:"
-
-#~ msgid "FAQ"
-#~ msgstr "FAQ"
 
 #~ msgid "Hi"
 #~ msgstr "Hallo"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1215,6 +1215,7 @@ msgstr "Has cerrado la sesión correctamente."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Iniciar sesión"
 
@@ -1429,12 +1430,50 @@ msgid "Connect"
 msgstr "Conectar"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Cerrar sesión"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Inicio"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Experimentador"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Estudios"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "Preguntas más frecuentes"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Los científicos"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Recursos"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Mi cuenta"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Estudios pasados"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Cerrar sesión"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Regístrese"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -4255,10 +4294,6 @@ msgstr "Aún no ha participado en ningún estudio."
 msgid "You have not yet participated in any external studies."
 msgstr "Aún no ha participado en ningún estudio."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Estudios"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -4275,10 +4310,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Recursos"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -4339,6 +4370,7 @@ msgstr "Duración"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Este estudio es realizado por %(contact)s."
 
@@ -4434,10 +4466,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Regístrese"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -4550,9 +4578,6 @@ msgstr ""
 
 #~ msgid "varies"
 #~ msgstr "varía"
-
-#~ msgid "My Account"
-#~ msgstr "Mi cuenta"
 
 #~ msgid "Last Active:"
 #~ msgstr "Activo por última vez:"
@@ -4965,9 +4990,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Dirección de correo electrónico:"
-
-#~ msgid "FAQ"
-#~ msgstr "Preguntas más frecuentes"
 
 #~ msgid "Hi"
 #~ msgstr "Hola"

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: es-ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1205,6 +1205,7 @@ msgstr "Ha cerrado la sesión correctamente."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Iniciar sesión"
 
@@ -1414,12 +1415,50 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Cerrar sesión"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Inicio"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Investigador"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Estudios"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "Preguntas más frecuentes"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Los científicos"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Recursos"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Mi cuenta"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Estudios anteriores"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Cerrar sesión"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Regístrese"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3233,10 +3272,6 @@ msgstr "Aún no ha participado en ningún estudio."
 msgid "You have not yet participated in any external studies."
 msgstr "Aún no ha participado en ningún estudio."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Estudios"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3253,10 +3288,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Recursos"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3322,6 +3353,7 @@ msgstr "Duración"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Este estudio es realizado por %(contact)s."
 
@@ -3416,10 +3448,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Regístrese"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3529,9 +3557,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "varía"
 
-#~ msgid "My Account"
-#~ msgstr "Mi cuenta"
-
 #~ msgid "Last Active:"
 #~ msgstr "Activo por última vez:"
 
@@ -3575,9 +3600,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Dirección de correo electrónico:"
-
-#~ msgid "FAQ"
-#~ msgstr "Preguntas más frecuentes"
 
 #~ msgid "Hi"
 #~ msgstr "Hola"

--- a/locale/eu/LC_MESSAGES/django.po
+++ b/locale/eu/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:36-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1173,6 +1173,7 @@ msgstr ""
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr ""
 
@@ -1344,11 +1345,43 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
+msgid "CHS Home"
 msgstr ""
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
+msgstr ""
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr ""
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr ""
+
+#: web/templates/web/_navigation.html:7
+msgid "The Scientists"
+msgstr ""
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr ""
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr ""
+
+#: web/templates/web/_navigation.html:10
+msgid "My Past Studies"
+msgstr ""
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr ""
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
 msgstr ""
 
 #: web/templates/web/_studies-by-age-group.html:10
@@ -3093,10 +3126,6 @@ msgstr ""
 msgid "You have not yet participated in any external studies."
 msgstr ""
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr ""
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3112,10 +3141,6 @@ msgstr ""
 #: web/templates/web/studies-list.html:67
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
-msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
 msgstr ""
 
 #: web/templates/web/studies-list.html:71
@@ -3236,10 +3261,6 @@ msgid ""
 "Clicking to participate will make it possible for the researchers of this "
 "study to contact you, and will share your child's profile information with "
 "the researchers."
-msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
 msgstr ""
 
 #: web/templatetags/web_extras.py:191

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1219,6 +1219,7 @@ msgstr "Vous vous êtes déconnecté avec succès."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "S'identifier"
 
@@ -1434,12 +1435,50 @@ msgid "Connect"
 msgstr "Connexion"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Se déconnecter"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Accueil"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Experimenter"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Études"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "FAQ"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Les scientifiques"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressources"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Mon compte"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Études antérieures"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Se déconnecter"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "S'inscrire"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3250,10 +3289,6 @@ msgstr "Vous n'avez encore participé à aucune étude."
 msgid "You have not yet participated in any external studies."
 msgstr "Vous n'avez encore participé à aucune étude."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Études"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3270,10 +3305,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Ressources"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3333,6 +3364,7 @@ msgstr "Durée"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Cette étude est menée par %(contact)s."
 
@@ -3429,10 +3461,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "S'inscrire"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3554,9 +3582,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "varie"
 
-#~ msgid "My Account"
-#~ msgstr "Mon compte"
-
 #~ msgid "Last Active:"
 #~ msgstr "Dernière activité :"
 
@@ -3601,9 +3626,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Adresse e-mail :"
-
-#~ msgid "FAQ"
-#~ msgstr "FAQ"
 
 #~ msgid "Hi"
 #~ msgstr "Salut"

--- a/locale/fr_CA/LC_MESSAGES/django.po
+++ b/locale/fr_CA/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: fr-ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1212,6 +1212,7 @@ msgstr "Vous avez réussi à vous déconnecter."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "S'identifier"
 
@@ -1419,12 +1420,50 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Se déconnecter"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Accueil"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Expérimentateur"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Études"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "FAQ"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Les scientifiques"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressources"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Mon compte"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Études passées"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Se déconnecter"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "S'inscrire"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3240,10 +3279,6 @@ msgstr "Vous n'avez pas encore participé à une étude."
 msgid "You have not yet participated in any external studies."
 msgstr "Vous n'avez pas encore participé à une étude."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Études"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3260,10 +3295,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Ressources"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3329,6 +3360,7 @@ msgstr "Durée"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Cette étude est menée par %(contact)s."
 
@@ -3425,10 +3457,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "S'inscrire"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3539,9 +3567,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "varie"
 
-#~ msgid "My Account"
-#~ msgstr "Mon compte"
-
 #~ msgid "Last Active:"
 #~ msgstr "Dernière activité:"
 
@@ -3586,9 +3611,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Adresse courriel:"
-
-#~ msgid "FAQ"
-#~ msgstr "FAQ"
 
 #~ msgid "Hi"
 #~ msgstr "Bonjour"

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1193,6 +1193,7 @@ msgstr "התנתקת בהצלחה."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "התחברות"
 
@@ -1397,12 +1398,50 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "להתנתק"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "בית"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "נסיינ/ית"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "מחקרים"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "שאלות נפוצות"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "המדענים והמדעניות"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "משאבים"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "החשבון שלי"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "מחקרים קודמים"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "להתנתק"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "להרשם"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3209,10 +3248,6 @@ msgstr "עדיין לא השתתפת בשום מחקרים."
 msgid "You have not yet participated in any external studies."
 msgstr "עדיין לא השתתפת בשום מחקרים."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "מחקרים"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3229,10 +3264,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "משאבים"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3298,6 +3329,7 @@ msgstr "מֶשֶׁך"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "מחקר זה נערך על ידי %(contact)s."
 
@@ -3390,10 +3422,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "להרשם"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3502,9 +3530,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "משתנה"
 
-#~ msgid "My Account"
-#~ msgstr "החשבון שלי"
-
 #~ msgid "Last Active:"
 #~ msgstr "פעיל לאחרונה:"
 
@@ -3548,9 +3573,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "כתובת דוא\"ל:"
-
-#~ msgid "FAQ"
-#~ msgstr "שאלות נפוצות"
 
 #~ msgid "Hi"
 #~ msgstr "היי"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1173,6 +1173,7 @@ msgstr ""
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr ""
 
@@ -1344,11 +1345,43 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
+msgid "CHS Home"
 msgstr ""
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
+msgstr ""
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr ""
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr ""
+
+#: web/templates/web/_navigation.html:7
+msgid "The Scientists"
+msgstr ""
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr ""
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr ""
+
+#: web/templates/web/_navigation.html:10
+msgid "My Past Studies"
+msgstr ""
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr ""
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
 msgstr ""
 
 #: web/templates/web/_studies-by-age-group.html:10
@@ -3093,10 +3126,6 @@ msgstr ""
 msgid "You have not yet participated in any external studies."
 msgstr ""
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr ""
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3112,10 +3141,6 @@ msgstr ""
 #: web/templates/web/studies-list.html:67
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
-msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
 msgstr ""
 
 #: web/templates/web/studies-list.html:71
@@ -3236,10 +3261,6 @@ msgid ""
 "Clicking to participate will make it possible for the researchers of this "
 "study to contact you, and will share your child's profile information with "
 "the researchers."
-msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
 msgstr ""
 
 #: web/templatetags/web_extras.py:191

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1221,6 +1221,7 @@ msgstr "Ti sei disconnesso con successo."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Accesso"
 
@@ -1432,12 +1433,50 @@ msgid "Connect"
 msgstr "Connettiti"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Disconnettiti"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Home"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Sperimentatore"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studi"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "FAQ"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Gli scienziati"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Risorse"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Il mio account"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Studi passati"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Disconnettiti"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Iscriviti"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -4268,10 +4307,6 @@ msgstr "Non hai ancora partecipato a nessuno studio."
 msgid "You have not yet participated in any external studies."
 msgstr "Non hai ancora partecipato a nessuno studio."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Studi"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -4288,10 +4323,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Risorse"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -4351,6 +4382,7 @@ msgstr "Durata"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Questo studio è condotto da %(contact)s."
 
@@ -4445,10 +4477,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Iscriviti"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -4564,9 +4592,6 @@ msgstr ""
 
 #~ msgid "varies"
 #~ msgstr "varia"
-
-#~ msgid "My Account"
-#~ msgstr "Il mio account"
 
 #~ msgid "Last Active:"
 #~ msgstr "Ultimo attivo:"
@@ -4831,9 +4856,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Indirizzo email:"
-
-#~ msgid "FAQ"
-#~ msgstr "FAQ"
 
 #~ msgid "Hi"
 #~ msgstr "Ciao"

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1212,6 +1212,7 @@ msgstr "ログアウトに成功しました。"
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "ログイン"
 
@@ -1401,12 +1402,50 @@ msgid "Connect"
 msgstr "接続する"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "ログアウト"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "ホーム"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "研究者"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "研究・調査"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr ""
+
+#: web/templates/web/_navigation.html:7
+msgid "The Scientists"
+msgstr "科学者たち"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "参考資料"
+
+#: web/templates/web/_navigation.html:9
+#, fuzzy
+#| msgid "My account"
+msgid "My Account"
+msgstr "マイアカウント"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "これまでの研究・調査"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "ログアウト"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "登録する"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3882,10 +3921,6 @@ msgstr "あなたはまだLookitの研究・調査に参加したことがあり
 msgid "You have not yet participated in any external studies."
 msgstr "あなたはまだ外部の研究・調査に参加したことがありません。"
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "研究・調査"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3902,10 +3937,6 @@ msgstr "研究・調査が見つかりません。"
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr "&nbsp;"
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "参考資料"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3957,6 +3988,7 @@ msgstr "期間"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "この研究・調査を実施している研究者／研究グループ %(contact)s."
 
@@ -4051,10 +4083,6 @@ msgstr ""
 "参加するをクリックすると、この研究・調査の研究者があなたに連絡することが可能"
 "になり、あなたのお子様のプロフィール情報が研究者と共有されます。"
 
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "登録する"
-
 #: web/templatetags/web_extras.py:191
 msgid ""
 "Use the tabs above to see activities you can do right now, or scheduled "
@@ -4147,12 +4175,6 @@ msgstr ""
 #~ "め、収集されたデータを実際の研究・調査に使うことはできませんが、その場合で"
 #~ "も研究・調査に参加してみることは可能です (歓迎します！)。もしこの記載が誤"
 #~ "りだと思われる場合は、担当する研究者 %(contact)s にお問い合わせください。"
-
-#~ msgid "The Scientists"
-#~ msgstr "科学者たち"
-
-#~ msgid "My account"
-#~ msgstr "マイアカウント"
 
 #~ msgid "My past studies"
 #~ msgstr "過去の調査"

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1247,6 +1247,7 @@ msgstr "성공적으로 로그아웃 하셨습니다."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 #, fuzzy
 msgid "Login"
 msgstr "로그인"
@@ -1463,12 +1464,49 @@ msgid "Connect"
 msgstr "연결하기"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "로그아웃"
+#, fuzzy
+msgid "CHS Home"
+msgstr "홈(메인 페이지)"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "연구자"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "연구들"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "자주 묻는 질문들"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+msgid "The Scientists"
+msgstr "연구자들"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+#, fuzzy
+msgid "Resources"
+msgstr "참고 자료실"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "나의 계정"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "지난 연구들"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "로그아웃"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "회원가입"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -4009,10 +4047,6 @@ msgstr "귀하께서는 아직 어떤 연구에도 참여하지 않으셨습니�
 msgid "You have not yet participated in any external studies."
 msgstr "귀하께서는 아직 어떤 연구에도 참여하지 않으셨습니다."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "연구들"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -4029,11 +4063,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-#, fuzzy
-msgid "Resources"
-msgstr "참고 자료실"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -4095,6 +4124,7 @@ msgstr "지속 기간"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "이 연구는  에서 진행합니다 %(contact)s."
 
@@ -4187,10 +4217,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "회원가입"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -4312,9 +4338,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "varies"
 #~ msgstr "상황에 따라 다름"
-
-#~ msgid "My Account"
-#~ msgstr "나의 계정"
 
 #~ msgid "Last Active:"
 #~ msgstr "마지막 활동:"
@@ -4582,9 +4605,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "이메일 주소:"
-
-#~ msgid "FAQ"
-#~ msgstr "자주 묻는 질문들"
 
 #~ msgid "Hi"
 #~ msgstr "안녕하십니까"

--- a/locale/nb/LC_MESSAGES/django.po
+++ b/locale/nb/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1237,6 +1237,7 @@ msgstr "Du har logget av"
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Logg inn"
 
@@ -1450,13 +1451,52 @@ msgid "Connect"
 msgstr "Få kontakt"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Logg ut"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Hjem"
 
 #: web/templates/web/_navigation.html:4
 #, fuzzy
 msgid "Experimenter"
 msgstr "Experimenter"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studier"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "Spørsmål og svar"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Forskerne:"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressurser"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Min konto"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Tidligere studier"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Logg ut"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+#, fuzzy
+msgid "Sign up"
+msgstr "Lag en konto"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3271,10 +3311,6 @@ msgstr "Du har ikke deltatt i noen studier enda"
 msgid "You have not yet participated in any external studies."
 msgstr "Du har ikke deltatt i noen studier enda"
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Studier"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3291,10 +3327,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Ressurser"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3353,6 +3385,7 @@ msgstr "Varighet"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Denne studien utføres av %(contact)s."
 
@@ -3439,11 +3472,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-#, fuzzy
-msgid "Sign up"
-msgstr "Lag en konto"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3557,9 +3585,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "Varierer"
 
-#~ msgid "My Account"
-#~ msgstr "Min konto"
-
 #~ msgid "Last Active:"
 #~ msgstr "Sist aktiv"
 
@@ -3606,9 +3631,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "E-postadresse: "
-
-#~ msgid "FAQ"
-#~ msgstr "Spørsmål og svar"
 
 #~ msgid "Hi"
 #~ msgstr "Hei"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1220,6 +1220,7 @@ msgstr "U bent succesvol uitgelogd."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Log in"
 
@@ -1430,12 +1431,50 @@ msgid "Connect"
 msgstr "Verbind"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Uitloggen"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Thuis"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Onderzoeker"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studies"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "FAQ"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "De wetenschappers"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Middelen"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Mijn account"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Eerdere studies"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Uitloggen"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Aanmelden"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3242,10 +3281,6 @@ msgstr "U hebt nog geen studies gedaan."
 msgid "You have not yet participated in any external studies."
 msgstr "U hebt nog geen studies gedaan."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Studies"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3262,10 +3297,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Middelen"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3325,6 +3356,7 @@ msgstr "Duur"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Dit onderzoek wordt uitgevoerd door %(contact)s."
 
@@ -3420,10 +3452,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Aanmelden"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3540,9 +3568,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "varieert"
 
-#~ msgid "My Account"
-#~ msgstr "Mijn account"
-
 #~ msgid "Last Active:"
 #~ msgstr "Laatst actief:"
 
@@ -3587,9 +3612,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "E-mailadres:"
-
-#~ msgid "FAQ"
-#~ msgstr "FAQ"
 
 #~ msgid "Hi"
 #~ msgstr "Hallo"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1237,6 +1237,7 @@ msgstr "Du har logget av"
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Logg inn"
 
@@ -1450,13 +1451,52 @@ msgid "Connect"
 msgstr "Få kontakt"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Logg ut"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Hjem"
 
 #: web/templates/web/_navigation.html:4
 #, fuzzy
 msgid "Experimenter"
 msgstr "Experimenter"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studier"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "Spørsmål og svar"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Forskerne:"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ressurser"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Min konto"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Tidligere studier"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Logg ut"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+#, fuzzy
+msgid "Sign up"
+msgstr "Lag en konto"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3271,10 +3311,6 @@ msgstr "Du har ikke deltatt i noen studier enda"
 msgid "You have not yet participated in any external studies."
 msgstr "Du har ikke deltatt i noen studier enda"
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Studier"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3291,10 +3327,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Ressurser"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3353,6 +3385,7 @@ msgstr "Varighet"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Denne studien utføres av %(contact)s."
 
@@ -3439,11 +3472,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-#, fuzzy
-msgid "Sign up"
-msgstr "Lag en konto"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3557,9 +3585,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "Varierer"
 
-#~ msgid "My Account"
-#~ msgstr "Min konto"
-
 #~ msgid "Last Active:"
 #~ msgstr "Sist aktiv"
 
@@ -3606,9 +3631,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "E-postadresse: "
-
-#~ msgid "FAQ"
-#~ msgstr "Spørsmål og svar"
 
 #~ msgid "Hi"
 #~ msgstr "Hei"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1205,6 +1205,7 @@ msgstr "Udało ci się wylogować."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Login"
 
@@ -1411,12 +1412,50 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Wyloguj się"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Strona główna"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Badacz(ka)"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Badania"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "FAQ"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Badacze"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Zasoby"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Moje konto"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Zeszłe badania"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Wyloguj się"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Zarejestruj się"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3232,10 +3271,6 @@ msgstr "Nie brali Państwo jeszcze udziału w żadnych badaniach."
 msgid "You have not yet participated in any external studies."
 msgstr "Nie brali Państwo jeszcze udziału w żadnych badaniach."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Badania"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3252,10 +3287,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Zasoby"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3321,6 +3352,7 @@ msgstr "Czas trwania"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "To badanie jest przeprowadzane przez %(contact)s."
 
@@ -3415,10 +3447,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Zarejestruj się"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3532,9 +3560,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "różnie"
 
-#~ msgid "My Account"
-#~ msgstr "Moje konto"
-
 #~ msgid "Last Active:"
 #~ msgstr "Ostatnio aktywny/a:"
 
@@ -3580,9 +3605,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Adres e-mail:"
-
-#~ msgid "FAQ"
-#~ msgstr "FAQ"
 
 #~ msgid "Hi"
 #~ msgstr "Dzień dobry"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: pt-br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1216,6 +1216,7 @@ msgstr "Você efetuou logout com sucesso."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Login"
 
@@ -1425,12 +1426,50 @@ msgid "Connect"
 msgstr "Conecte-se"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Sair"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Tela Inicial"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Pesquisador"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Estudos"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "Perguntas frequentes"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Os cientistas"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Recursos"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Minha conta"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Estudos anteriores"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Sair"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "inscrever-se"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3240,10 +3279,6 @@ msgstr "Você ainda não participou de nenhum estudo."
 msgid "You have not yet participated in any external studies."
 msgstr "Você ainda não participou de nenhum estudo."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Estudos"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3260,10 +3295,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Recursos"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3323,6 +3354,7 @@ msgstr "Duração"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Este estudo é realizado por %(contact)s."
 
@@ -3417,10 +3449,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "inscrever-se"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3536,9 +3564,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "varia"
 
-#~ msgid "My Account"
-#~ msgstr "Minha conta"
-
 #~ msgid "Last Active:"
 #~ msgstr "Ativo pela última vez:"
 
@@ -3620,9 +3645,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Endereço de e-mail:"
-
-#~ msgid "FAQ"
-#~ msgstr "Perguntas frequentes"
 
 #~ msgid "Hi"
 #~ msgstr "Oi"

--- a/locale/pt_PT/LC_MESSAGES/django.po
+++ b/locale/pt_PT/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1207,6 +1207,7 @@ msgstr "Você efetuou logout com sucesso."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Login"
 
@@ -1398,12 +1399,50 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Sair"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Tela Inicial"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Pesquisador"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Estudos"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "Perguntas frequentes"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Os cientistass"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Recursos"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Minha conta"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Estudos anteriores"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Sair"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "inscrever-se"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3211,10 +3250,6 @@ msgstr "Você ainda não participou de nenhum estudo."
 msgid "You have not yet participated in any external studies."
 msgstr "Você ainda não participou de nenhum estudo."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Estudos"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3231,10 +3266,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Recursos"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3300,6 +3331,7 @@ msgstr "Duração"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Este estudo é realizado por %(contact)s."
 
@@ -3394,10 +3426,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "inscrever-se"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3508,9 +3536,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "varia"
 
-#~ msgid "My Account"
-#~ msgstr "Minha conta"
-
 #~ msgid "Last Active:"
 #~ msgstr "Ativo pela última vez:"
 
@@ -3548,9 +3573,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Endereço de e-mail:"
-
-#~ msgid "FAQ"
-#~ msgstr "Perguntas frequentes"
 
 #~ msgid "Hi"
 #~ msgstr "Oi"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1204,6 +1204,7 @@ msgstr "V-ați deconectat cu succes."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Autentificare"
 
@@ -1410,12 +1411,50 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Deconectare"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Acasă"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Experimentator"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Studii"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "Întrebări frecvente"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Oamenii de știință"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Resurse"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Contul meu"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Studiile precedente"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Deconectare"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Înscriere"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3232,10 +3271,6 @@ msgstr "Încă nu ați participat la nici un studiu."
 msgid "You have not yet participated in any external studies."
 msgstr "Încă nu ați participat la nici un studiu."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Studii"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3252,10 +3287,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Resurse"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3321,6 +3352,7 @@ msgstr "Durată"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Acest studiu e condus de %(contact)s."
 
@@ -3417,10 +3449,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Înscriere"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3530,9 +3558,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "depinde"
 
-#~ msgid "My Account"
-#~ msgstr "Contul meu"
-
 #~ msgid "Last Active:"
 #~ msgstr "Ultima accesare"
 
@@ -3577,9 +3602,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Adresă de e-mail"
-
-#~ msgid "FAQ"
-#~ msgstr "Întrebări frecvente"
 
 #~ msgid "Hi"
 #~ msgstr "Bună ziua!"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1203,6 +1203,7 @@ msgstr "Вы успешно вышли из системы."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 #, fuzzy
 msgid "Login"
 msgstr "Вход"
@@ -1412,12 +1413,50 @@ msgid "Connect"
 msgstr ""
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Выход"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Главная страница"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Экспериментатор"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Исследования"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "FAQ"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Исследователи"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Ресурсы"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Мой аккаунт"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Прошлые исследования"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Выход"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Зарегистрироваться"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3234,10 +3273,6 @@ msgstr "Вы еще не участвовали в исследованиях."
 msgid "You have not yet participated in any external studies."
 msgstr "Вы еще не участвовали в исследованиях."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Исследования"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3254,10 +3289,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Ресурсы"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -3323,6 +3354,7 @@ msgstr "Продолжительность"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Это исследование проводится %(contact)s."
 
@@ -3418,10 +3450,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Зарегистрироваться"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -3536,9 +3564,6 @@ msgstr ""
 #~ msgid "varies"
 #~ msgstr "варьируется"
 
-#~ msgid "My Account"
-#~ msgstr "Мой аккаунт"
-
 #~ msgid "Last Active:"
 #~ msgstr "Последнее посещение:"
 
@@ -3583,9 +3608,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Адрес электронной почты:"
-
-#~ msgid "FAQ"
-#~ msgstr "FAQ"
 
 #~ msgid "Hi"
 #~ msgstr "Здравствуйте!"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1214,6 +1214,7 @@ msgstr "Başarılı bir şekilde çıkış yaptınız."
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "Giriş yap"
 
@@ -1422,12 +1423,50 @@ msgid "Connect"
 msgstr "Bağlan"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "Çıkış yap"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "Anasayfa"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "Deneyci"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "Çalışmalar"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "SSS"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "Bilim insanları"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "Kaynaklar"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "Hesabım"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "Geçmiş Çalışmalar"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "Çıkış yap"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "Kayıt ol"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -4216,10 +4255,6 @@ msgstr "Henüz herhangi bir çalışmaya katılmadınız."
 msgid "You have not yet participated in any external studies."
 msgstr "Henüz herhangi bir çalışmaya katılmadınız."
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "Çalışmalar"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -4236,10 +4271,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "Kaynaklar"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -4299,6 +4330,7 @@ msgstr "Süre"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "Bu çalışma şu kişiler tarafından yürütülmektedir %(contact)s."
 
@@ -4393,10 +4425,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "Kayıt ol"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -4509,9 +4537,6 @@ msgstr ""
 
 #~ msgid "varies"
 #~ msgstr "değişiyor"
-
-#~ msgid "My Account"
-#~ msgstr "Hesabım"
 
 #~ msgid "Last Active:"
 #~ msgstr "Son aktif olma:"
@@ -4798,9 +4823,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "Email adresi:"
-
-#~ msgid "FAQ"
-#~ msgstr "SSS"
 
 #~ msgid "Hi"
 #~ msgstr "Merhaba"

--- a/locale/zh_HANS/LC_MESSAGES/django.po
+++ b/locale/zh_HANS/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MBAH_studiespage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-09 19:34-0400\n"
+"POT-Creation-Date: 2024-04-10 18:01-0400\n"
 "Language: zh-Hans\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1200,6 +1200,7 @@ msgstr "您已经成功退出。"
 
 #: web/templates/registration/login.html:6
 #: web/templates/registration/login.html:9
+#: web/templates/web/_navigation.html:13
 msgid "Login"
 msgstr "登录"
 
@@ -1398,12 +1399,50 @@ msgid "Connect"
 msgstr "关注我们"
 
 #: web/templates/web/_navigation.html:3
-msgid "Logout"
-msgstr "退出登录"
+#, fuzzy
+#| msgid "Home"
+msgid "CHS Home"
+msgstr "主页"
 
 #: web/templates/web/_navigation.html:4
 msgid "Experimenter"
 msgstr "实验者"
+
+#: web/templates/web/_navigation.html:5 web/templates/web/studies-list.html:7
+msgid "Studies"
+msgstr "研究"
+
+#: web/templates/web/_navigation.html:6
+msgid "FAQ"
+msgstr "常见问题解答"
+
+#: web/templates/web/_navigation.html:7
+#, fuzzy
+#| msgid "The Scientists"
+msgid "The Scientists"
+msgstr "科学家团队"
+
+#: web/templates/web/_navigation.html:8 web/templates/web/studies-list.html:70
+msgid "Resources"
+msgstr "相关资源"
+
+#: web/templates/web/_navigation.html:9
+msgid "My Account"
+msgstr "我的账号"
+
+#: web/templates/web/_navigation.html:10
+#, fuzzy
+#| msgid "Past Studies"
+msgid "My Past Studies"
+msgstr "参与过的研究"
+
+#: web/templates/web/_navigation.html:11
+msgid "Logout"
+msgstr "退出登录"
+
+#: web/templates/web/_navigation.html:12 web/templatetags/web_extras.py:169
+msgid "Sign up"
+msgstr "创建账号"
 
 #: web/templates/web/_studies-by-age-group.html:10
 msgid "studies for babies (under 1)"
@@ -3971,10 +4010,6 @@ msgstr "您尚未参与任何研究。"
 msgid "You have not yet participated in any external studies."
 msgstr "您尚未参与任何研究。"
 
-#: web/templates/web/studies-list.html:7
-msgid "Studies"
-msgstr "研究"
-
 #: web/templates/web/studies-list.html:24
 msgid "Log in to find studies just right for your child!"
 msgstr ""
@@ -3991,10 +4026,6 @@ msgstr ""
 msgid ""
 "Want to learn more about research with babies & children? Check out the "
 msgstr ""
-
-#: web/templates/web/studies-list.html:70
-msgid "Resources"
-msgstr "相关资源"
 
 #: web/templates/web/studies-list.html:71
 msgid "page for activities to try at home and developmental labs near you!"
@@ -4054,6 +4085,7 @@ msgstr "时长"
 
 #. Translators: Please include the untranslated "%(contact)s" string to mark where the contact information should be inserted.
 #: web/templates/web/study-detail.html:88
+#, python-format
 msgid "This study is conducted by %(contact)s."
 msgstr "研究负责人：%(contact)s."
 
@@ -4142,10 +4174,6 @@ msgid ""
 "study to contact you, and will share your child's profile information with "
 "the researchers."
 msgstr ""
-
-#: web/templatetags/web_extras.py:169
-msgid "Sign up"
-msgstr "创建账号"
 
 #: web/templatetags/web_extras.py:191
 #, fuzzy
@@ -4256,9 +4284,6 @@ msgstr ""
 
 #~ msgid "varies"
 #~ msgstr "不定"
-
-#~ msgid "My Account"
-#~ msgstr "我的账号"
 
 #~ msgid "Last Active:"
 #~ msgstr "最后访问："
@@ -4513,9 +4538,6 @@ msgstr ""
 
 #~ msgid "Email address:"
 #~ msgstr "电子邮件地址："
-
-#~ msgid "FAQ"
-#~ msgstr "常见问题解答"
 
 #~ msgid "Hi"
 #~ msgstr "你好"

--- a/web/templates/web/_navigation.html
+++ b/web/templates/web/_navigation.html
@@ -1,12 +1,21 @@
 {% load i18n %}
 {% load web_extras %}
-{% trans "Logout" as logout %}
+{% trans "CHS Home" as chs_home %}
 {% trans "Experimenter" as experimenter %}
+{% trans "Studies" as studies %}
+{% trans "FAQ" as faq %}
+{% trans "The Scientists" as scientists %}
+{% trans "Resources" as resources %}
+{% trans "My Account" as my_account %}
+{% trans "My Past Studies" as my_past_studies %}
+{% trans "Logout" as logout %}
+{% trans "Sign up" as sign_up %}
+{% trans "Login" as login %}
 <header class="row" id="navbar-row">
     <nav class="navbar navbar-expand-md bg-light text-dark">
         <div class="container-fluid">
             <div class="navbar-nav nav-pills navbar-collapse">
-                {% nav_link request 'web:home' 'CHS Home' %}
+                {% nav_link request 'web:home' chs_home %}
                 {% if user.is_researcher %}
                     {% nav_link request 'exp:study-list' experimenter %}
                 {% endif %}
@@ -19,19 +28,19 @@
             </div>
             {% block nav_links %}
                 <div class="navbar-nav nav-pills navbar-collapse collapse collapse1 justify-content-center">
-                    {% nav_link request 'web:studies-list' 'Studies' %}
-                    {% nav_link request 'web:faq' 'FAQ' %}
-                    {% nav_link request 'web:scientists' 'The Scientists' %}
-                    {% nav_link request 'web:resources' 'Resources' %}
+                    {% nav_link request 'web:studies-list' studies %}
+                    {% nav_link request 'web:faq' faq %}
+                    {% nav_link request 'web:scientists' scientists %}
+                    {% nav_link request 'web:resources' resources %}
                 </div>
                 <div class="navbar-nav nav-pills navbar-collapse collapse collapse1 justify-content-end">
                     {% if user.is_authenticated %}
-                        {% nav_link request 'accounts:manage-account' 'My Account' %}
-                        {% nav_link request 'web:studies-history' 'My Past Studies' %}
+                        {% nav_link request 'accounts:manage-account' my_account %}
+                        {% nav_link request 'web:studies-history' my_past_studies %}
                         {% nav_link request 'logout' logout %}
                     {% else %}
-                        {% nav_signup request 'Sign up' %}
-                        {% nav_login request 'Login' %}
+                        {% nav_signup request sign_up %}
+                        {% nav_login request login %}
                     {% endif %}
                 </div>
             {% endblock nav_links %}

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -107,7 +107,7 @@ def nav_link(
     Args:
         request (Request): Reqeust submitted from template
         url_name (Text): Name of url to be looked up by reverse
-        text (Text): Text to be displayed in item
+        text (Text): Text to be displayed in item (translated before passed in as argument)
         html_classes (Array): optional list of one or more classes for the <a> element
         queryString (Text): optional query string to be appended to the end of URL
         list (Boolean): should the nav links be inside <li> elements? (default is False)
@@ -135,7 +135,7 @@ def nav_link(
     if queryString:
         url = url + queryString
     nav_a_tag = (
-        f'<a class="{" ".join(html_classes)}"{aria_current} href="{url}">{_(text)}</a>'
+        f'<a class="{" ".join(html_classes)}"{aria_current} href="{url}">{text}</a>'
     )
 
     if list:


### PR DESCRIPTION
# TL;DR

This PR fixes a problem with the navigation bar button labels not being translated. The problem was related to how we were generating the navigation bar buttons, which was causing Django to not pick up the button text as needing translation.

# Description

While testing the translation updates, I noticed that some of the navigation bar button labels weren't being added to the translation (.po) files. A while ago we changed the way that we create the nav buttons in the templates (with a custom `nav_link` template tag) but it turns out that translating the text within that template tag meant that the text wasn't being picked up by Django and added to the .po file. This fixes the problem by translating the text in the template first, before passing the translation as an argument into the `nav_link` tag. I also re-generated all of the .po files so that they include the navigation bar button labels - the updated file versions are included in this PR.

# Screenshots

Before this change, most of the navigation bar button labels were not being picked up for translation. Here is a screenshot from the `develop` branch in Japanese, which uses our most up-to-date translation file:

![Screenshot 2024-04-10 at 3 42 25 PM](https://github.com/lookit/lookit-api/assets/9041788/2a1058c8-1ca9-44f5-b1c9-bee134d2cf7b)

The text for the untranslated buttons (CHS Home, FAQ, The Scientists, My Account, My Past Studies) does not exist in the .po file (vs existing in the file but not containing a translation value).

After the changes in this PR, the navigation button labels are being picked up for translation and added to the .po files. (For this screenshot, I was able to set some actual Japanese translations using fuzzy/suggested values, and then I just put in some "TEST" placeholder values for the others that were empty.)

![Screenshot 2024-04-10 at 3 40 00 PM](https://github.com/lookit/lookit-api/assets/9041788/fc67238f-88bd-4a3e-92bd-1d868e449c3f)

# Implementation notes:

I realize this is less elegant than translating the text argument inside the template tag, because now we have to have a bunch of separate lines in the templates to store each translation string. I did try a few different ways of translating the text inside the `nav_link` code but couldn't get that approach to work.