### PR TITLE
Jspsych framedata psychds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,9 @@ collectstatic:
 	docker compose run --rm web poetry run ./manage.py collectstatic --clear --noinput
 
 poetry:
-	poetry self update
 	poetry check 
+	poetry self update
+	poetry env use 3.9
 	poetry install --sync --no-root
 
 lint: poetry 

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -226,7 +226,13 @@ def get_frame_data(resp: Union[Response, Dict]) -> List[FrameDataRow]:
         exp_data. Descriptions of each field of the FrameDataRow are given in FRAME_DATA_HEADER_DESCRIPTIONS.
     """
 
-    if not isinstance(resp, dict):
+    if isinstance(resp, Response):
+        # Where study type is jspysch, convert experiment data to format expected below.
+        if resp.study_type.is_jspsych:
+            resp.exp_data = {
+                key: value for key, value in zip(resp.sequence, resp.exp_data)
+            }
+
         resp = {
             "child__uuid": resp.child.uuid,
             "study__uuid": resp.study.uuid,

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -227,19 +227,13 @@ def get_frame_data(resp: Union[Response, Dict]) -> List[FrameDataRow]:
     """
 
     if isinstance(resp, Response):
-        # Where study type is jspysch, convert experiment data to format expected below.
-        if resp.study_type.is_jspsych:
-            resp.exp_data = {
-                key: value for key, value in zip(resp.sequence, resp.exp_data)
-            }
-
         resp = {
             "child__uuid": resp.child.uuid,
             "study__uuid": resp.study.uuid,
             "study__salt": resp.study.salt,
             "study__hash_digits": resp.study.hash_digits,
             "uuid": resp.uuid,
-            "exp_data": resp.exp_data,
+            "exp_data": resp.normalized_exp_data,
             "global_event_timings": resp.global_event_timings,
         }
 

--- a/studies/models.py
+++ b/studies/models.py
@@ -1174,6 +1174,14 @@ class Response(models.Model):
         else:
             return None
 
+    @property
+    def normalized_exp_data(self):
+        # Where study type is jspysch, convert experiment data to resemble EFP exp data.
+        if self.study_type.is_jspsych:
+            return {key: value for key, value in zip(self.sequence, self.exp_data)}
+        else:
+            return self.exp_data
+
     def generate_videos_from_events(self):
         """Creates the video containers/representations for this given response.
 


### PR DESCRIPTION
Closes #1467

# Summary

When attempting to download PsychDS formatted data for a jsPsych experiment, the site would throw 500.  The issue is how the jsPsych experiment data is formatted.  This was easily solved by converting the sequence and experiment data into a dictionary and providing it to PsychDS.  