### PR TITLE
IR table: fix bug with Star values

### DIFF
--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -176,6 +176,7 @@
                                                    id="star-checkbox-{{ forloop.counter }}"
                                                    class="researcher-editable input-checkbox-hidden star-checkbox"
                                                    aria-label="Toggle optional Star selection for this response"
+                                                   {% if response.response__researcher_star %}checked{% endif %} 
                                                    {% if not can_edit_feedback %}disabled{% endif %} />
                                             <label for="star-checkbox-{{ forloop.counter }}">
                                                 {% if response.response__researcher_star %}


### PR DESCRIPTION
This PR fixes a bug with the data updating for Star values. 

## Problem

The input element was always in an 'unchecked' state when the page loaded (regardless of the Star value in the database and the filled/unfilled star that was shown). When we send the data back to the server, we check the 'checked' state of the input element and use that as the new value. This meant that, upon changing a Star value, it was always changed from False to True. 

## Fix

This PR fixes the problem by setting the input element's "checked" state according to the response's Star value when the page loads, so that when the Star value is changed, the value is updated correctly.

## Screenshots

https://github.com/user-attachments/assets/03da778c-8e99-4da2-9929-e33442990535

