### PR TITLE
change filename of psychdsignore in response download

### DIFF
--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -566,7 +566,7 @@ def build_zip_for_psychds(
         )
         # save psychds-ignore file to avoid NOT_INCLUDED warnings
         zipped.writestr(
-            "/.psychdsignore",
+            "/.psychds-ignore",
             PSYCHDS_IGNORE_STR,
         )
         study_ad = {


### PR DESCRIPTION
This is a one-line change to the psych-DS response download function, with the name of the generated ignore file being changed from .psychdsignore to .psychds-ignore