### PR TITLE
Bug fix for null values of ConsentRuling model

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -1075,7 +1075,7 @@ class Response(models.Model):
     @property
     def most_recent_ruling_comment(self):
         ruling = self._get_recent_consent_ruling()
-        return ruling.comments if ruling else None
+        return ruling.comments if ruling and ruling.comments else None
 
     @property
     def comment_or_reason_for_absence(self):
@@ -1096,7 +1096,7 @@ class Response(models.Model):
     @property
     def most_recent_ruling_arbiter(self):
         ruling = self._get_recent_consent_ruling()
-        return ruling.arbiter.get_full_name() if ruling else None
+        return ruling.arbiter.get_full_name() if ruling and ruling.arbiter else None
 
     @property
     def current_consent_details(self):


### PR DESCRIPTION
This is a small addition of conditionals to two lines in the most_recent_ruling_comment and most_recent_ruling_arbiter functions of the Response data model. The model specifies that both fields are allowable as null, so the conditionals account for this by checking that they are not none before trying to access their properties.