### PR TITLE
Update CHS-jsPsych packages lookit-initjspsych (v2.0.1) and record (v3.0.1)

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -35,11 +35,11 @@
                 integrity="sha384-pFbKMtALU+nxncMjtRL7BOm4SjMZnsH7/5WJfLEhB4vcFIPPBuKgDjhxRxLBFsV0"
                 crossorigin="anonymous"></script>
         {% comment %} End peer dependencies. {% endcomment %}
-        <script src="https://unpkg.com/@lookit/lookit-initjspsych@2.0.0"
-                integrity="sha384-NgGItJfqHH+X9FYqSH8IixpRmTdmF7CKS4478moXvrkBRuw5vkTJTVLyX8uM5lB6"
+        <script src="https://unpkg.com/@lookit/lookit-initjspsych@2.0.1"
+                integrity="sha384-LaIT76+kq1KHK5qcTSZeifJAxsf0esp46jXmRNmq0hULN+/nqZjD9TghNM55EU4J"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/record@3.0.0"
-                integrity="sha384-OgK3OcKASIuUR22VBQWY8J1Tlg2OtnbNGHf3xx0WL/+NxgQvD+7ZtlcuGDP6r0+1"
+        <script src="https://unpkg.com/@lookit/record@3.0.1"
+                integrity="sha384-p47ZKHOQWnb2EPQS2S3PIVDAmJmjLnu8a9eAHUp0fBoP6IzTj9RLdusUDGDvwcDk"
                 crossorigin="anonymous"></script>
         <script src="https://unpkg.com/@lookit/surveys@3.0.0"
                 integrity="sha384-VGTgnbjyqwY8iskMk78Ws8rD42Tt1L36O8siFiUxBGwPJki+OAukw3zUbGmyuEpt"


### PR DESCRIPTION
This PR modifies the jsPsych study template to update two CHS jsPsych packages to their latest versions:
- lookit-initjspsych v2.0.1
- record v3.0.1

The details of package updates are here: https://github.com/lookit/lookit-jspsych/pull/125

I tested these unpkg links locally with the following tests:
- Recording in Chrome and playing back the recording in both FF and Chrome: https://github.com/lookit/lookit-jspsych/pull/127
- Running a jsPsych study that contains a [nested timeline](https://www.jspsych.org/latest/overview/timeline/#nested-timelines), timeline node, [timeline variables](https://www.jspsych.org/latest/overview/timeline/#timeline-variables), [looping timeline](https://www.jspsych.org/latest/overview/timeline/#looping-timelines), and [conditional timeline](https://www.jspsych.org/latest/overview/timeline/#conditional-timelines): https://github.com/lookit/lookit-jspsych/pull/134