### PR TITLE
Revert "Add short hash to the end of static file names (#1538)"

### DIFF
--- a/project/storages.py
+++ b/project/storages.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.contrib.staticfiles.storage import ManifestFilesMixin
 from storages.backends.gcloud import GoogleCloudStorage
 
 
@@ -19,7 +18,7 @@ class LookitGoogleCloudStorage(GoogleCloudStorage):
         return f"/{name.lstrip('/')}"
 
 
-class LookitStaticStorage(ManifestFilesMixin, LookitGoogleCloudStorage):
+class LookitStaticStorage(LookitGoogleCloudStorage):
     location = settings.STATICFILES_LOCATION
 
 


### PR DESCRIPTION
This reverts commit db645cd678987afa1383954ee6329fef377e5f2c.

# Summary

We don't know what happened with this release.  The filenames were changed as expected, but the deployment failed.  This PR reverts the last commit.  