### PR TITLE
Add jsPsych `video-button-response` plugin

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -21,6 +21,9 @@
         <script src="https://unpkg.com/@jspsych/plugin-image-button-response@2.0.0"
                 integrity="sha384-akngF9Va8sW0TdFvi4EsfM6SGOE94o2XZ+n99/QKYbVhdUEvX1h/OJdfa8yRoEPX"
                 crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/@jspsych/plugin-video-button-response@2.0.0"
+                integrity="sha384-u1N4HtXTAx8IPaZxRLKurCoPhFnSQ+TrF+33Lr1ORBhnRogBnU8Fd7tbPkFh1uUj"
+                crossorigin="anonymous"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@2.0.0"
                 integrity="sha384-veBuhHbf5WLQIFlG9N6a+5E/kRYJcBTDKkqJRTkc7wuGwptljsBa2fYuTseMkOBI"
                 crossorigin="anonymous"></script>


### PR DESCRIPTION
This PR adds the jsPsych `video-button-response` plugin to the set of automatically loaded plugins for jsPsych studies.