### PR TITLE
Add short hash to the end of static file names

### DIFF
--- a/project/storages.py
+++ b/project/storages.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.staticfiles.storage import ManifestFilesMixin
 from storages.backends.gcloud import GoogleCloudStorage
 
 
@@ -18,7 +19,7 @@ class LookitGoogleCloudStorage(GoogleCloudStorage):
         return f"/{name.lstrip('/')}"
 
 
-class LookitStaticStorage(LookitGoogleCloudStorage):
+class LookitStaticStorage(ManifestFilesMixin, LookitGoogleCloudStorage):
     location = settings.STATICFILES_LOCATION
 
 


### PR DESCRIPTION
# Issue

After releases there are some who find the site broken.  This is due to their browser having cached files that need to be updated.  

# Solution

Add a short md5 hash to the the end of static files.  

## Note

This _should_ work, but testing on staging will be needed.  