### PR TITLE
Handle IR table when there's no resp data

### DIFF
--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -37,6 +37,7 @@
     <div class="row">
         <div class="col">{% include "studies/_response_nav_tabs.html" with active="individual" %}</div>
     </div>
+    {% if response_data %}
     <div class="row my-4">
         <div class="col">
             <p>
@@ -76,7 +77,6 @@
             </div>
         </div>
     </div>
-    {% if response_data %}
         <div class="row my-4">
             <div class="col">
                 <div class="card">

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -24,7 +24,9 @@ function updateInfoBox(index) {
     // Select table rows of response details table.
     const rows = document
         .querySelector(`#response-summary-${index}`)
-        .querySelectorAll('table tbody tr');
+        ?.querySelectorAll('table tbody tr');
+
+    if (!rows) return
 
     // construct parent ID
     const parentName = rows[13].children[1].textContent


### PR DESCRIPTION
# Problem

The information displayed at the IR view's top looks odd when there's no response data.  

# Fix

Don't show that row when there's no response data.  