### PR TITLE
AWS video upload credentials for jsPsych studies

### DIFF
--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -918,17 +918,26 @@ class JsPsychPreviewView(
 
     test_func = can_preview
 
-    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        context = super().get_context_data(**kwargs)
-        response = get_jspsych_response(context, is_preview=True)
+    def get(self, request, *args, **kwargs):
+        # Need to check for AWS variables here instead of get_context_data, so that we can redirect if there's an error.
         aws_vars = get_jspsych_aws_values()
         if aws_vars is None:
             messages.error(
                 self.request,
                 "There was an error starting this study. Please contact lookit@mit.edu.",
             )
+            return redirect(
+                reverse("exp:preview-detail", kwargs={"uuid": self.get_object().uuid})
+            )
+
+        self.aws_vars = aws_vars
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        response = get_jspsych_response(context, is_preview=True)
         context.update(response=response)
-        context.update({"aws_vars": aws_vars})
+        context.update({"aws_vars": self.aws_vars})
         return context
 
 

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -920,8 +920,8 @@ class JsPsychPreviewView(
 
     def get(self, request, *args, **kwargs):
         # Need to check for AWS variables here instead of get_context_data, so that we can redirect if there's an error.
-        aws_vars = get_jspsych_aws_values()
-        if aws_vars is None:
+        self.aws_vars = get_jspsych_aws_values()
+        if self.aws_vars is None:
             messages.error(
                 self.request,
                 "There was an error starting this study. Please contact lookit@mit.edu.",
@@ -930,7 +930,6 @@ class JsPsychPreviewView(
                 reverse("exp:preview-detail", kwargs={"uuid": self.get_object().uuid})
             )
 
-        self.aws_vars = aws_vars
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -50,7 +50,12 @@ from studies.workflow import (
     TRANSITION_HELP_TEXT,
     TRANSITION_LABELS,
 )
-from web.views import create_external_response, get_external_url, get_jspsych_response
+from web.views import (
+    create_external_response,
+    get_external_url,
+    get_jspsych_aws_values,
+    get_jspsych_response,
+)
 
 
 class DiscoverabilityKey(NamedTuple):
@@ -916,8 +921,14 @@ class JsPsychPreviewView(
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         response = get_jspsych_response(context, is_preview=True)
+        aws_vars = get_jspsych_aws_values()
+        if aws_vars is None:
+            messages.error(
+                self.request,
+                "There was an error starting this study. Please contact lookit@mit.edu.",
+            )
         context.update(response=response)
-
+        context.update({"aws_vars": aws_vars})
         return context
 
 

--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -5,6 +5,7 @@
         <meta name="description" content="">
         <meta name="keywords" content="">
         <title>My experiment</title>
+        {{ aws_vars|json_script:"aws-vars" }}
         <script src="https://unpkg.com/jspsych@8.0.2"
                 integrity="sha384-Jv5oCjRKoeC3ZAbZHoc9+PbvlVKc6wIr1furnITdjHLbmxoC/tu+9cXzONlMoDEY"
                 crossorigin="anonymous"></script>

--- a/web/views.py
+++ b/web/views.py
@@ -902,7 +902,7 @@ class JsPsychExperimentView(
                 "There was an error starting this study. Please contact lookit@mit.edu.",
             )
             return redirect(
-                reverse("exp:preview-detail", kwargs={"uuid": self.get_object().uuid})
+                reverse("web:study-detail", kwargs={"uuid": self.get_object().uuid})
             )
 
         self.aws_vars = aws_vars

--- a/web/views.py
+++ b/web/views.py
@@ -893,17 +893,26 @@ class JsPsychExperimentView(
 
     test_func = user_can_participate
 
-    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        context = super().get_context_data(**kwargs)
-        response = get_jspsych_response(context)
+    def get(self, request, *args, **kwargs):
+        # Need to check for AWS variables here instead of get_context_data, so that we can redirect if there's an error.
         aws_vars = get_jspsych_aws_values()
         if aws_vars is None:
             messages.error(
                 self.request,
                 "There was an error starting this study. Please contact lookit@mit.edu.",
             )
+            return redirect(
+                reverse("exp:preview-detail", kwargs={"uuid": self.get_object().uuid})
+            )
+
+        self.aws_vars = aws_vars
+        return super().get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        response = get_jspsych_response(context)
         context.update(response=response)
-        context.update({"aws_vars": aws_vars})
+        context.update({"aws_vars": self.aws_vars})
         return context
 
 

--- a/web/views.py
+++ b/web/views.py
@@ -895,8 +895,8 @@ class JsPsychExperimentView(
 
     def get(self, request, *args, **kwargs):
         # Need to check for AWS variables here instead of get_context_data, so that we can redirect if there's an error.
-        aws_vars = get_jspsych_aws_values()
-        if aws_vars is None:
+        self.aws_vars = get_jspsych_aws_values()
+        if self.aws_vars is None:
             messages.error(
                 self.request,
                 "There was an error starting this study. Please contact lookit@mit.edu.",
@@ -905,7 +905,6 @@ class JsPsychExperimentView(
                 reverse("web:study-detail", kwargs={"uuid": self.get_object().uuid})
             )
 
-        self.aws_vars = aws_vars
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:


### PR DESCRIPTION
This PR generates temporary AWS credentials and passes them into the jsPsych study template, where they can be retrieved and used by the lookit-jspsych `data` package. We're using the maximum duration for these credentials, which is 36 hours.

**Screenshots**

The temporary AWS credentials have to be requested each time a user tries to start a jsPsych study. If for some reason there's an error obtaining those credentials, the user is redirected back to the study/preview details page, and they'll see an error message.

![Screenshot 2024-10-28 at 11 51 13 AM](https://github.com/user-attachments/assets/b103deeb-a308-40b1-bb32-af5022409b4c)

