### PR TITLE
Add tests for new researcher-editable response fields

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,2 @@
 sonar.python.version=3.9
-sonar.cpd.exclusions=./**/tests/**/*,./studies/test*
+sonar.cpd.exclusions = **/tests/**/*

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
 sonar.python.version=3.9
+sonar.cpd.exclusions=./**/tests/**/*,./studies/test*

--- a/exp/tests/test_response_views.py
+++ b/exp/tests/test_response_views.py
@@ -384,10 +384,14 @@ class ResponseViewsTestCase(TestCase):
                 self.assertEqual(response.status_code, 200)
                 success_str = f"Response {resp.id} field {field} updated to {self.fields_new_values[field]}"
                 self.assertIn(success_str, response.json().get("success"))
+                updated_resp = Response.objects.get(id=resp.id)
                 self.assertEqual(
-                    getattr(Response.objects.get(id=resp.id), field),
+                    getattr(updated_resp, field),
                     self.fields_new_values[field],
                 )
+                # Reset the response object to default values
+                setattr(updated_resp, field, self.fields_default_values[field])
+                updated_resp.save()
 
 
 class ResponseDataDownloadTestCase(TestCase):


### PR DESCRIPTION
This PR adds tests for the new exp `StudyResponseSetResearcherFields` view that is used to update the researcher-editable fields for responses. This view accepts a POST request sent from the IR page when a researcher changes the value of one of the editable fields in the table.

- Researchers without 'edit study feedback' permissions for the study cannot change any of the researcher-editable response values (POST request fails with 403 Forbidden).
- Researchers with 'edit study feedback' permissions for the study can change any of the researcher-editable response values (POST request succeeds with 200 ok and response field/value is changed in database).
- The new researcher-editable fields are included in the CSV and JSON response data downloads.
- The POST request fails for the following reasons (with appropriate error message):
  - missing data
  - invalid value for field
  - invalid (un-editable) field
  - response does not exist
  - response exists but is not associated with this study
- The POST request succeeds with valid blank (empty string) and `False` values

Note: this PR is failing the code duplication check (by .4% :weary:). I need to figure out how to ignore test files in this check, or refactor the code.