### PR TITLE
Individual Responses page: improve video prefetch queryset

### DIFF
--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -908,7 +908,7 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
                 if col.id in columns_included_in_summary
             ]
 
-            video_info = [
+            this_resp_data["videos"] = [
                 {
                     "pk": v.id,
                     "display_name": (
@@ -917,9 +917,8 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
                         ).replace("_{}_".format(resp.uuid), "...")
                     ),
                 }
-                for v in resp.prefetched_videos
+                for v in getattr(resp, "prefetched_videos", [])
             ]
-            this_resp_data["videos"] = video_info
             response_data.append(this_resp_data)
         context["response_data"] = response_data
         context["data_options"] = [col for col in RESPONSE_COLUMNS if col.optional]

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -839,8 +839,6 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
     model = Response
 
     def get_queryset(self):
-        video_queryset = Video.objects.only("full_name")
-
         study = self.study
         return (
             study.responses_for_researcher(self.request.user)
@@ -856,7 +854,7 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
                 ),
                 Prefetch(
                     "videos",
-                    queryset=video_queryset,
+                    queryset=Video.objects.only("id", "full_name", "response_id"),
                     to_attr="prefetched_videos",
                 ),
             )
@@ -912,7 +910,7 @@ class StudyResponsesList(CanViewStudyResponsesMixin, generic.ListView):
 
             video_info = [
                 {
-                    "pk": v.pk,
+                    "pk": v.id,
                     "display_name": (
                         v.full_name.replace(
                             "videoStream_{}_".format(study.uuid), "..."


### PR DESCRIPTION
This PR modifies the Video Prefetch queryset to include all of the fields that are needed by the Individual Responses page. I added this Video Prefetch recently but somehow missed the fact that not all necessary fields were included, so the view was producing one additional query per Video to get the non-prefetched fields. 

Tested on Study 374 from staging. 

**Before (develop branch)**

Page load time: 3.61 seconds
Number of queries: 342, including 330 similar (these are the separate repeated queries for each video because some fields were left out of the prefetch)

![IR_page_load_video_queryset_before](https://github.com/user-attachments/assets/d2652d89-1062-422c-a162-c92bf10ac1e0)

![IR_page_sql_video_queryset_before](https://github.com/user-attachments/assets/b47fd5cd-5416-4fda-8075-355bea98f59e)

**After (this branch)**

Page load time: 1.02 seconds
Number of queries: 12, including 2 duplicates

![IR_page_load_video_queryset_after](https://github.com/user-attachments/assets/087f69d3-abdf-4741-8fea-33d1c28b951a)

![IR_page_sql_video_queryset_after](https://github.com/user-attachments/assets/cd398a96-02fb-4221-b021-0ad33e969da1)

Note that there are still two duplicate queries happening with this view. It's not immediately clear to me where these are coming from. So this view might benefit from more optimization, but this change is at least a step in the right direction.