### PR TITLE
Add jsPsych survey-text and survey-multi-choice

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -27,6 +27,12 @@
         <script src="https://unpkg.com/@jspsych/plugin-preload@2.0.0"
                 integrity="sha384-veBuhHbf5WLQIFlG9N6a+5E/kRYJcBTDKkqJRTkc7wuGwptljsBa2fYuTseMkOBI"
                 crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/@jspsych/plugin-survey-text@2.1.0"
+                integrity="sha384-wSdh5i8tkmhhMiddYPH0Sc0HNw6wDfVWT80sTyRdjs62ctEKZHPLDdF2WXj2sPa/"
+                crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/@jspsych/plugin-survey-multi-choice@2.1.0"
+                integrity="sha384-NDx/PP6brJOK2yI3xA9yYbsgRe6I7BUZ3jcBD9aiVRWNYiei88wLmzsMEdWGJXOr"
+                crossorigin="anonymous"></script>
         {% comment %} Data and templates packages are peer dependencies and should be listed first. {% endcomment %}
         <script src="https://unpkg.com/@lookit/data@0.2.0"
                 integrity="sha384-iMjDaQDmCTXe6XO59EktLBsg7KmDZZvT5jN/QMiP+ctA8YfQDT/hATDKM1EtoxBQ"


### PR DESCRIPTION
This PR adds the following jsPsych plugins to the study template:

- survey-text v2.1.0
- survey-multi-choice v2.1.0

This gives researchers the option to use these plugins in their experiments, and doesn't change anything else about CHS jsPsych studies/code.

These are the latest versions of these plugins and compatible with the jsPsych core version that we're using (v8.0.3, and these both require jspsych >=7.1.0).

Fixes #1544