### PR TITLE
Sentry: KeyError  /studies/

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -500,7 +500,7 @@ class StudyListSearchForm(forms.Form):
 
     def clean(self):
         cleaned_data = super().clean()
-        child = cleaned_data["child"]
+        child = cleaned_data.get("child")
         if (
             not child
             or "," in child

--- a/accounts/tests/test_forms.py
+++ b/accounts/tests/test_forms.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+
+from accounts.forms import StudyListSearchForm
+
+
+class StudyListSearchFormTestCase(TestCase):
+    def test_none_child(self):
+        form = StudyListSearchForm(data={})
+
+        # Confirm form has no error and is valid
+        self.assertFalse(form.errors)
+        self.assertTrue(form.is_valid())
+
+        # Remove child from cleaned data
+        del form.cleaned_data["child"]
+
+        # confirm clean doesn't throw an error
+        self.assertTrue(form.clean())


### PR DESCRIPTION
# Summary

[Sentry Issue](https://massachusetts-institute-of-technology.sentry.io/issues/3005539080/events/d27ab00de892428ab5edd21f65563da0/)

If there's no key value "Child" on data, then it'll throw a `KeyError`.  Using dictionary's get method should solve this problem. 

