### PR TITLE
Remove unnecessary ".csv" in filename

### DIFF
--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1405,7 +1405,7 @@ class StudyChildrenCSV(ResponseDownloadMixin, generic.list.ListView):
         writer.writerows(session_list)
         cleaned_data = output.getvalue()
 
-        filename = "all-children{}.csv".format(
+        filename = "all-children{}".format(
             ("-identifiable" if IDENTIFIABLE_DATA_HEADERS & header_options else ""),
         )
         filename = csv_filename(study, filename)


### PR DESCRIPTION
Closes #1468

# Summary

The file download by clicking the "CSV" button in the "Child Data" section of the "All Responses" view would have a double extension.  This PR changes ".csv.csv" to ".csv".
