### PR TITLE
Add "Time Elapsed" column

### DIFF
--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -81,6 +81,7 @@
                                     <th scope="col">Response UUID</th>
                                     <th scope="col">Status</th>
                                     <th scope="col">Date</th>
+                                    <th scope="col">Time Elapsed</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -102,6 +103,7 @@
                                             {% endif %}
                                         </td>
                                         <td>{{ response.response__date_created|date:"n/j/Y g:i A"|default:"N/A" }}</td>
+                                        <td>{{ response.response__date_created|timesince }}</td>
                                     </tr>
                                 {% endfor %}
                             </tbody>

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -43,9 +43,10 @@ function showResponse(index) {
 const resp_table = $("#individualResponsesTable").DataTable({
     order: [[4, 'desc']], // Sort on "Date" column
     columnDefs: [
-        { className: "column-text-search", targets: [1,2,3] }, // add class to text search columns
-        { className: "dt-nowrap", "targets": 4 }, // don't wrap "Date" column
-        { type: "date", targets: 4 } // set type for "Date" column
+        // add class to text search columns
+        { className: "column-text-search", targets: [1,2,3] }, 
+        // For "Date" column, set type and don't wrap "Date" column. For "Time Elapsed" column, sort by "Date" column's data.
+        { className: "dt-nowrap", type: "date", orderData: 4, targets: [4,5] }, 
     ],
     initComplete: function () {
         // Apply the text search to any column with the class "column-text-search"


### PR DESCRIPTION
# Summary

Add column "Time Elapsed" to Individual Response table.  This column is a differently formatted version of the Date column and uses the data from the Date column to sort itself.  It's possible that these two columns could be the same column. 

# Screenshots

<img width="1552" alt="Screenshot 2025-03-06 at 10 43 49 AM" src="https://github.com/user-attachments/assets/ac2c560d-f7a0-43a8-87d6-1fbbd3429191" />
