### PR TITLE
IR Table: Update database when values change

### DIFF
--- a/exp/urls.py
+++ b/exp/urls.py
@@ -49,6 +49,7 @@ from exp.views import (
     StudyResponsesConsentManager,
     StudyResponsesCSV,
     StudyResponsesDictCSV,
+    StudyResponseSetResearcherFields,
     StudyResponsesFrameDataCSV,
     StudyResponsesFrameDataDictCSV,
     StudyResponsesFrameDataPsychDS,
@@ -287,5 +288,10 @@ urlpatterns = [
         "studies/<int:pk>/design/jspsych/",
         JSPsychEditView.as_view(),
         name="jspsych-study-edit-design",
+    ),
+    path(
+        "studies/<int:pk>/responses/researcher_update/",
+        StudyResponseSetResearcherFields.as_view(),
+        name="study-responses-researcher-update",
     ),
 ]

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1115,12 +1115,9 @@ class StudyResponseSetResearcherFields(
         user = self.request.user
         study = self.study
         # First check user has permission to be editing response from this study - use same permissions as editing feedback
-        if not user.is_researcher and user.has_study_perms(
+        return user.is_researcher and user.has_study_perms(
             StudyPermission.EDIT_STUDY_FEEDBACK, study
-        ):
-            return False
-
-        return True
+        )
 
     test_func = user_can_edit_response
 

--- a/scss/study-responses.scss
+++ b/scss/study-responses.scss
@@ -24,6 +24,16 @@ input[type="checkbox"].input-checkbox-hidden {
     display: none;
 }
 
+select.researcher-editable:disabled {
+    background-color: lightgray;
+    cursor: not-allowed;
+}
+
+input[type="checkbox"].researcher-editable:disabled+label .icon-star {
+    color: lightgray;
+    cursor: not-allowed;
+}
+
 .truncate-parent-feedback {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/scss/study-responses.scss
+++ b/scss/study-responses.scss
@@ -12,7 +12,8 @@ tr.preview-row {
     background-color: $hovergray;
 }
 
-input[type="checkbox"].input-checkbox-hidden {
+// Input elements in the responses table
+input[type="checkbox"].researcher-editable.input-checkbox-hidden {
     display: none;
 }
 
@@ -34,6 +35,7 @@ input[type="checkbox"].researcher-editable:disabled+label .icon-star {
     cursor: not-allowed;
 }
 
+// Response info box
 .truncate-parent-feedback {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -142,8 +142,8 @@
                                             </select>
                                         </td>
                                         <td>
-                                            <select name="response-status"
-                                                    id="response-status-{{ forloop.counter }}"
+                                            <select name="session-status"
+                                                    id="session-status-{{ forloop.counter }}"
                                                     class="researcher-editable"
                                                     autocomplete="off"
                                                     aria-label="Set optional session status for this response">
@@ -157,7 +157,7 @@
                                         </td>
                                         <td>
                                             <input type="checkbox"
-                                                   name="toggle_star"
+                                                   name="star"
                                                    id="star-checkbox-{{ forloop.counter }}"
                                                    class="researcher-editable input-checkbox-hidden star-checkbox"
                                                    aria-label="Toggle optional Star selection for this response" />

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -80,6 +80,11 @@
             <div class="col">
                 <div class="card">
                     <div class="card-body table-responsive">
+                        <input type="hidden"
+                               id="csrftokenurl"
+                               name="csrfmiddlewaretoken"
+                               value="{{ csrf_token }}"
+                               data-update-url="{% url 'exp:study-responses-researcher-update' pk=study.id %}" />
                         <table id="individualResponsesTable" class="table">
                             <caption class="d-none">Study Responses</caption>
                             <thead>

--- a/web/static/custom_bootstrap5.css
+++ b/web/static/custom_bootstrap5.css
@@ -31,7 +31,7 @@ tr.preview-row {
 .list-group-hover .list-group-item:hover:not(.active) {
   background-color: #f5f5f5; }
 
-input[type="checkbox"].input-checkbox-hidden {
+input[type="checkbox"].researcher-editable.input-checkbox-hidden {
   display: none; }
 
 .icon-star-filled {
@@ -39,6 +39,14 @@ input[type="checkbox"].input-checkbox-hidden {
 
 .icon-hidden {
   display: none; }
+
+select.researcher-editable:disabled {
+  background-color: lightgray;
+  cursor: not-allowed; }
+
+input[type="checkbox"].researcher-editable:disabled + label .icon-star {
+  color: lightgray;
+  cursor: not-allowed; }
 
 .truncate-parent-feedback {
   overflow: hidden;

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -183,9 +183,9 @@ $('.researcher-editable').change(
             if (data.success) console.log(data.success);
         })
         .catch(error => {
-            target.disabled = false;
-            // If the update fails, log the reason to the console and revert to the previous value
+            // If the update fails, log the reason to the console and revert to the previous value by reloading the page.
             console.error(error);
+            location.reload();
         });
     }
 );

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -173,7 +173,8 @@ $('.researcher-editable').change(
             if (!response.ok) {
                 // If the response is not successful then parse the JSON for the error message and re-throw
                 return response.json().then(errorData => {
-                    throw new Error(errorData.error);
+                    const errMsg = (errorData && errorData.error) ? errorData.error : "Request to update a response field has failed.";
+                    throw new Error(errMsg);
                 });
             }
             return response.json();


### PR DESCRIPTION
This PR adds data saving to the researcher-editable fields in the Individual Responses table.
- Adds JavaScript to update the Response object in the database when the researcher-editable column values changes.
- Adds an endpoint that processes the POST request sent from the IR page. The `StudyResponseSetResearcherFields` view checks the following:
  - User is a researcher with `EDIT_STUDY_FEEDBACK` permissions for this study
  - Response object exists and is a response to this study
  - The field that was changed is one of the researcher-editable Response fields (session_status, payment_status, star)
  - The value is valid for that field - one of the allowed status options (for payment/session status) or a boolean (star).
- Adds a CSRF token and the endpoint URL to the IR page template.
- Adds CSS for the input element that was changed while the POST request is still pending. The input element will become disabled with a 'not allowed' cursor type until a success/error response is received.

Note: I'll put in a separate PR with tests.

## Screenshots

(Now updated with latest formatting changes from develop)

https://github.com/user-attachments/assets/a3c90776-82fe-4a1a-bca4-245ed2925cfd

