### PR TITLE
Key error in incomplete videos task

### DIFF
--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -522,10 +522,10 @@ def get_all_incomplete_video_files():
             Bucket=settings.S3_BUCKET_NAME
         )
     except ClientError as error:
-        logger.error(f"Failed to list multipart uploads: {error}")
+        logger.error(f"Failed to list multipart uploads due to a ClientError: {error}")
         raise error
     except ParamValidationError as error:
-        logger.error("Failed to list multipart uploads")
+        logger.error("Failed to list multipart uploads due to a ParamValidationError")
         raise ValueError(f"The parameters you provided are incorrect: {error}")
 
     if uploads_response is not None and "Uploads" in uploads_response:

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -538,6 +538,10 @@ def get_all_incomplete_video_files():
                 > datetime.timedelta(hours=24)
             )
         ]
+    else:
+        logger.debug(
+            f"Uploads key not found in list of multipart uploads for bucket {settings.S3_BUCKET_NAME}: {uploads_response}"
+        )
 
     return incomplete_uploads
 

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -526,7 +526,7 @@ def get_all_incomplete_video_files():
     except ParamValidationError as error:
         raise ValueError(f"The parameters you provided are incorrect: {error}")
 
-    if uploads_response["Uploads"]:
+    if "Uploads" in uploads_response:
         # Filter out incomplete uploads that might still be actively recording - started in last 24 hours.
         # The upload's 'Initiated' value is a datetime in UTC timezone.
         uploads_list = uploads_response["Uploads"]

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -522,11 +522,13 @@ def get_all_incomplete_video_files():
             Bucket=settings.S3_BUCKET_NAME
         )
     except ClientError as error:
+        logger.error(f"Failed to list multipart uploads: {error}")
         raise error
     except ParamValidationError as error:
+        logger.error("Failed to list multipart uploads")
         raise ValueError(f"The parameters you provided are incorrect: {error}")
 
-    if "Uploads" in uploads_response:
+    if uploads_response is not None and "Uploads" in uploads_response:
         # Filter out incomplete uploads that might still be actively recording - started in last 24 hours.
         # The upload's 'Initiated' value is a datetime in UTC timezone.
         uploads_list = uploads_response["Uploads"]

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -527,6 +527,9 @@ def get_all_incomplete_video_files():
     except ParamValidationError as error:
         logger.error("Failed to list multipart uploads due to a ParamValidationError")
         raise ValueError(f"The parameters you provided are incorrect: {error}")
+    except Exception as error:
+        logger.error("Failed to list multipart uploads: Unknown error type")
+        raise error
 
     if uploads_response is not None and "Uploads" in uploads_response:
         # Filter out incomplete uploads that might still be actively recording - started in last 24 hours.

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -561,12 +561,26 @@ def get_file_parts(filename, id):
             Bucket=settings.S3_BUCKET_NAME, Key=filename, UploadId=id
         )
     except ClientError as error:
-        logger.debug(f"Error completing file {filename}: {error}")
+        logger.error(
+            f"Failed to list file parts for file {filename} due to a ClientError: {error}"
+        )
         raise error
     except ParamValidationError as error:
+        logger.error(
+            f"Failed to list file parts for file {filename} ParamValidationError"
+        )
         raise ValueError(f"The parameters you provided are incorrect: {error}")
+    except Exception as error:
+        logger.error(
+            f"Failed to list file parts for file {filename}: Unknown error type"
+        )
+        raise error
 
-    if "Parts" in file_parts_response and file_parts_response["Parts"]:
+    if (
+        file_parts_response is not None
+        and "Parts" in file_parts_response
+        and file_parts_response["Parts"]
+    ):
         parts = [
             {"PartNumber": part["PartNumber"], "ETag": eval(part["ETag"])}
             for part in file_parts_response["Parts"]

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -1865,7 +1865,7 @@ class TestCompleteMultipartUpload(TestCase):
         )
 
         # complete_multipart_upload should log this error but not raise it
-        mock_logger.debug.assert_called_with(
+        mock_logger.error.assert_called_with(
             "Error completing file example_video.webm: An error occurred (EntityTooSmall) when calling the CompleteMultipartUpload operation: Your proposed upload is smaller than the minimum allowed size"
         )
 


### PR DESCRIPTION
Fixes #1495

This PR fixes a key error in the "cleanup incomplete videos" task, which was caused by the "Uploads" key not existing in the AWS API response. 

First, this changes the conditional statement to prevent the error from being thrown when "Uploads" does not exist in the response. 

Second, this adds a log statement with the response when it doesn't contain the "Uploads" key, so that I can figure out when/why this happens. Once I have that information, I should be able to remove the log message and handle this case another way.