### PR TITLE
Sentry: AttributeError  /2fa-login/

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -91,7 +91,7 @@ class TOTPCheckForm(forms.Form):
     def clean_otp_code(self):
         """Validation check on OTP code."""
         otp_code = self.cleaned_data["otp_code"]
-        if self.otp.verify(otp_code):
+        if self.otp and self.otp.verify(otp_code):
             return otp_code
         else:
             raise forms.ValidationError(


### PR DESCRIPTION
# Summary
[Sentry Issue](https://massachusetts-institute-of-technology.sentry.io/issues/5080130387/events/e7fdbc7ab1a94a69acfe53220c32b894/)

This PR adds a check before verifying OTP.  I am not entirely sure why this is happening, but it's simple enough to check if the OTP object not None before the verify.  
