### PR TITLE
Conditionally disable field based on user permission

### DIFF
--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -143,7 +143,8 @@
                                                     id="payment-status-{{ forloop.counter }}"
                                                     class="researcher-editable form-select"
                                                     autocomplete="off"
-                                                    aria-label="Set optional payment status for this response">
+                                                    aria-label="Set optional payment status for this response"
+                                                    {% if not can_edit_feedback %}disabled{% endif %}>
                                                 {% for pstatus in payment_status_options %}
                                                     <option value="{{ pstatus.0 }}"
                                                             {% if response.response__researcher_payment_status == pstatus.1 %}selected{% endif %}>
@@ -157,7 +158,8 @@
                                                     id="session-status-{{ forloop.counter }}"
                                                     class="researcher-editable form-select"
                                                     autocomplete="off"
-                                                    aria-label="Set optional session status for this response">
+                                                    aria-label="Set optional session status for this response"
+                                                    {% if not can_edit_feedback %}disabled{% endif %}>
                                                 {% for sstatus in session_status_options %}
                                                     <option value="{{ sstatus.0 }}"
                                                             {% if response.response__researcher_session_status == sstatus.1 %}selected{% endif %}>
@@ -171,7 +173,8 @@
                                                    name="star"
                                                    id="star-checkbox-{{ forloop.counter }}"
                                                    class="researcher-editable input-checkbox-hidden star-checkbox"
-                                                   aria-label="Toggle optional Star selection for this response" />
+                                                   aria-label="Toggle optional Star selection for this response"
+                                                   {% if not can_edit_feedback %}disabled{% endif %} />
                                             <label for="star-checkbox-{{ forloop.counter }}">
                                                 {% if response.response__researcher_star %}
                                                     {% bs_icon "star" extra_classes="icon-star icon-hidden" size='1.5em' %}{% bs_icon "star-fill" extra_classes="icon-star icon-star-filled" size='1.5em' %}

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -223,6 +223,11 @@
                                 </tr>
                             </tfoot>
                         </table>
+                        {% if not can_edit_feedback %}
+                            <p class="text-center">
+                                <em>Based on your permissions, you are unable to update responses</em>
+                            </p>
+                        {% endif %}
                         {% if can_view_regular_responses and not can_view_preview_responses %}
                             <p class="text-center">
                                 <em>Based on your permissions, no preview responses are shown.</em>

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -225,7 +225,7 @@
                         </table>
                         {% if not can_edit_feedback %}
                             <p class="text-center">
-                                <em>Based on your permissions, you are unable to update responses</em>
+                                <em>Based on your permissions, you are unable to modify responses.</em>
                             </p>
                         {% endif %}
                         {% if can_view_regular_responses and not can_view_preview_responses %}


### PR DESCRIPTION
# Summary
If user doesn't have edit feedback permissions on this study, disable "payment status", "session status", and "star" columns.

## Screenshot

<img width="1512" alt="Screenshot 2025-03-12 at 3 46 19 PM" src="https://github.com/user-attachments/assets/28f5fa1d-022c-4d94-ab80-7f4a75c5a50b" />
