### PR TITLE
Fix issue when attempting to review jspsych study

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ collectstatic:
 	docker compose run --rm web poetry run ./manage.py collectstatic --clear --noinput
 
 poetry:
-	poetry check && poetry install --sync --no-root
+	poetry self update
+	poetry check 
+	poetry install --sync --no-root
 
 lint: poetry 
 	poetry run pre-commit run --all-files

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -20,7 +20,7 @@ from django.views import generic
 from django.views.generic.detail import SingleObjectMixin
 from revproxy.views import ProxyView
 
-from accounts.models import Child, DemographicData, User
+from accounts.models import Child, User
 from exp.mixins.paginator_mixin import PaginatorMixin
 from exp.views.mixins import (
     ResearcherAuthenticatedRedirectMixin,
@@ -38,7 +38,7 @@ from studies.forms import (
     StudyEditForm,
 )
 from studies.helpers import send_mail
-from studies.models import Response, Study, StudyType
+from studies.models import Study, StudyType
 from studies.permissions import LabPermission, StudyPermission
 from studies.queries import get_study_list_qs
 from studies.tasks import ember_build_and_gcp_deploy
@@ -50,7 +50,7 @@ from studies.workflow import (
     TRANSITION_HELP_TEXT,
     TRANSITION_LABELS,
 )
-from web.views import create_external_response, get_external_url
+from web.views import create_external_response, get_external_url, get_jspsych_response
 
 
 class DiscoverabilityKey(NamedTuple):
@@ -915,18 +915,7 @@ class JsPsychPreviewView(
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        study = self.object
-        child_uuid = context["view"].kwargs["child_id"]
-        child = Child.objects.get(uuid=child_uuid)
-        demo = DemographicData.objects.filter(user=child.user).first()
-        response = Response.objects.create(
-            study=study,
-            child=child,
-            demographic_snapshot=demo,
-            is_preview=True,
-            exp_data=[],
-        )
-
+        response = get_jspsych_response(context, is_preview=True)
         context.update(response=response)
 
         return context

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -171,7 +171,7 @@ class FrameActionDispatcher(object):
 
         if response.study_type.is_jspsych:
             exp_data = response.exp_data[-1]
-            frame_data = exp_data["response"]
+            frame_data = exp_data.get("response")
             frame_type = exp_data.get("chs_type")
         elif response.study_type.is_ember_frame_player:
             frame_data = response.exp_data[current_frame_id]

--- a/web/views.py
+++ b/web/views.py
@@ -93,6 +93,21 @@ def get_external_url(study: Study, response: Response) -> Text:
     return url.geturl()
 
 
+def get_jspsych_response(context, is_preview=False):
+    study = context["study"]
+    child_uuid = context["view"].kwargs["child_id"]
+    child = Child.objects.get(uuid=child_uuid)
+    demo = child.user.latest_demographics
+    return Response.objects.create(
+        study=study,
+        child=child,
+        demographic_snapshot=demo,
+        exp_data=[],
+        is_preview=is_preview,
+        study_type=study.study_type,
+    )
+
+
 class ParticipantSignupView(generic.CreateView):
     """
     Allows a participant to sign up. Redirects them to a page to add their demographic data.
@@ -820,18 +835,7 @@ class JsPsychExperimentView(
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        study = context["study"]
-        child_uuid = context["view"].kwargs["child_id"]
-        child = Child.objects.get(uuid=child_uuid)
-        demo = child.user.latest_demographics
-        response = Response.objects.create(
-            study=study,
-            child=child,
-            demographic_snapshot=demo,
-            exp_data=[],
-            study_type=study.study_type,
-        )
-
+        response = get_jspsych_response(context)
         context.update(response=response)
 
         return context


### PR DESCRIPTION
# Summary

A quick PR to fix an issue found with reviewing JsPsych studies.  

# Explanation

When we start any experiment, we also create a response.  If you make a response and don't set the study type, it will default to E.F.P. even though you have provided a study.  When creating JsPsych studies, I created the response and stated the study type but forgot to update when a researcher would review a study.  These are two different views.  This PR places the creation of a response for a JsPsych study into a single function.