### PR TITLE
IR table: sort date using Response ID

### DIFF
--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -207,11 +207,11 @@ const resp_table = $("#individualResponsesTable").DataTable({
             { features: [{ div: { className: 'show-hide-cols text-center mx-3' } }] },
             'search'],
     },
-    order: [[3, 'desc']], // Sort on "Date" column
+    order: [[2, 'desc']], // Sort on "Response ID" column
     columnDefs: [
         { className: "column-text-search", targets: [1, 2, 4] }, // add class to text search columns
         { className: "column-dropdown-search", targets: [5, 6, 7] }, // add class to dropdown search columns
-        { orderData: 3, targets: [3, 4] }, // Sort "Time Elapsed" by "Date" column's data.
+        { orderData: 2, targets: [2, 3, 4] }, // Sort "Time Elapsed" and "Date" by "Response ID" column's data.
         { targets: 3, type: 'date', render: dateColRender}
     ],
     initComplete: function () {

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -207,11 +207,12 @@ const resp_table = $("#individualResponsesTable").DataTable({
             { features: [{ div: { className: 'show-hide-cols text-center mx-3' } }] },
             'search'],
     },
-    order: [[2, 'desc']], // Sort on "Response ID" column
+    order: [[2, 'desc']], // Sort on "Response ID" column (most recent first). Sorting on Date doesn't work as expected.
     columnDefs: [
         { className: "column-text-search", targets: [1, 2, 4] }, // add class to text search columns
         { className: "column-dropdown-search", targets: [5, 6, 7] }, // add class to dropdown search columns
-        { orderData: 2, targets: [2, 3, 4] }, // Sort "Time Elapsed" and "Date" by "Response ID" column's data.
+        // This tells datatables to sort "Time Elapsed" and "Date" by "Response ID" column's data. Date sorting isn't working (it doesn't take the full timestamp into account). The right way to do this is to pass the full timestamp into the template and tell datatables how to parse and display it, but I couldn't get that to work (docs https://datatables.net/examples/datetime/.)
+        { orderData: 2, targets: [2, 3, 4] },
         { targets: 3, type: 'date', render: dateColRender}
     ],
     initComplete: function () {


### PR DESCRIPTION
This PR fixes a bug that was causing the date column not to sort properly. I believe the problem was caused by the date column losing access to the full timestamp. After multiple failed attempts at fixing this through datatables datetime formatting, I decided to sort the Date column on the Response ID value (which increases incrementally with the creation of each new response object).

@okaycj I'm not entirely sure why, but this change seems to fix the row re-sorting bug that was triggered by `updateAJAXCellData`, but please feel free to check too. I can also test again tomorrow and on staging.