### PR TITLE
IR page: replace bootstrap star icons with fontawesome

### DIFF
--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -839,10 +839,13 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
     model = Response
 
     def get_queryset(self):
+        video_queryset = Video.objects.only("full_name")
+
         study = self.study
         return (
             study.responses_for_researcher(self.request.user)
             .order_by("-date_created")
+            .select_related("study_type", "child", "demographic_snapshot")
             .prefetch_related(
                 "consent_rulings__arbiter",
                 Prefetch(
@@ -850,6 +853,11 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
                     queryset=Feedback.objects.select_related("researcher").order_by(
                         "-id"
                     ),
+                ),
+                Prefetch(
+                    "videos",
+                    queryset=video_queryset,
+                    to_attr="prefetched_videos",
                 ),
             )
         )
@@ -901,13 +909,19 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
                 for col in RESPONSE_COLUMNS
                 if col.id in columns_included_in_summary
             ]
-            this_resp_data["videos"] = resp.videos.values("pk", "full_name")
-            for v in this_resp_data["videos"]:
-                v["display_name"] = (
-                    v["full_name"]
-                    .replace("videoStream_{}_".format(study.uuid), "...")
-                    .replace("_{}_".format(resp.uuid), "...")
-                )
+
+            video_info = [
+                {
+                    "pk": v.pk,
+                    "display_name": (
+                        v.full_name.replace(
+                            "videoStream_{}_".format(study.uuid), "..."
+                        ).replace("_{}_".format(resp.uuid), "...")
+                    ),
+                }
+                for v in resp.prefetched_videos
+            ]
+            this_resp_data["videos"] = video_info
             response_data.append(this_resp_data)
         context["response_data"] = response_data
         context["data_options"] = [col for col in RESPONSE_COLUMNS if col.optional]

--- a/scss/study-responses.scss
+++ b/scss/study-responses.scss
@@ -18,15 +18,12 @@ input[type="checkbox"].researcher-editable.input-checkbox-hidden {
 }
 
 .icon-star {
-    font-size: 1.5em;
+    fill: lightgray;
 }
 
 .icon-star-filled {
     color: $yellow;
-}
-
-.icon-hidden {
-    display: none;
+    fill: $yellow;
 }
 
 select.researcher-editable:disabled {

--- a/scss/study-responses.scss
+++ b/scss/study-responses.scss
@@ -17,6 +17,10 @@ input[type="checkbox"].researcher-editable.input-checkbox-hidden {
     display: none;
 }
 
+.icon-star {
+    font-size: 1.5em;
+}
+
 .icon-star-filled {
     color: $yellow;
 }

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -1,6 +1,5 @@
 {% extends "exp/base.html" %}
 {% load django_bootstrap5 %}
-{% load bootstrap_icons %}
 {% load exp_extras %}
 {% load web_extras %}
 {% load tz %}
@@ -10,6 +9,7 @@
 {% endblock title %}
 {% block head %}
     {{ block.super }}
+    <script src="https://kit.fontawesome.com/a54f9a117d.js" crossorigin="anonymous"></script>
     <script src="{% static 'js/table-date-filter.js' %}"
             type="application/javascript"
             defer></script>
@@ -180,9 +180,9 @@
                                                    {% if not can_edit_feedback %}disabled{% endif %} />
                                             <label for="star-checkbox-{{ forloop.counter }}">
                                                 {% if response.response__researcher_star %}
-                                                    {% bs_icon "star" extra_classes="icon-star icon-hidden" size='1.5em' %}{% bs_icon "star-fill" extra_classes="icon-star icon-star-filled" size='1.5em' %}
+                                                    <span class="icon-star icon-hidden"><i class="fa-regular fa-star"></i></span><span class="icon-star icon-star-filled"><i class="fa-solid fa-star"></i></span>
                                                 {% else %}
-                                                    {% bs_icon "star" extra_classes="icon-star" size='1.5em' %}{% bs_icon "star-fill" extra_classes="icon-star icon-star-filled icon-hidden" size='1.5em' %}
+                                                    <span class="icon-star"><i class="fa-regular fa-star"></i></span><span class="icon-star icon-star-filled icon-hidden"><i class="fa-solid fa-star"></i></span>
                                                 {% endif %}
                                             </label>
                                         </td>

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -9,7 +9,6 @@
 {% endblock title %}
 {% block head %}
     {{ block.super }}
-    <script src="https://kit.fontawesome.com/a54f9a117d.js" crossorigin="anonymous"></script>
     <script src="{% static 'js/table-date-filter.js' %}"
             type="application/javascript"
             defer></script>
@@ -178,12 +177,8 @@
                                                    aria-label="Toggle optional Star selection for this response"
                                                    {% if response.response__researcher_star %}checked{% endif %} 
                                                    {% if not can_edit_feedback %}disabled{% endif %} />
-                                            <label for="star-checkbox-{{ forloop.counter }}">
-                                                {% if response.response__researcher_star %}
-                                                    <span class="icon-star icon-hidden"><i class="fa-regular fa-star"></i></span><span class="icon-star icon-star-filled"><i class="fa-solid fa-star"></i></span>
-                                                {% else %}
-                                                    <span class="icon-star"><i class="fa-regular fa-star"></i></span><span class="icon-star icon-star-filled icon-hidden"><i class="fa-solid fa-star"></i></span>
-                                                {% endif %}
+                                            <label for="star-checkbox-{{ forloop.counter }}" >
+                                                <svg class="icon-star {% if response.response__researcher_star %}icon-star-filled{% endif %}" xmlns="http://www.w3.org/2000/svg" height="30" width="30" viewBox="0 0 576 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M316.9 18C311.6 7 300.4 0 288.1 0s-23.4 7-28.8 18L195 150.3 51.4 171.5c-12 1.8-22 10.2-25.7 21.7s-.7 24.2 7.9 32.7L137.8 329 113.2 474.7c-2 12 3 24.2 12.9 31.3s23 8 33.8 2.3l128.3-68.5 128.3 68.5c10.8 5.7 23.9 4.9 33.8-2.3s14.9-19.3 12.9-31.3L438.5 329 542.7 225.9c8.6-8.5 11.7-21.2 7.9-32.7s-13.7-19.9-25.7-21.7L381.2 150.3 316.9 18z"/></svg>
                                             </label>
                                         </td>
                                     </tr>

--- a/web/static/custom_bootstrap5.css
+++ b/web/static/custom_bootstrap5.css
@@ -35,13 +35,11 @@ input[type="checkbox"].researcher-editable.input-checkbox-hidden {
   display: none; }
 
 .icon-star {
-  font-size: 1.5em; }
+  fill: lightgray; }
 
 .icon-star-filled {
-  color: #f3c90f; }
-
-.icon-hidden {
-  display: none; }
+  color: #f3c90f;
+  fill: #f3c90f; }
 
 select.researcher-editable:disabled {
   background-color: lightgray;

--- a/web/static/custom_bootstrap5.css
+++ b/web/static/custom_bootstrap5.css
@@ -34,6 +34,9 @@ tr.preview-row {
 input[type="checkbox"].researcher-editable.input-checkbox-hidden {
   display: none; }
 
+.icon-star {
+  font-size: 1.5em; }
+
 .icon-star-filled {
   color: #f3c90f; }
 

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -207,11 +207,12 @@ const resp_table = $("#individualResponsesTable").DataTable({
             { features: [{ div: { className: 'show-hide-cols text-center mx-3' } }] },
             'search'],
     },
-    order: [[3, 'desc']], // Sort on "Date" column
+    order: [[2, 'desc']], // Sort on "Response ID" column (most recent first). Sorting on Date doesn't work as expected.
     columnDefs: [
         { className: "column-text-search", targets: [1, 2, 4] }, // add class to text search columns
         { className: "column-dropdown-search", targets: [5, 6, 7] }, // add class to dropdown search columns
-        { orderData: 3, targets: [3, 4] }, // Sort "Time Elapsed" by "Date" column's data.
+        // This tells datatables to sort "Time Elapsed" and "Date" by "Response ID" column's data. Date sorting isn't working (it doesn't take the full timestamp into account). The right way to do this is to pass the full timestamp into the template and tell datatables how to parse and display it, but I couldn't get that to work (docs https://datatables.net/examples/datetime/.)
+        { orderData: 2, targets: [2, 3, 4] },
         { targets: 3, type: 'date', render: dateColRender}
     ],
     initComplete: function () {

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -234,7 +234,7 @@ function updateAJAXCellData(target) {
         td.dataset.filter = text;
     } else if (classes.contains("star-checkbox")) {
         td.querySelectorAll('.icon-star').forEach(el => {
-            el.classList.toggle('icon-hidden')
+            el.classList.toggle('icon-star-filled')
         })
         td.dataset.sort = "False" == td.dataset.sort ? "True" : "False"
     }


### PR DESCRIPTION
This PR replaces the bootstrap icon template tags with fontawesome icons as the stars in the "Star" column.

For some reason, the `bs_icon` template tags we were using to generate the filled/unfilled stars for the "Star" column were causing significant page load delays. I looked into options for replacing them, and found that loading fontawesome icons from a kit link is faster. 

## Timing results

I tested the loading times by finding a study in my local DB that has a large number of responses (997). I loaded the Individual Response page for this study on two different branches: develop and this one (ir-page-timeout-icons). Here are the loading times on the two branches, with browser caching disabled:

| branch  | load time (min) | load time (sec) |
| ------------- | ------------- | ------------- |
| develop | 1.87 | 112 |
| icons | 0.55 | 33 |

There are some studies on production with even more responses (the most is around ~2000), so it's possible that some studies on production would still produce a 504 timeout even with these improvements.

## Screenshots

### Develop

![develop_study_94_load_time](https://github.com/user-attachments/assets/dfb1d0d6-c386-45ea-a04b-06889338902d)
![develop_study_94_debug_time](https://github.com/user-attachments/assets/72685d30-2c2f-4d37-9f97-7f97ccd6671f)
![develop_study_94_debug_profiling](https://github.com/user-attachments/assets/88a4f8dd-4c1b-4e27-a9fb-759cd5039598)

### This branch

![icon_study_94_load_time](https://github.com/user-attachments/assets/5427fd00-eb58-4a1c-88ff-625d515b1784)
![icon_study_94_debug_time](https://github.com/user-attachments/assets/c7467cf0-e9d3-4795-b611-b05b307a1e0e)
![icon_study_94_debug_profiling](https://github.com/user-attachments/assets/0875b4bb-9509-4d5f-b45b-217c81fb3bc3)
