### PR TITLE
Disable zip video download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,7 @@ RUN apt-get update \
     && gosu nobody true \
     && update-ca-certificates \
     && pip install -U pip wheel setuptools \
-    && curl https://install.python-poetry.org > /tmp/install-poetry.py \
-    && python /tmp/install-poetry.py \ 
+    && curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4 \
     && poetry config virtualenvs.create false \
     && poetry install --no-dev \
-    && python manage.py compilemessages \
-    && rm /tmp/install-poetry.py
+    && python manage.py compilemessages 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -18,5 +18,5 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -sSL https://install.python-poetry.org | python3 - \
+    && curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4 \
     && poetry install

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ collectstatic:
 
 poetry:
 	poetry check 
-	poetry self update
+	poetry self update 1.8.4
 	poetry env use 3.9
 	poetry install --sync --no-root
 

--- a/studies/templates/studies/study_attachments.html
+++ b/studies/templates/studies/study_attachments.html
@@ -37,11 +37,14 @@
     <div class="row">
         <div class="col-12">
             <span class="text-end">
+                {% comment %}
+                {# TODO: When the zip video files task has been fixed, this comment should be removed. #}
                 <form method="post">
                     {% csrf_token %}
                     {% bootstrap_button "Download all videos" button_class=btn_primary_classes button_type="submit" name="all-attachments" value="all" %}
                     {% bootstrap_button "Download all consent videos" button_class=btn_primary_classes button_type="submit" name="all-consent-videos" value="all" %}
                 </form>
+                {% endcomment %}
             </span>
         </div>
     </div>


### PR DESCRIPTION
# Summary
This PR will disable the ability to zip an experiment's video files.  This is in response to the issues with our site going down randomly.  Once we've redesigned the zipping videos celery task, these buttons should be re-enabled.

