### PR TITLE
Update study edit UI

### DIFF
--- a/exp/tests/test_runner_views.py
+++ b/exp/tests/test_runner_views.py
@@ -25,7 +25,7 @@ class RunnerDetailsViewsTestCase(TestCase):
     def setUp(self):
         self.client = Force2FAClient()
         self.efp_study_details = "exp:efp-study-edit-design"
-        self.study_details = "exp:study-details"
+        self.study_edit_design = "exp:study-edit-design"
 
     def test_external_details_view(self):
         user = G(User, is_active=True, is_researcher=True)
@@ -96,7 +96,7 @@ class RunnerDetailsViewsTestCase(TestCase):
         self.client.force_login(user)
 
         response = self.client.get(
-            reverse(self.study_details, kwargs={"pk": efp.id}), follow=True
+            reverse(self.study_edit_design, kwargs={"pk": efp.id}), follow=True
         )
         self.assertEqual(
             response.redirect_chain,
@@ -119,7 +119,7 @@ class RunnerDetailsViewsTestCase(TestCase):
         self.client.force_login(user)
 
         response = self.client.get(
-            reverse(self.study_details, kwargs={"pk": external.id}), follow=True
+            reverse(self.study_edit_design, kwargs={"pk": external.id}), follow=True
         )
         self.assertEqual(
             response.redirect_chain,
@@ -143,7 +143,7 @@ class RunnerDetailsViewsTestCase(TestCase):
 
         self.client.force_login(user)
         response = self.client.get(
-            reverse(self.study_details, kwargs={"pk": jspsych.id}), follow=True
+            reverse(self.study_edit_design, kwargs={"pk": jspsych.id}), follow=True
         )
         self.assertEqual(
             response.redirect_chain,

--- a/exp/tests/test_runner_views.py
+++ b/exp/tests/test_runner_views.py
@@ -24,7 +24,7 @@ class Force2FAClient(Client):
 class RunnerDetailsViewsTestCase(TestCase):
     def setUp(self):
         self.client = Force2FAClient()
-        self.efp_study_details = "exp:efp-study-details"
+        self.efp_study_details = "exp:efp-study-edit-design"
         self.study_details = "exp:study-details"
 
     def test_external_details_view(self):
@@ -45,7 +45,7 @@ class RunnerDetailsViewsTestCase(TestCase):
 
         self.client.force_login(user)
         response = self.client.post(
-            reverse("exp:external-study-details", kwargs={"pk": study.id}),
+            reverse("exp:external-study-edit-design", kwargs={"pk": study.id}),
             {"scheduled": ScheduledChoice.scheduled.value, "url": metadata["url"]},
             follow=True,
         )
@@ -125,7 +125,9 @@ class RunnerDetailsViewsTestCase(TestCase):
             response.redirect_chain,
             [
                 (
-                    reverse("exp:external-study-details", kwargs={"pk": external.id}),
+                    reverse(
+                        "exp:external-study-edit-design", kwargs={"pk": external.id}
+                    ),
                     HTTPStatus.FOUND,
                 )
             ],
@@ -147,7 +149,7 @@ class RunnerDetailsViewsTestCase(TestCase):
             response.redirect_chain,
             [
                 (
-                    reverse("exp:jspsych-study-details", kwargs={"pk": jspsych.id}),
+                    reverse("exp:jspsych-study-edit-design", kwargs={"pk": jspsych.id}),
                     HTTPStatus.FOUND,
                 )
             ],

--- a/exp/urls.py
+++ b/exp/urls.py
@@ -263,23 +263,23 @@ urlpatterns = [
     ),
     path("support/", SupportView.as_view(), name="support"),
     path(
-        "studies/<int:pk>/study-details/",
+        "studies/<int:pk>/design/",
         ExperimentRunnerRedirect.as_view(),
-        name="study-details",
+        name="study-edit-design",
     ),
     path(
-        "studies/<int:pk>/study-details/efp/",
+        "studies/<int:pk>/design/efp/",
         EFPEditView.as_view(),
-        name="efp-study-details",
+        name="efp-study-edit-design",
     ),
     path(
-        "studies/<int:pk>/study-details/external/",
+        "studies/<int:pk>/design/external/",
         ExternalEditView.as_view(),
-        name="external-study-details",
+        name="external-study-edit-design",
     ),
     path(
-        "studies/<int:pk>/study-details/jspsych/",
+        "studies/<int:pk>/design/jspsych/",
         JSPsychEditView.as_view(),
-        name="jspsych-study-details",
+        name="jspsych-study-edit-design",
     ),
 ]

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -141,7 +141,7 @@ class StudyCreateView(
         return HttpResponseRedirect(self.get_success_url())
 
     def get_success_url(self):
-        return reverse("exp:study-details", kwargs=dict(pk=self.object.id))
+        return reverse("exp:study-edit-design", kwargs=dict(pk=self.object.id))
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -240,7 +240,7 @@ class StudyUpdateView(
         return context
 
     def get_success_url(self):
-        return reverse("exp:study-details", kwargs={"pk": self.object.id})
+        return reverse("exp:study-edit-design", kwargs={"pk": self.object.id})
 
 
 class StudyListView(

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -1074,13 +1074,13 @@ class ExperimentRunnerRedirect(
         study_type: StudyType = study.study_type
 
         if study_type.is_ember_frame_player:
-            view_name = "exp:efp-study-details"
+            view_name = "exp:efp-study-edit-design"
 
         elif study_type.is_external:
-            view_name = "exp:external-study-details"
+            view_name = "exp:external-study-edit-design"
 
         elif study_type.is_jspsych:
-            view_name = "exp:jspsych-study-details"
+            view_name = "exp:jspsych-study-edit-design"
 
         return redirect(reverse(view_name, kwargs={"pk": study.id}))
 

--- a/studies/templates/studies/experiment_runner/base.html
+++ b/studies/templates/studies/experiment_runner/base.html
@@ -33,7 +33,7 @@
             <div class="card bg-light my-4">
                 <div class="card-header">
                     <h3 class="card-subtitle my-1">
-                        Study Details
+                        Edit Study Design
                         <div class="float-end me-4">
                             {% bootstrap_button bs_icon_play_circle|add:"Preview Study" href=url_preview_detail button_class=btn_secondary_classes %}
                         </div>

--- a/studies/templates/studies/study_detail.html
+++ b/studies/templates/studies/study_detail.html
@@ -143,9 +143,9 @@
                 {% endif %}
                 {% if can_edit_study_details %}
                     <a class="list-group-item list-group-item-action"
-                       href="{% url 'exp:study-edit' pk=study.id %}">{% bs_icon "megaphone-fill" %}Study Ad and Recruitment</a>
+                       href="{% url 'exp:study-edit' pk=study.id %}">{% bs_icon "megaphone-fill" %}Edit Study Ad</a>
                     <a class="list-group-item list-group-item-action"
-                       href="{% url 'exp:study-details' pk=study.id %}">{% bs_icon "pencil-square" %}Study Details</a>
+                       href="{% url 'exp:study-edit-design' pk=study.id %}">{% bs_icon "pencil-square" %}Edit Study Design</a>
                 {% endif %}
                 {% if "read_study__responses" in study_perms or "read_study__responses(is_preview=True)" in study_perms %}
                     <a class="list-group-item list-group-item-action"

--- a/studies/templates/studies/study_edit.html
+++ b/studies/templates/studies/study_edit.html
@@ -36,7 +36,7 @@
             <div class="card bg-light my-4">
                 <div class="card-header">
                     <h3 class="card-subtitle my-1">
-                        Study Ad and Recruitment
+                        Edit Study Ad
                         <div class="float-end me-4">
                             {% bootstrap_button bs_icon_play_circle|add:"Preview Study" href=url_preview_detail button_class=btn_secondary_classes %}
                         </div>

--- a/web/templates/web/faq.html
+++ b/web/templates/web/faq.html
@@ -192,15 +192,15 @@
                 <p>Some studies ask you (the parent or guardian) to sign an online form after either reading about what the study involves or talking with a researcher. Other studies, especially ones that happen on our own Children Helping Science platform, ask that you read aloud (or sign in ASL) a statement of consent which is recorded using your webcam. This statement holds the same weight as a signed form, but should be less hassle for you. It also lets us verify that you understand written English and that you understand you're being videotaped.</p>
                 <p>Researchers watch these consent videos on a special page of the researcher interface, and record for each one whether the video shows informed consent. They cannot view other video or download data from a session unless they have confirmed that you consented to participate! If they see a consent video that does NOT clearly demonstrate informed consent--for instance, there was a technical problem and there's no audio--they may contact you to check, depending on your email settings.</p>
                 {% endblocktranslate %}
-                <div class="d-flex justify-content-center">
-                    <video controls preload="metadata">
-                        <source src="{% static video_consent_mp4 %}" type="video/mp4" />
-                        <track label="{{ captions_label }}" 
-                            kind="captions"
-                            srclang="en"
-                            src="{% static captions_src %}" />
-                    </video>
-                </div>
+                    <div class="d-flex justify-content-center">
+                        <video controls preload="metadata">
+                            <source src="{% static video_consent_mp4 %}" type="video/mp4" />
+                            <track label="{{ captions_label }}"
+                                   kind="captions"
+                                   srclang="en"
+                                   src="{% static captions_src %}" />
+                        </video>
+                    </div>
                 </div>
             </div>
         </div>

--- a/web/urls.py
+++ b/web/urls.py
@@ -79,10 +79,10 @@ urlpatterns = [
     ),
     path("", TemplateView.as_view(template_name="web/home.html"), name="home"),
     path(
-        "faq/", 
-        views.FaqView.as_view(), 
+        "faq/",
+        views.FaqView.as_view(),
         name="faq",
-        ),
+    ),
     path(
         "privacy/",
         TemplateView.as_view(template_name="web/privacy.html"),

--- a/web/views.py
+++ b/web/views.py
@@ -842,18 +842,19 @@ class ScientistsView(generic.TemplateView):
 
         return context
 
+
 class FaqView(generic.TemplateView):
     template_name = "web/faq.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        if get_language() == 'ja':
-            context["video_consent_mp4"] = 'videos/consent_ja.mp4' 
-            context["captions_label"] = ''
-            context["captions_src"] = ''
+        if get_language() == "ja":
+            context["video_consent_mp4"] = "videos/consent_ja.mp4"
+            context["captions_label"] = ""
+            context["captions_src"] = ""
         else:
-            context["video_consent_mp4"] = 'videos/consent.mp4' 
-            context["captions_label"] = 'English'
-            context["captions_src"] = 'videos/english/consent.vtt'
+            context["video_consent_mp4"] = "videos/consent.mp4"
+            context["captions_label"] = "English"
+            context["captions_src"] = "videos/english/consent.vtt"
 
         return context


### PR DESCRIPTION
### Summary

The copy on a few study edit buttons was confusing.  This PR changes that copy. 

Closes #1378 

### Implementation

The card titles and buttons were updated as requested.  The URL `name` attribute was also updated to reflect the copy. 

### Images

jsPsych study type:

<img width="1339" alt="Screenshot 2024-04-11 at 11 31 47 AM" src="https://github.com/lookit/lookit-api/assets/44074998/845db400-e488-4a76-a1cf-fc6fdf0e61b4">
<img width="1339" alt="Screenshot 2024-04-11 at 11 31 56 AM" src="https://github.com/lookit/lookit-api/assets/44074998/fba9efe8-d1b6-4e6a-9a30-dd6488c24531">
<img width="1339" alt="Screenshot 2024-04-11 at 11 31 50 AM" src="https://github.com/lookit/lookit-api/assets/44074998/b9560623-a72c-43e5-9629-712cb9aa8383">

Internal study type:

<img width="1339" alt="Screenshot 2024-04-11 at 11 31 13 AM" src="https://github.com/lookit/lookit-api/assets/44074998/c7ad613e-f512-47bf-9377-623665093eb1">
<img width="1339" alt="Screenshot 2024-04-11 at 11 31 24 AM" src="https://github.com/lookit/lookit-api/assets/44074998/5e10ccab-9b1f-4a4c-9a9b-d8a5e1228645">
<img width="1339" alt="Screenshot 2024-04-11 at 11 31 17 AM" src="https://github.com/lookit/lookit-api/assets/44074998/e14a12fe-0070-44e0-b5b0-9b39a4d66b6f">

External study type:

<img width="1339" alt="Screenshot 2024-04-11 at 11 30 43 AM" src="https://github.com/lookit/lookit-api/assets/44074998/ba605ba5-7322-4db5-bf73-0252240bc776">
<img width="1339" alt="Screenshot 2024-04-11 at 11 30 56 AM" src="https://github.com/lookit/lookit-api/assets/44074998/9a38f827-6e84-4138-a4d9-ba4a74135d52">
<img width="1339" alt="Screenshot 2024-04-11 at 11 30 49 AM" src="https://github.com/lookit/lookit-api/assets/44074998/f98a93fb-505f-418f-bdd9-787446cd95c7">



