### PR TITLE
IR page fixes; jsPsych updates

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
 sonar.python.version=3.9
+sonar.cpd.exclusions = **/tests/**/*

--- a/exp/tests/test_response_views.py
+++ b/exp/tests/test_response_views.py
@@ -12,6 +12,7 @@ from django_dynamic_fixture import G
 from accounts.backends import TWO_FACTOR_AUTH_SESSION_KEY
 from accounts.models import Child, DemographicData, User
 from accounts.utils import hash_id
+from exp.views.responses import StudyResponseSetResearcherFields
 from studies.models import ConsentRuling, Lab, Response, Study, StudyType, Video
 
 
@@ -39,6 +40,9 @@ class ResponseViewsTestCase(TestCase):
         )
         self.study_reader = G(
             User, is_active=True, is_researcher=True, given_name="Researcher 2"
+        )
+        self.study_previewer = G(
+            User, is_active=True, is_researcher=True, given_name="Researcher 4"
         )
         self.other_researcher = G(
             User, is_active=True, is_researcher=True, given_name="Researcher 3"
@@ -70,6 +74,7 @@ class ResponseViewsTestCase(TestCase):
 
         self.study.admin_group.user_set.add(self.study_admin)
         self.study.researcher_group.user_set.add(self.study_reader)
+        self.study.preview_group.user_set.add(self.study_previewer)
 
         self.study_reader_child = G(
             Child,
@@ -199,6 +204,22 @@ class ResponseViewsTestCase(TestCase):
             ),
             reverse("exp:study-attachments", kwargs={"pk": self.study.pk}),
         ]
+        # For testing researcher-editable response fields: researcher_session_status, researcher_payment_status, researcher_star
+        self.editable_fields = StudyResponseSetResearcherFields.EDITABLE_FIELDS
+        default_values = [
+            "",
+            "",
+            False,
+        ]  # These correspond to session status, payment status, and star
+        new_values = ["follow_up", "to_pay", True]
+        self.fields_default_values = {
+            self.editable_fields[i]: default_values[i]
+            for i in range(len(self.editable_fields))
+        }
+        self.fields_new_values = {
+            self.editable_fields[i]: new_values[i]
+            for i in range(len(self.editable_fields))
+        }
 
     def test_cannot_see_any_responses_views_unauthenticated(self):
         for url in self.all_response_urls:
@@ -295,6 +316,86 @@ class ResponseViewsTestCase(TestCase):
         )
         self.client.post(url, {})
         self.assertEqual(self.study.responses.filter(is_preview=True).count(), 0)
+
+    def test_unassociated_researcher_cannot_edit_modifiable_fields_in_response(self):
+        self.client.force_login(self.other_researcher)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        for resp in self.responses:
+            for field in self.editable_fields:
+                self.assertEqual(
+                    getattr(resp, field), self.fields_default_values[field]
+                )
+                data = {
+                    "responseId": resp.id,
+                    "field": field,
+                    "value": self.fields_new_values[field],
+                }
+                response = self.client.post(
+                    url, json.dumps(data), content_type="application/json"
+                )
+                self.assertEqual(response.status_code, 403)
+                self.assertIn("Forbidden", response.content.decode("utf-8"))
+                self.assertEqual(
+                    getattr(Response.objects.get(id=resp.id), field),
+                    self.fields_default_values[field],
+                )
+
+    def test_previewer_researcher_cannot_edit_modifiable_fields_in_response(self):
+        self.client.force_login(self.study_previewer)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        for resp in self.responses:
+            for field in self.editable_fields:
+                self.assertEqual(
+                    getattr(resp, field), self.fields_default_values[field]
+                )
+                data = {
+                    "responseId": resp.id,
+                    "field": field,
+                    "value": self.fields_new_values[field],
+                }
+                response = self.client.post(
+                    url, json.dumps(data), content_type="application/json"
+                )
+                self.assertEqual(response.status_code, 403)
+                self.assertIn("Forbidden", response.content.decode("utf-8"))
+                self.assertEqual(
+                    getattr(Response.objects.get(id=resp.id), field),
+                    self.fields_default_values[field],
+                )
+
+    def test_edit_modifiable_fields_in_response(self):
+        self.client.force_login(self.study_admin)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        for resp in self.responses:
+            for field in self.editable_fields:
+                self.assertEqual(
+                    getattr(resp, field), self.fields_default_values[field]
+                )
+                data = {
+                    "responseId": resp.id,
+                    "field": field,
+                    "value": self.fields_new_values[field],
+                }
+                response = self.client.post(
+                    url, json.dumps(data), content_type="application/json"
+                )
+                self.assertEqual(response.status_code, 200)
+                success_str = f"Response {resp.id} field {field} updated to {self.fields_new_values[field]}"
+                self.assertIn(success_str, response.json().get("success"))
+                updated_resp = Response.objects.get(id=resp.id)
+                self.assertEqual(
+                    getattr(updated_resp, field),
+                    self.fields_new_values[field],
+                )
+                # Reset the response object to default values
+                setattr(updated_resp, field, self.fields_default_values[field])
+                updated_resp.save()
 
 
 class ResponseDataDownloadTestCase(TestCase):
@@ -571,6 +672,17 @@ class ResponseDataDownloadTestCase(TestCase):
         self.response_summary_json_url = reverse(
             "exp:study-responses-download-json", kwargs={"pk": self.study.pk}
         )
+        # For testing presence of researcher-editable fields/values
+        self.editable_fields = StudyResponseSetResearcherFields.EDITABLE_FIELDS
+        default_values = [
+            "",
+            "",
+            False,
+        ]  # These correspond to session status, payment status, and star
+        self.fields_default_values = {
+            self.editable_fields[i]: default_values[i]
+            for i in range(len(self.editable_fields))
+        }
 
     def test_get_appropriate_fields_in_csv_downloads_set1(self):
         self.client.force_login(self.study_reader)
@@ -990,6 +1102,34 @@ class ResponseDataDownloadTestCase(TestCase):
         self.assertEqual(this_response["response"]["birthdate_difference"], 17)
         self.assertEqual(this_response["consent"]["ruling"], "accepted")
 
+    def test_get_researcher_editable_fields_in_csv_downloads(self):
+        self.client.force_login(self.study_reader)
+        query_string = urlencode({"data_options": self.optionset_1}, doseq=True)
+        response = self.client.get(f"{self.response_summary_url}?{query_string}")
+        content = response.content.decode("utf-8")
+        csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
+        csv_body = list(csv_reader)
+        csv_headers = csv_body.pop(0)
+        self.assertEqual(True, True)
+        researcher_editable_field_headers = [
+            "response__" + field for field in self.editable_fields
+        ]
+        for field in researcher_editable_field_headers:
+            self.assertIn(field, csv_headers)
+
+    def test_get_researcher_editable_fields_in_json_downloads(self):
+        self.client.force_login(self.study_reader)
+        query_string = urlencode({"data_options": self.optionset_1}, doseq=True)
+        response = self.client.get(f"{self.response_summary_json_url}?{query_string}")
+        content = b"".join(response.streaming_content).decode("utf-8")
+        data = json.loads(content)
+        for row in data:
+            for field in self.editable_fields:
+                self.assertEqual(
+                    row["response"][field],
+                    self.fields_default_values[field],
+                )
+
     def test_get_appropriate_children_in_child_csv_as_previewer(self):
         self.client.force_login(self.study_previewer)
         csv_response = self.client.get(
@@ -1232,6 +1372,288 @@ class ResponseDataDownloadTestCase(TestCase):
 
         # Assumes n_previews fit on one page
         self.assertEqual(n_matches, self.n_previews)
+
+
+class ResponseViewResearcherUpdateFieldsTestCase(TestCase):
+    def setUp(self):
+        self.client = Force2FAClient()
+
+        self.study_admin = G(
+            User, is_active=True, is_researcher=True, given_name="Researcher 1"
+        )
+        self.other_researcher = G(
+            User, is_active=True, is_researcher=True, given_name="Other researcher"
+        )
+        self.lab = G(Lab, name="MIT")
+        self.study = G(
+            Study,
+            creator=self.study_admin,
+            shared_preview=False,
+            name="Test Study 1",
+            lab=self.lab,
+            study_type=StudyType.get_ember_frame_player(),
+        )
+        self.study.admin_group.user_set.add(self.study_admin)
+
+        self.other_study = G(
+            Study,
+            creator=self.other_researcher,
+            shared_preview=False,
+            name="Other study",
+            lab=self.lab,
+            study_type=StudyType.get_ember_frame_player(),
+        )
+
+        self.participant = G(User, is_active=True, given_name="Parent")
+        self.child = G(
+            Child,
+            user=self.participant,
+            given_name="Child 1",
+            existing_conditions=Child.existing_conditions.multiple_birth,
+            birthday=datetime.date.today() - datetime.timedelta(60),
+        )
+        self.demo_snapshot = G(DemographicData, user=self.participant, density="urban")
+        self.response = G(
+            Response,
+            child=self.child,
+            study=self.study,
+            study_type=self.study.study_type,
+            completed=True,
+            completed_consent_frame=True,
+            sequence=["0-video-config", "1-video-setup", "2-my-consent-frame"],
+            exp_data={
+                "0-video-config": {"frameType": "DEFAULT"},
+                "1-video-setup": {"frameType": "DEFAULT"},
+                "2-my-consent-frame": {"frameType": "CONSENT"},
+                "3-my-exit-frame": {"frameType": "EXIT"},
+            },
+            demographic_snapshot=self.demo_snapshot,
+        )
+        self.consent_ruling = G(
+            ConsentRuling,
+            response=self.response,
+            action="accepted",
+            arbiter=self.study_admin,
+        )
+        self.other_response = G(
+            Response,
+            child=self.child,
+            study=self.other_study,
+            study_type=self.other_study.study_type,
+            completed=True,
+            completed_consent_frame=True,
+            sequence=["0-video-config", "1-video-setup", "2-my-consent-frame"],
+            exp_data={
+                "0-video-config": {"frameType": "DEFAULT"},
+                "1-video-setup": {"frameType": "DEFAULT"},
+                "2-my-consent-frame": {"frameType": "CONSENT"},
+                "3-my-exit-frame": {"frameType": "EXIT"},
+            },
+            demographic_snapshot=self.demo_snapshot,
+        )
+        self.other_consent_ruling = G(
+            ConsentRuling,
+            response=self.other_response,
+            action="accepted",
+            arbiter=self.other_researcher,
+        )
+        # For testing researcher-editable response fields: researcher_session_status, researcher_payment_status, researcher_star
+        self.editable_fields = StudyResponseSetResearcherFields.EDITABLE_FIELDS
+        default_values = [
+            "",
+            "",
+            False,
+        ]  # These correspond to session status, payment status, and star
+        new_values = ["follow_up", "to_pay", True]
+        invalid_values = ["some_other_string", 42, "true"]
+        self.fields_default_values = {
+            self.editable_fields[i]: default_values[i]
+            for i in range(len(self.editable_fields))
+        }
+        self.fields_new_values = {
+            self.editable_fields[i]: new_values[i]
+            for i in range(len(self.editable_fields))
+        }
+        self.fields_invalid_values = {
+            self.editable_fields[i]: invalid_values[i]
+            for i in range(len(self.editable_fields))
+        }
+
+    def test_update_fails_with_missing_data(self):
+        self.client.force_login(self.study_admin)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        invalid_data_list = [
+            {},
+            {"responseId": self.response.id},
+            {"field": self.editable_fields[0]},
+            {"value": self.fields_new_values[self.editable_fields[0]]},
+            {
+                "responseId": self.response.id,
+                "field": self.editable_fields[0],
+            },
+            {
+                "responseId": self.response.id,
+                "value": self.fields_new_values[self.editable_fields[0]],
+            },
+            {
+                "field": self.editable_fields[0],
+                "value": self.fields_new_values[self.editable_fields[0]],
+            },
+        ]
+        for data in invalid_data_list:
+            post_response = self.client.post(
+                url, json.dumps(data), content_type="application/json"
+            )
+            self.assertEqual(post_response.status_code, 400)
+            error_str = (
+                "Invalid request: One or more of the required arguments is missing."
+            )
+            self.assertIn(error_str, post_response.json().get("error"))
+
+    def test_update_fails_with_invalid_values(self):
+        self.client.force_login(self.study_admin)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        # These correspond to the fields: session status, payment status, star
+        err_strings = [
+            "Invalid request: Session Status must be one of ",
+            "Invalid request: Payment Status must be one of ",
+            "Invalid request: Star field must be a boolean value.",
+        ]
+        fields_err_strings = {
+            self.editable_fields[i]: err_strings[i]
+            for i in range(len(self.editable_fields))
+        }
+        for field in self.editable_fields:
+            self.assertEqual(
+                getattr(self.response, field), self.fields_default_values[field]
+            )
+            data_invalid = {
+                "responseId": self.response.id,
+                "field": field,
+                "value": self.fields_invalid_values[field],
+            }
+            post_response = self.client.post(
+                url, json.dumps(data_invalid), content_type="application/json"
+            )
+            self.assertEqual(post_response.status_code, 400)
+            self.assertIn(fields_err_strings[field], post_response.json().get("error"))
+
+    def test_update_fails_with_invalid_fields(self):
+        self.client.force_login(self.study_admin)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        # Test that researchers can't modify any other Response fields (with somewhat-reasonable values)
+        fields = Response._meta.get_fields()
+        other_fields = [
+            field.name
+            for field in fields
+            if field.name not in self.editable_fields and field.concrete
+        ]
+        other_fields_types = {
+            field.name: field.get_internal_type()
+            for field in fields
+            if field.name not in self.editable_fields and field.concrete
+        }
+        valid_values = {
+            "DateTimeField": str(datetime.datetime(2025, 3, 15, 12, 0, 0)),
+            "JSONField": "{'foo': 'bar'}",
+            "BooleanField": True,
+            "CharField": "bad data!",
+            "ArrayField": ["uh-oh"],
+            "AutoField": 999999,
+            "UUIDField": str(self.response.uuid),
+            "ForeignKey": 1,
+        }
+        for field in other_fields:
+            data_invalid_field = {
+                "responseId": self.response.id,
+                "field": field,
+                "value": valid_values[other_fields_types[field]],
+            }
+            post_response = self.client.post(
+                url, json.dumps(data_invalid_field), content_type="application/json"
+            )
+            self.assertEqual(post_response.status_code, 400)
+            self.assertIn(
+                f"""Invalid request: Invalid field {field}""",
+                post_response.json().get("error"),
+            )
+
+    def test_update_fails_when_response_does_not_exist(self):
+        self.client.force_login(self.study_admin)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        non_existent_id = 999999
+        data_response_invalid = {
+            "responseId": non_existent_id,
+            "field": self.editable_fields[0],
+            "value": self.fields_new_values[self.editable_fields[0]],
+        }
+        post_response = self.client.post(
+            url, json.dumps(data_response_invalid), content_type="application/json"
+        )
+        self.assertEqual(post_response.status_code, 400)
+        error_str = (
+            f"""Invalid request: Response object {non_existent_id} does not exist"""
+        )
+        self.assertIn(error_str, post_response.json().get("error"))
+
+    def test_update_fails_when_response_not_from_this_study(self):
+        self.client.force_login(self.study_admin)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        data_resp_id_not_from_study = {
+            "responseId": self.other_response.id,
+            "field": self.editable_fields[0],
+            "value": self.fields_new_values[self.editable_fields[0]],
+        }
+        post_response = self.client.post(
+            url,
+            json.dumps(data_resp_id_not_from_study),
+            content_type="application/json",
+        )
+        self.assertEqual(post_response.status_code, 400)
+        error_str = f"""Invalid request: Response object {self.other_response.id} is not from this study."""
+        self.assertIn(error_str, post_response.json().get("error"))
+
+    def test_update_with_blank_value_is_successful(self):
+        self.client.force_login(self.study_admin)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        data_with_blank = {
+            "responseId": self.response.id,
+            "field": self.editable_fields[0],
+            "value": "",
+        }
+        post_response = self.client.post(
+            url, json.dumps(data_with_blank), content_type="application/json"
+        )
+        success_str = f"Response {self.response.id} field {self.editable_fields[0]} updated to {''}"
+        self.assertIn(success_str, post_response.json().get("success"))
+
+    def test_update_with_false_value_is_successful(self):
+        self.client.force_login(self.study_admin)
+        url = reverse(
+            "exp:study-responses-researcher-update", kwargs={"pk": self.study.pk}
+        )
+        data_with_blank = {
+            "responseId": self.response.id,
+            "field": self.editable_fields[2],
+            "value": False,
+        }
+        post_response = self.client.post(
+            url, json.dumps(data_with_blank), content_type="application/json"
+        )
+        success_str = f"Response {self.response.id} field {self.editable_fields[2]} updated to {False}"
+        self.assertIn(success_str, post_response.json().get("success"))
 
     # TODO: test individual file downloads from response-list
     #       * cannot get response from another study,

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -839,10 +839,13 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
     model = Response
 
     def get_queryset(self):
+        video_queryset = Video.objects.only("full_name")
+
         study = self.study
         return (
             study.responses_for_researcher(self.request.user)
             .order_by("-date_created")
+            .select_related("study_type", "child", "demographic_snapshot")
             .prefetch_related(
                 "consent_rulings__arbiter",
                 Prefetch(
@@ -850,6 +853,11 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
                     queryset=Feedback.objects.select_related("researcher").order_by(
                         "-id"
                     ),
+                ),
+                Prefetch(
+                    "videos",
+                    queryset=video_queryset,
+                    to_attr="prefetched_videos",
                 ),
             )
         )
@@ -901,13 +909,19 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
                 for col in RESPONSE_COLUMNS
                 if col.id in columns_included_in_summary
             ]
-            this_resp_data["videos"] = resp.videos.values("pk", "full_name")
-            for v in this_resp_data["videos"]:
-                v["display_name"] = (
-                    v["full_name"]
-                    .replace("videoStream_{}_".format(study.uuid), "...")
-                    .replace("_{}_".format(resp.uuid), "...")
-                )
+
+            video_info = [
+                {
+                    "pk": v.pk,
+                    "display_name": (
+                        v.full_name.replace(
+                            "videoStream_{}_".format(study.uuid), "..."
+                        ).replace("_{}_".format(resp.uuid), "...")
+                    ),
+                }
+                for v in resp.prefetched_videos
+            ]
+            this_resp_data["videos"] = video_info
             response_data.append(this_resp_data)
         context["response_data"] = response_data
         context["data_options"] = [col for col in RESPONSE_COLUMNS if col.optional]

--- a/project/storages.py
+++ b/project/storages.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.staticfiles.storage import ManifestFilesMixin
 from storages.backends.gcloud import GoogleCloudStorage
 
 
@@ -18,7 +19,7 @@ class LookitGoogleCloudStorage(GoogleCloudStorage):
         return f"/{name.lstrip('/')}"
 
 
-class LookitStaticStorage(LookitGoogleCloudStorage):
+class LookitStaticStorage(ManifestFilesMixin, LookitGoogleCloudStorage):
     location = settings.STATICFILES_LOCATION
 
 

--- a/project/storages.py
+++ b/project/storages.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.contrib.staticfiles.storage import ManifestFilesMixin
 from storages.backends.gcloud import GoogleCloudStorage
 
 
@@ -19,7 +18,7 @@ class LookitGoogleCloudStorage(GoogleCloudStorage):
         return f"/{name.lstrip('/')}"
 
 
-class LookitStaticStorage(ManifestFilesMixin, LookitGoogleCloudStorage):
+class LookitStaticStorage(LookitGoogleCloudStorage):
     location = settings.STATICFILES_LOCATION
 
 

--- a/scss/study-responses.scss
+++ b/scss/study-responses.scss
@@ -17,12 +17,13 @@ input[type="checkbox"].researcher-editable.input-checkbox-hidden {
     display: none;
 }
 
-.icon-star-filled {
-    color: $yellow;
+.icon-star {
+    fill: lightgray;
 }
 
-.icon-hidden {
-    display: none;
+.icon-star-filled {
+    color: $yellow;
+    fill: $yellow;
 }
 
 select.researcher-editable:disabled {

--- a/studies/templates/studies/study_responses.html
+++ b/studies/templates/studies/study_responses.html
@@ -1,6 +1,5 @@
 {% extends "exp/base.html" %}
 {% load django_bootstrap5 %}
-{% load bootstrap_icons %}
 {% load exp_extras %}
 {% load web_extras %}
 {% load tz %}
@@ -178,12 +177,8 @@
                                                    aria-label="Toggle optional Star selection for this response"
                                                    {% if response.response__researcher_star %}checked{% endif %} 
                                                    {% if not can_edit_feedback %}disabled{% endif %} />
-                                            <label for="star-checkbox-{{ forloop.counter }}">
-                                                {% if response.response__researcher_star %}
-                                                    {% bs_icon "star" extra_classes="icon-star icon-hidden" size='1.5em' %}{% bs_icon "star-fill" extra_classes="icon-star icon-star-filled" size='1.5em' %}
-                                                {% else %}
-                                                    {% bs_icon "star" extra_classes="icon-star" size='1.5em' %}{% bs_icon "star-fill" extra_classes="icon-star icon-star-filled icon-hidden" size='1.5em' %}
-                                                {% endif %}
+                                            <label for="star-checkbox-{{ forloop.counter }}" >
+                                                <svg class="icon-star {% if response.response__researcher_star %}icon-star-filled{% endif %}" xmlns="http://www.w3.org/2000/svg" height="30" width="30" viewBox="0 0 576 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M316.9 18C311.6 7 300.4 0 288.1 0s-23.4 7-28.8 18L195 150.3 51.4 171.5c-12 1.8-22 10.2-25.7 21.7s-.7 24.2 7.9 32.7L137.8 329 113.2 474.7c-2 12 3 24.2 12.9 31.3s23 8 33.8 2.3l128.3-68.5 128.3 68.5c10.8 5.7 23.9 4.9 33.8-2.3s14.9-19.3 12.9-31.3L438.5 329 542.7 225.9c8.6-8.5 11.7-21.2 7.9-32.7s-13.7-19.9-25.7-21.7L381.2 150.3 316.9 18z"/></svg>
                                             </label>
                                         </td>
                                     </tr>

--- a/web/static/custom_bootstrap5.css
+++ b/web/static/custom_bootstrap5.css
@@ -34,11 +34,12 @@ tr.preview-row {
 input[type="checkbox"].researcher-editable.input-checkbox-hidden {
   display: none; }
 
-.icon-star-filled {
-  color: #f3c90f; }
+.icon-star {
+  fill: lightgray; }
 
-.icon-hidden {
-  display: none; }
+.icon-star-filled {
+  color: #f3c90f;
+  fill: #f3c90f; }
 
 select.researcher-editable:disabled {
   background-color: lightgray;

--- a/web/static/js/study-responses.js
+++ b/web/static/js/study-responses.js
@@ -207,11 +207,12 @@ const resp_table = $("#individualResponsesTable").DataTable({
             { features: [{ div: { className: 'show-hide-cols text-center mx-3' } }] },
             'search'],
     },
-    order: [[3, 'desc']], // Sort on "Date" column
+    order: [[2, 'desc']], // Sort on "Response ID" column (most recent first). Sorting on Date doesn't work as expected.
     columnDefs: [
         { className: "column-text-search", targets: [1, 2, 4] }, // add class to text search columns
         { className: "column-dropdown-search", targets: [5, 6, 7] }, // add class to dropdown search columns
-        { orderData: 3, targets: [3, 4] }, // Sort "Time Elapsed" by "Date" column's data.
+        // This tells datatables to sort "Time Elapsed" and "Date" by "Response ID" column's data. Date sorting isn't working (it doesn't take the full timestamp into account). The right way to do this is to pass the full timestamp into the template and tell datatables how to parse and display it, but I couldn't get that to work (docs https://datatables.net/examples/datetime/.)
+        { orderData: 2, targets: [2, 3, 4] },
         { targets: 3, type: 'date', render: dateColRender}
     ],
     initComplete: function () {
@@ -234,7 +235,7 @@ function updateAJAXCellData(target) {
         td.dataset.filter = text;
     } else if (classes.contains("star-checkbox")) {
         td.querySelectorAll('.icon-star').forEach(el => {
-            el.classList.toggle('icon-hidden')
+            el.classList.toggle('icon-star-filled')
         })
         td.dataset.sort = "False" == td.dataset.sort ? "True" : "False"
     }

--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -27,6 +27,12 @@
         <script src="https://unpkg.com/@jspsych/plugin-preload@2.0.0"
                 integrity="sha384-veBuhHbf5WLQIFlG9N6a+5E/kRYJcBTDKkqJRTkc7wuGwptljsBa2fYuTseMkOBI"
                 crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/@jspsych/plugin-survey-text@2.1.0"
+                integrity="sha384-wSdh5i8tkmhhMiddYPH0Sc0HNw6wDfVWT80sTyRdjs62ctEKZHPLDdF2WXj2sPa/"
+                crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/@jspsych/plugin-survey-multi-choice@2.1.0"
+                integrity="sha384-NDx/PP6brJOK2yI3xA9yYbsgRe6I7BUZ3jcBD9aiVRWNYiei88wLmzsMEdWGJXOr"
+                crossorigin="anonymous"></script>
         {% comment %} Data and templates packages are peer dependencies and should be listed first. {% endcomment %}
         <script src="https://unpkg.com/@lookit/data@0.2.0"
                 integrity="sha384-iMjDaQDmCTXe6XO59EktLBsg7KmDZZvT5jN/QMiP+ctA8YfQDT/hATDKM1EtoxBQ"

--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -35,11 +35,11 @@
                 integrity="sha384-pFbKMtALU+nxncMjtRL7BOm4SjMZnsH7/5WJfLEhB4vcFIPPBuKgDjhxRxLBFsV0"
                 crossorigin="anonymous"></script>
         {% comment %} End peer dependencies. {% endcomment %}
-        <script src="https://unpkg.com/@lookit/lookit-initjspsych@2.0.0"
-                integrity="sha384-NgGItJfqHH+X9FYqSH8IixpRmTdmF7CKS4478moXvrkBRuw5vkTJTVLyX8uM5lB6"
+        <script src="https://unpkg.com/@lookit/lookit-initjspsych@2.0.1"
+                integrity="sha384-LaIT76+kq1KHK5qcTSZeifJAxsf0esp46jXmRNmq0hULN+/nqZjD9TghNM55EU4J"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/record@3.0.0"
-                integrity="sha384-OgK3OcKASIuUR22VBQWY8J1Tlg2OtnbNGHf3xx0WL/+NxgQvD+7ZtlcuGDP6r0+1"
+        <script src="https://unpkg.com/@lookit/record@3.0.1"
+                integrity="sha384-p47ZKHOQWnb2EPQS2S3PIVDAmJmjLnu8a9eAHUp0fBoP6IzTj9RLdusUDGDvwcDk"
                 crossorigin="anonymous"></script>
         <script src="https://unpkg.com/@lookit/surveys@3.0.0"
                 integrity="sha384-VGTgnbjyqwY8iskMk78Ws8rD42Tt1L36O8siFiUxBGwPJki+OAukw3zUbGmyuEpt"


### PR DESCRIPTION
This PR moves the following changes into production:

**Individual Responses page**

- Attempt to fix, or at least improve, the loading duration/timeout problems

**jsPsych studies**

- Update the CHS lookit-initjspsych package version to fix a problem with nested timelines and timeline nodes (https://github.com/lookit/lookit-jspsych/issues/130).
- Update the CHS record package version to fix a problem with video recording playback (https://github.com/lookit/lookit-jspsych/issues/126)
- Load the jsPsych survey-text and survey-multi-choice plugins (short-term solution for researchers who are having problems with our CHS exit survey plugin: https://github.com/lookit/lookit-jspsych/issues/138)

**Other**

- Add unit tests for the recently-added view to handle POST requests to update the researcher-editable fields on the Individual Responses table.

Here are the specific PRs that are included:

- #1530
- #1541
- #1545 (this PR includes #1546 and #1548)
- #1551 

**Note**: the commit history here also shows PR #1538 that adds a hash to the end of static file names, for browser cache-busting purposes. But this change caused problems on the staging server and was reverted in PR #1542, so it is not actually included here.