### PR TITLE
Display a 0 instead of empty string

### DIFF
--- a/studies/queries.py
+++ b/studies/queries.py
@@ -193,7 +193,10 @@ def get_consent_statistics(study_id, preview_only):
     Returns:
         A dict containing the summary stats.
     """
-    statistics = {"responses": {"total": 0}, "children": {}}
+    statistics = {
+        "responses": {"total": 0, "rejected": 0, "pending": 0, "accepted": 0},
+        "children": {},
+    }
     response_stats = statistics["responses"]
     child_stats = statistics["children"]
 


### PR DESCRIPTION
# Summary
In the info row on the IR view, the statistics data displayed an empty string when there was no data for a category.  We'll instead have a 0 when there's no data.