### PR TITLE
Individual response info box

### DIFF
--- a/exp/views/contact.py
+++ b/exp/views/contact.py
@@ -134,6 +134,14 @@ class StudyParticipantContactView(
 
         return ctx
 
+    def get_initial(self):
+        initial = super().get_initial()
+        recipient = self.request.GET.get("recipient", "")
+
+        initial.update({"recipients": [recipient]})
+
+        return initial
+
     def post(self, request, *args, **kwargs):
         """Handles saving message and sending email.
 

--- a/exp/views/contact.py
+++ b/exp/views/contact.py
@@ -186,7 +186,7 @@ class StudyParticipantContactView(
                     email, update the selection in the Recipients Filter and 
                     re-select the family ID.""",
                 )
-        except ValidationError:
+        except (ValidationError, User.DoesNotExist):
             pass
 
         return super().get(request, *args, **kwargs)

--- a/exp/views/contact.py
+++ b/exp/views/contact.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.forms import ValidationError
 from django.http import HttpResponseRedirect
 from django.shortcuts import reverse
 from django.utils.text import slugify
@@ -170,3 +171,22 @@ class StudyParticipantContactView(
         return HttpResponseRedirect(
             reverse("exp:study-participant-contact", kwargs=dict(pk=study.pk))
         )
+
+    def get(self, request, *args, **kwargs):
+        recipient_uuid = request.GET.get("recipient")
+
+        try:
+            user = User.objects.get(uuid=recipient_uuid)
+
+            if not user.email_next_session:
+                messages.warning(
+                    request,
+                    f"""User "{user.nickname or user.username}" has opted out of 
+                    these types of emails.  If you wish to send another type of 
+                    email, update the selection in the Recipients Filter and 
+                    re-select the family ID.""",
+                )
+        except ValidationError:
+            pass
+
+        return super().get(request, *args, **kwargs)

--- a/exp/views/contact.py
+++ b/exp/views/contact.py
@@ -178,7 +178,7 @@ class StudyParticipantContactView(
         try:
             user = User.objects.get(uuid=recipient_uuid)
 
-            if not user.email_next_session:
+            if not user.email_response_questions:
                 messages.warning(
                     request,
                     f"""User "{user.nickname or user.username}" has opted out of 

--- a/scss/study-responses.scss
+++ b/scss/study-responses.scss
@@ -11,3 +11,11 @@ tr.preview-row {
 .list-group-hover .list-group-item:hover:not(.active) {
     background-color: $hovergray;
 }
+
+.truncate-parent-feedback {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical
+}

--- a/studies/templates/studies/study_participant_contact.html
+++ b/studies/templates/studies/study_participant_contact.html
@@ -98,8 +98,7 @@
                                    name="btnradio"
                                    id="btnradio1"
                                    autocomplete="off"
-                                   data-filter="next-session"
-                                   checked />
+                                   data-filter="next-session" />
                             <label class="btn btn-outline-secondary" for="btnradio1">{% bs_icon "calendar2-check" %}</label>
                             <input type="radio"
                                    class="btn-check"
@@ -120,7 +119,8 @@
                                    name="btnradio"
                                    id="btnradio4"
                                    autocomplete="off"
-                                   data-filter="response-questions" />
+                                   data-filter="response-questions"
+                                   checked />
                             <label class="btn btn-outline-secondary" for="btnradio4">{% bs_icon "chat" %}</label>
                             <input type="radio"
                                    class="btn-check"

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -57,10 +57,11 @@
         <div class="col">
             <div class="card bg-light">
                 <div class="card-body">
-                    <div>Selected response SHORTID (1/31/2025 2:24 PM).</div>
                     <div>
-                        Parent/guardian feedback: had trouble hearing. I wrote a
-                        really long message but it's only to be allowed to go...
+                        Selected response <span class="short-child-id"></span> (<span class="response-date"></span>).
+                    </div>
+                    <div>
+                        Parent/guardian feedback: <span class="parent-feedback"></span>
                     </div>
                     <div>Send a message to this family (EHJEC-kaitlin)</div>
                 </div>

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -61,7 +61,10 @@
                         Selected response <span class="short-child-id"></span> (<span class="response-date"></span>).
                     </div>
                     <div>
-                        Parent/guardian feedback: <span class="parent-feedback"></span>
+                        <div class="truncate-parent-feedback">
+                            <span class="fw-bold">Parent/guardian feedback:</span>
+                            <span class="parent-feedback"></span>
+                        </div>
                     </div>
                     <div>Send a message to this family (EHJEC-kaitlin)</div>
                 </div>

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -66,7 +66,10 @@
                             <span class="parent-feedback"></span>
                         </div>
                     </div>
-                    <div>Send a message to this family (EHJEC-kaitlin)</div>
+                    <a rel="noopener noreferrer"
+                       target="_blank"
+                       class="contact-family"
+                       href="{% url "exp:study-participant-contact" study.id %}">Send a message to this family (<span class="parent-id"></span>)</a>
                 </div>
             </div>
         </div>

--- a/web/static/custom_bootstrap5.css
+++ b/web/static/custom_bootstrap5.css
@@ -31,6 +31,13 @@ tr.preview-row {
 .list-group-hover .list-group-item:hover:not(.active) {
   background-color: #f5f5f5; }
 
+.truncate-parent-feedback {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical; }
+
 /*!
    * Bootstrap  v5.2.0 (https://getbootstrap.com/)
    * Copyright 2011-2022 The Bootstrap Authors

--- a/web/static/js/study-participant-contact.js
+++ b/web/static/js/study-participant-contact.js
@@ -50,22 +50,22 @@ $('#id_recipients').select2({
 });
 
 // 
-document.querySelectorAll("#recipientFilter input").forEach(el =>
-    el.addEventListener("click", event => {
-        $('#id_recipients').val(null).trigger('change');  // Clear recipients field
+// document.querySelectorAll("#recipientFilter input").forEach(el =>
+//     el.addEventListener("click", event => {
+//         $('#id_recipients').val(null).trigger('change');  // Clear recipients field
 
-        // Show appropriate message for filter selected
-        document.querySelectorAll(".msg").forEach(el => el.classList.add('d-none'));
-        document.querySelectorAll(`.msg.${event.target.dataset.filter}`).forEach(el => el.classList.remove('d-none'));
+//         // Show appropriate message for filter selected
+//         document.querySelectorAll(".msg").forEach(el => el.classList.add('d-none'));
+//         document.querySelectorAll(`.msg.${event.target.dataset.filter}`).forEach(el => el.classList.remove('d-none'));
 
-        // Disable recipient if they've opted out of email type
-        document.querySelectorAll(`#id_recipients option:disabled`).forEach(el => el.disabled = false);
-        document.querySelectorAll(`#id_recipients option:not([data-${event.target.dataset.filter}=""])`).forEach(el => el.disabled = true);
+//         // Disable recipient if they've opted out of email type
+//         document.querySelectorAll(`#id_recipients option:disabled`).forEach(el => el.disabled = false);
+//         document.querySelectorAll(`#id_recipients option:not([data-${event.target.dataset.filter}=""])`).forEach(el => el.disabled = true);
 
-    })
-);
-// Initial recipient filter click on page load
-document.querySelector("#recipientFilter input:checked").click();
+//     })
+// );
+// // Initial recipient filter click on page load
+// document.querySelector("#recipientFilter input:checked").click();
 
 // Summernote init/config for email body field
 $('#id_body').summernote({

--- a/web/static/js/study-participant-contact.js
+++ b/web/static/js/study-participant-contact.js
@@ -49,23 +49,29 @@ $('#id_recipients').select2({
     placeholder: "Select Email Recipients",
 });
 
-// 
-// document.querySelectorAll("#recipientFilter input").forEach(el =>
-//     el.addEventListener("click", event => {
-//         $('#id_recipients').val(null).trigger('change');  // Clear recipients field
+// Remove users based on email filter preferences
+document.querySelectorAll("#recipientFilter input").forEach(el =>
+    el.addEventListener("click", event => {
+        // Show appropriate message for filter selected
+        document.querySelectorAll(".msg").forEach(el => el.classList.add('d-none'));
+        document.querySelectorAll(`.msg.${event.target.dataset.filter}`).forEach(el => el.classList.remove('d-none'));
 
-//         // Show appropriate message for filter selected
-//         document.querySelectorAll(".msg").forEach(el => el.classList.add('d-none'));
-//         document.querySelectorAll(`.msg.${event.target.dataset.filter}`).forEach(el => el.classList.remove('d-none'));
+        // Disable recipient if they've opted out of email type
+        document.querySelectorAll(`#id_recipients option:disabled`).forEach(el => el.disabled = false);
+        document.querySelectorAll(`#id_recipients option:not([data-${event.target.dataset.filter}=""])`).forEach(el => el.disabled = true);
 
-//         // Disable recipient if they've opted out of email type
-//         document.querySelectorAll(`#id_recipients option:disabled`).forEach(el => el.disabled = false);
-//         document.querySelectorAll(`#id_recipients option:not([data-${event.target.dataset.filter}=""])`).forEach(el => el.disabled = true);
-
-//     })
-// );
-// // Initial recipient filter click on page load
-// document.querySelector("#recipientFilter input:checked").click();
+        // Get values of selected recipient who aren't disabled from email filter
+        const values = $('#id_recipients').val()
+            .map(s => document.querySelector(`#id_recipients option[value="${s}"]`))
+            .filter(s => !s.disabled)
+            .map(s =>s.value)
+        
+        // Trigger select2 to redraw recipients field
+        $('#id_recipients').val(values).trigger('change');
+    })
+);
+// Initial recipient filter click on page load
+document.querySelector("#recipientFilter input:checked").click();
 
 // Summernote init/config for email body field
 $('#id_body').summernote({

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -85,10 +85,11 @@ function updateInfoBox(index) {
       .join(""))
     .join("-");
   const parentId = `${rows[12].children[1].textContent}-${parentName || "anonymous"}`;
+  const parentUUID = rows[11].children[1].textContent
   
   // Recipient ID for sending message URL
   const url = new URL(document.querySelector('.contact-family').href);
-  url.searchParams.set("recipientId",parentId);
+  url.searchParams.set("recipient",parentUUID);
 
   // Short ID for child
   document.querySelector('.short-child-id').textContent =

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -1,6 +1,7 @@
 $(".selectable-response").first().addClass('selected');
 let currentResponseId = $(".selectable-response").first().data("response-id");
 showResponse(1);
+updateInfoBox(1)
 showFeedbackList(currentResponseId);
 $('form.download [name=response_id]').val(currentResponseId);
 showAttachments(1);
@@ -12,6 +13,7 @@ $('.selectable-response').click(function () {
     $('.selectable-response').removeClass('selected');
     $('#' + id).addClass('selected');
     showResponse(index);
+    updateInfoBox(index);
     showAttachments(index);
     const responseId = $(this).data("response-id");
     $('form.download [name=response_id]').val(responseId);
@@ -67,3 +69,23 @@ const resp_table = $("#individualResponsesTable").DataTable({
 
 // Date Range UI and filter for "Date" column
 setupDataTableDates("individualResponsesTable", 4, "dateRangeFilter");
+
+function updateInfoBox(index) {
+    // Select table rows of response details table.
+    const rows = document
+      .querySelector(`#response-summary-${index}`)
+      .querySelectorAll('table tbody tr');
+  
+    // Short ID for child
+    document.querySelector('.short-child-id').textContent =
+      rows[15].children[1].textContent;
+  
+    // Create date for response with formatted date
+    document.querySelector('.response-date').textContent = moment(
+      rows[2].children[1].textContent
+    ).format('M/D/YYYY h:m A');
+  
+    // Parent Feedback
+    document.querySelector('.parent-feedback').textContent =
+      rows[6].children[1].textContent;
+  }

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -77,7 +77,14 @@ function updateInfoBox(index) {
     .querySelectorAll('table tbody tr');
 
   // construct parent ID
-  const parentId = `${rows[12].children[1].textContent}-${rows[13].children[1].textContent || "anonymous"}`;
+  const parentName = rows[13].children[1].textContent
+    .toLowerCase()
+    .split(" ")
+    .map(el => ([...el]
+      .filter(v => /[a-z\-]/.test(v)))
+      .join(""))
+    .join("-");
+  const parentId = `${rows[12].children[1].textContent}-${parentName || "anonymous"}`;
   
   // Recipient ID for sending message URL
   const url = new URL(document.querySelector('.contact-family').href);

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -71,21 +71,32 @@ const resp_table = $("#individualResponsesTable").DataTable({
 setupDataTableDates("individualResponsesTable", 4, "dateRangeFilter");
 
 function updateInfoBox(index) {
-    // Select table rows of response details table.
-    const rows = document
-      .querySelector(`#response-summary-${index}`)
-      .querySelectorAll('table tbody tr');
+  // Select table rows of response details table.
+  const rows = document
+    .querySelector(`#response-summary-${index}`)
+    .querySelectorAll('table tbody tr');
+
+  // construct parent ID
+  const parentId = `${rows[12].children[1].textContent}-${rows[13].children[1].textContent || "anonymous"}`;
   
-    // Short ID for child
-    document.querySelector('.short-child-id').textContent =
-      rows[15].children[1].textContent;
-  
-    // Create date for response with formatted date
-    document.querySelector('.response-date').textContent = moment(
-      rows[2].children[1].textContent
-    ).format('M/D/YYYY h:m A');
-  
-    // Parent Feedback
-    document.querySelector('.parent-feedback').textContent =
-      rows[6].children[1].textContent;
-  }
+  // Recipient ID for sending message URL
+  const url = new URL(document.querySelector('.contact-family').href);
+  url.searchParams.set("recipientId",parentId);
+
+  // Short ID for child
+  document.querySelector('.short-child-id').textContent =
+    rows[15].children[1].textContent;
+
+  // Create date for response with formatted date
+  document.querySelector('.response-date').textContent = moment(
+    rows[2].children[1].textContent
+  ).format('M/D/YYYY h:m A');
+
+  // Parent Feedback
+  document.querySelector('.parent-feedback').textContent =
+    rows[6].children[1].textContent;
+
+  // Send message to family URL
+  document.querySelector('.parent-id').textContent = parentId;
+  document.querySelector('.contact-family').href = url.toString();
+}


### PR DESCRIPTION
# Summary

The grey info box at the top right side of the individual response view is now updated with selections from the table.  Additionally, the link to contact participants' view will auto-populate the recipients field if their filter allows. 


## Screenshots

<img width="1552" alt="Screenshot 2025-03-04 at 1 01 49 PM" src="https://github.com/user-attachments/assets/d2e8b483-f555-4ea4-ac2a-cc777cde1f3f" />

https://github.com/user-attachments/assets/43ee6a73-7abe-40dc-a92b-385f58de138a

https://github.com/user-attachments/assets/fed09f4c-a207-4804-a879-49995196a8a7
