### PR TITLE
Fixed date field to show correct time based on tz

### DIFF
--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load exp_extras %}
 {% load web_extras %}
+{% load tz %}
 {% load static %}
 {% block title %}
     Responses | {{ study.name }}
@@ -109,7 +110,7 @@
                                                 Incomplete
                                             {% endif %}
                                         </td>
-                                        <td>{{ response.response__date_created|date:"n/j/Y g:i A"|default:"N/A" }}</td>
+                                        <td>{{ response.response__date_created|localtime|date:"n/j/Y g:i A"|default:"N/A" }}</td>
                                         <td>{{ response.response__date_created|timesince }}</td>
                                     </tr>
                                 {% endfor %}

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -122,7 +122,7 @@ function updateInfoBox(index) {
     // Create date for response with formatted date
     document.querySelector('.response-date').textContent = moment(
         rows[2].children[1].textContent
-    ).format('M/D/YYYY h:m A');
+    ).format('M/D/YYYY h:mm A');
 
     // Parent Feedback
     document.querySelector('.parent-feedback').textContent =


### PR DESCRIPTION
# Summary

The date column was showing in the default time zone (EST).  Should not be showing local time.

