### PR TITLE
IR page: improve queryset

### DIFF
--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -845,6 +845,7 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
         return (
             study.responses_for_researcher(self.request.user)
             .order_by("-date_created")
+            .select_related("study_type", "child", "demographic_snapshot")
             .prefetch_related(
                 "consent_rulings__arbiter",
                 Prefetch(


### PR DESCRIPTION
This PR updates the queryset for the Individual Responses page view to reduce the number of hits to the database. A number of other object lookups related to the study and response are required for this view: study type, child, participant/user, demographic snapshot, videos. These relationships were causing the [N+1 query problem](https://dev.to/herchila/how-to-avoid-n1-queries-in-django-tips-and-solutions-2ajo) because they were being retrieved separately for each response in a loop.

## To do

I used `select_related` to get the related objects that we need for the relevant set of Response objects, but this could probably still be improved.

For instance, we could try just grabbing the specific columns/values we need from each of these foreign key objects. But this is tricky because the info we need about each response comes from `RESPONSE_COLUMNS`, which is not a list of DB columns but rather a set of response fields that contains an extractor function. The extractor function sometimes just returns a column value, but sometimes it is used to calculate a value based on other values (e.g. child age in days comes from the response `date_created` and the child `birthday` fields). So to do this we would need to gather all of the DB columns that are used by extractor functions in the relevant set of `RESPONSE_COLUMNS`.

I used `prefetch_related` to get the Video objects related to each response, and limited this to just the column that we need ("full_name"). Not sure if this one could still be improved?

## Query results

I compared the number of queries and their total duration when loading the IR page in (1) develop and the branch with fontawesome icons (should be the same), and (2) this branch that tries to improve the SQL query efficiency.

| branch  | N queries | query duration (ms) |
| ------------- | ------------- | ------------- |
| develop/icons | 2005 | 835 / 782 respectively |
| this branch | 13 | 452 |

## Load time results

There was an improvement in page load time with these query changes, although it was not as drastic as with the change in icons.

| branch  | load time (min) | load time (sec) |
| ------------- | ------------- | ------------- |
| develop | 1.87 | 112 |
| icons | 0.55 | 33 |
| this branch | 0.30 | 18 |

## Screenshots

### develop/icons

![develop_study_94_sql_queries](https://github.com/user-attachments/assets/e1ae0cf4-5ee8-4c9c-958e-a2b23d2eaae7)

![icon_study_94_sql_queries](https://github.com/user-attachments/assets/211d9535-3179-4ce1-b0ab-3fa0ca4f00c2)

### This branch

![queryset_study_94_sql_queries](https://github.com/user-attachments/assets/bd14d70f-d82a-49f4-86e1-4b67ab47433a)

![queryset_study_94_load_time](https://github.com/user-attachments/assets/0715bfee-cad8-4561-90a4-bba599156d26)
