### PR TITLE
IR table: fix bug in date column sorting

### DIFF
--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -212,7 +212,7 @@ const resp_table = $("#individualResponsesTable").DataTable({
         { className: "column-text-search", targets: [1, 2, 4] }, // add class to text search columns
         { className: "column-dropdown-search", targets: [5, 6, 7] }, // add class to dropdown search columns
         { orderData: 3, targets: [3, 4] }, // Sort "Time Elapsed" by "Date" column's data.
-        { targets: 3, render: dateColRender }
+        { targets: 3, type: 'date', render: dateColRender}
     ],
     initComplete: function () {
         filterText(this);


### PR DESCRIPTION
This PR fixes a bug in the Individual Responses table, where the Date column was being sorted as a string rather than date.