### PR TITLE
Fix Video.DoesNotExist error when deleting videos from cloud

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -1457,8 +1457,9 @@ def delete_video_on_s3(sender, instance, using, **kwargs):
 
     Do this in a pre_delete hook rather than a custom delete function because this will
     be called when cascading deletion from responses."""
+    video_in_pipe_bucket = instance.recording_method_is_pipe
     delete_video_from_cloud.apply_async(
-        args=(instance.full_name,), countdown=60 * 60 * 24 * 7
+        args=(instance.full_name, video_in_pipe_bucket), countdown=60 * 60 * 24 * 7
     )  # Delete after 1 week.
 
 

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -25,7 +25,6 @@ from django.utils import timezone
 from google.cloud import storage as gc_storage
 from more_itertools import chunked, first, flatten, groupby_transform, map_reduce
 
-import studies.models
 from accounts.models import Child, Message, User
 from accounts.queries import get_child_eligibility_for_study
 from project.celery import app
@@ -478,15 +477,12 @@ def build_framedata_dict(filename, study_uuid, requesting_user_uuid):
 
 
 @app.task(bind=True)
-def delete_video_from_cloud(task, s3_video_name):
+def delete_video_from_cloud(task, s3_video_name, recording_method_is_pipe):
     """Delete videos in S3.
 
     Meant to have a delay of about 7 days.
     """
-    video_in_pipe_bucket = studies.models.Video.objects.get(
-        full_name=s3_video_name
-    ).recording_method_is_pipe
-    if video_in_pipe_bucket:
+    if recording_method_is_pipe:
         # delete from Pipe bucket
         S3_RESOURCE.Object(settings.BUCKET_NAME, s3_video_name).delete()
     else:


### PR DESCRIPTION
Fixes #1430

This PR fixes the Video.DoesNotExist error that we're getting in the celery `delete_video_from_cloud` task. The error is happening because the delete video task is running after the video object has been deleted, but then the code inside the task is trying to reference the deleted video object. The video object is being referenced in order to figure out which AWS bucket to delete the video from. So instead of looking for that information inside the task code, we can pass it in as an argument when the task is first set up.

**Implementation notes:**
- When jsPsych studies are added, we will have 3 possibilities for video storage buckets. Thus the current "pipe or not pipe" logic for the `delete_video_from_cloud` task will need to change. We could either change the `recording_method_is_pipe` argument to a non-boolean that can be 1 of 3 values that indicate which bucket to delete from, or we could add a separate argument for something like `study_type_is_jspsych`.
- As mentioned in #1430, another way to solve this problem would be to delete the video object at the same time as the S3 video. However, since we're going for the soft delete option for the raw video, we'd have to also keep the video object in the DB for that same period. The problems with this approach are that (1) currently the video deletion cascades from the response deletion, so we would need to set up a delay for the video object deletion separate from the response deletion (or delay response deletion), and (2) the site will continue to pick up video objects that exist in the DB even if they've been set up for future deletion, so it will appear to users as if the delete action didn't work. Instead, we want to delete the video from the DB immediately so that users can see the effect. 

**Testing:**
- The to-be-deleted video exists in the DB but not in S3 
- Needs testing on staging