### PR TITLE
Django 4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@2.1.1
+  python: circleci/python@3
 
 jobs:
   test: 
     docker:
       - image: cimg/python:3.9
-      - image: cimg/postgres:9.6
+      - image: cimg/postgres:17.4
     steps:
       - checkout
       - run:

--- a/accounts/__init__.py
+++ b/accounts/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "accounts.apps.AccountsConfig"

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -13,6 +13,7 @@ from accounts.models import (
 )
 
 
+@admin.register(Child)
 class ChildAdmin(GuardedModelAdmin):
     list_display = ("id", "uuid", "given_name", "birthday", "user")
     # list_filter = (
@@ -26,6 +27,7 @@ class ChildAdmin(GuardedModelAdmin):
     raw_id_fields = ("user",)
 
 
+@admin.register(User)
 class UserAdmin(GuardedModelAdmin):
     list_display = (
         "id",
@@ -44,11 +46,13 @@ class UserAdmin(GuardedModelAdmin):
     actions = (set_selected_as_spam,)
 
 
+@admin.register(DemographicData)
 class DemographicDataAdmin(GuardedModelAdmin):
     list_display = ("uuid", "created_at", "user", "lookit_referrer")
     raw_id_fields = ("user",)
 
 
+@admin.register(Message)
 class MessageAdmin(GuardedModelAdmin):
     list_display = ("date_created", "sender", "subject")
     list_filter = ("related_study",)
@@ -57,16 +61,10 @@ class MessageAdmin(GuardedModelAdmin):
     search_fields = ["subject", "body"]
 
 
+@admin.register(GoogleAuthenticatorTOTP)
 class TOTPAdmin(GuardedModelAdmin):
     list_display = ("user",)
     search_fields = ("user__username", "user__family_name")
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("user")
-
-
-admin.site.register(User, UserAdmin)
-admin.site.register(DemographicData, DemographicDataAdmin)
-admin.site.register(Child, ChildAdmin)
-admin.site.register(Message, MessageAdmin)
-admin.site.register(GoogleAuthenticatorTOTP, TOTPAdmin)

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -52,7 +52,7 @@ class VideoFromS3Permissions:
         """
         if request.method == "POST":
             try:
-                signature_received = request.META["HTTP_X_AWS_LAMBDA_HMAC_SIG"]
+                signature_received = request.headers["x-aws-lambda-hmac-sig"]
             except KeyError:
                 try:
                     signature_received = request.META["headers"][

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import include, re_path
 from rest_framework_nested import routers
 
 from api import views as api_views

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 from rest_framework_nested import routers
 
 from api import views as api_views
@@ -39,10 +40,10 @@ feedback_router = routers.NestedSimpleRouter(router, r"feedback", lookup="feedba
 
 pattern = r"^(?P<version>(v1|v2))/"
 urlpatterns = [
-    url(pattern, include(user_router.urls)),
-    url(pattern, include(study_router.urls)),
-    url(pattern, include(child_router.urls)),
-    url(pattern, include(response_router.urls)),
-    url(pattern, include(feedback_router.urls)),
-    url(pattern, include(router.urls)),
+    re_path(pattern, include(user_router.urls)),
+    re_path(pattern, include(study_router.urls)),
+    re_path(pattern, include(child_router.urls)),
+    re_path(pattern, include(response_router.urls)),
+    re_path(pattern, include(feedback_router.urls)),
+    re_path(pattern, include(router.urls)),
 ]

--- a/exp/admin.py
+++ b/exp/admin.py
@@ -13,6 +13,7 @@ from studies.models import (
 )
 
 
+@admin.register(Study)
 class StudyAdmin(GuardedModelAdmin):
     list_display = ("uuid", "name", "state", "public", "creator", "built")
     list_filter = ("state", "lab")
@@ -30,6 +31,7 @@ class StudyAdmin(GuardedModelAdmin):
     )
 
 
+@admin.register(Lab)
 class LabAdmin(GuardedModelAdmin):
     list_display = ("uuid", "name", "institution", "principal_investigator_name")
     search_fields = ["name", "institution", "principal_investigator_name"]
@@ -38,6 +40,7 @@ class LabAdmin(GuardedModelAdmin):
     filter_horizontal = ("researchers", "requested_researchers")
 
 
+@admin.register(Response)
 class ResponseAdmin(GuardedModelAdmin):
     list_display = (
         "date_created",
@@ -56,6 +59,7 @@ class ResponseAdmin(GuardedModelAdmin):
     date_hierarchy = "date_created"
 
 
+@admin.register(Feedback)
 class FeedbackAdmin(GuardedModelAdmin):
     list_display = ("uuid", "researcher", "response", "comment")
     search_fields = (
@@ -68,15 +72,18 @@ class FeedbackAdmin(GuardedModelAdmin):
     raw_id_fields = ("researcher", "response")
 
 
+@admin.register(StudyLog)
 class StudyLogAdmin(GuardedModelAdmin):
     list_filter = ("study",)
     raw_id_fields = ("study", "user")
 
 
+@admin.register(StudyType)
 class StudyTypeAdmin(GuardedModelAdmin):
     pass
 
 
+@admin.register(Video)
 class VideoAdmin(GuardedModelAdmin):
     list_display = (
         "uuid",
@@ -95,18 +102,9 @@ class VideoAdmin(GuardedModelAdmin):
     search_fields = ["uuid", "full_name"]
 
 
+@admin.register(ConsentRuling)
 class ConsentRulingAdmin(GuardedModelAdmin):
     list_display = ("uuid", "created_at", "action", "arbiter")
     list_filter = ("response__study", "arbiter")
     date_hierarchy = "created_at"
     raw_id_fields = ("arbiter", "response")
-
-
-admin.site.register(Study, StudyAdmin)
-admin.site.register(Response, ResponseAdmin)
-admin.site.register(StudyLog, StudyLogAdmin)
-admin.site.register(Feedback, FeedbackAdmin)
-admin.site.register(StudyType, StudyTypeAdmin)
-admin.site.register(Video, VideoAdmin)
-admin.site.register(ConsentRuling, ConsentRulingAdmin)
-admin.site.register(Lab, LabAdmin)

--- a/exp/views/lab.py
+++ b/exp/views/lab.py
@@ -454,7 +454,7 @@ class LabMembershipRequestView(
     test_func = can_request_lab_membership
 
     def get_redirect_url(self, *args, **kwargs):
-        return self.request.META.get("HTTP_REFERER", reverse("exp:lab-list"))
+        return self.request.headers.get("referer", reverse("exp:lab-list"))
 
     def post(self, request, *args, **kwargs):
         user = self.request.user

--- a/exp/views/video.py
+++ b/exp/views/video.py
@@ -37,7 +37,7 @@ class RenameVideoView(View):
         # Authenticate the webhook (see https://addpipe.com/docs#authenticating-webhooks)
         key = settings.PIPE_WEBHOOK_KEY
         # Append the JSON POST data received via webhook to the URL string.
-        thisURL = request.scheme + "://" + request.META["HTTP_HOST"] + request.path
+        thisURL = request.scheme + "://" + request.headers["host"] + request.path
         message = thisURL + postbody["payload"][0]  # TODO
         key = bytes(key, "UTF-8")
         message = bytes(message, "UTF-8")
@@ -47,7 +47,7 @@ class RenameVideoView(View):
         # Base64 encode the binary signature.
         signatureComputed = base64.b64encode(signatureBinary)
         # Compare to the one in the header
-        signatureSent = bytes(request.META["HTTP_X_PIPE_SIGNATURE"], "UTF-8")
+        signatureSent = bytes(request.headers["x-pipe-signature"], "UTF-8")
         authenticated = signatureComputed == signatureSent
 
         d = ast.literal_eval(

--- a/project/fields/datetime_aware_jsonfield.py
+++ b/project/fields/datetime_aware_jsonfield.py
@@ -10,9 +10,9 @@ import ciso8601
 import pytz
 from django.contrib.postgres import lookups
 from django.contrib.postgres.fields.jsonb import JSONField
-from django.contrib.postgres.forms.jsonb import JSONField as JSONFormField
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
+from django.forms import JSONField as JSONFormField
 from psycopg2.extras import Json
 
 

--- a/project/fields/datetime_aware_jsonfield.py
+++ b/project/fields/datetime_aware_jsonfield.py
@@ -9,9 +9,9 @@ from functools import partial
 import ciso8601
 import pytz
 from django.contrib.postgres import lookups
-from django.contrib.postgres.fields.jsonb import JSONField
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
+from django.db.models import JSONField
 from django.forms import JSONField as JSONFormField
 from psycopg2.extras import Json
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -231,7 +231,6 @@ TIME_ZONE = "America/New_York"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/project/urls.py
+++ b/project/urls.py
@@ -15,13 +15,12 @@ Including another URLconf
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
 
-from django.conf.urls import include
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.auth.urls import urlpatterns as auth_urls
-from django.urls import path
+from django.urls import include, path
 from more_itertools import locate
 
 from accounts import urls as accounts_urls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,18 +3,18 @@ name = "lookit-api"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9,<3.10"
+requires-python = "==3.9.*"
 dependencies = [
     "bcrypt==3.2.0",
     "boto3==1.20.50",
     "celery==4.4.7",
     "ciso8601==2.1.3",
-    "django==3.2.25",
+    "django==4.0",
     "django-ace-overlay",
-    "django-bitfield==2.1.0",
+    "django-bitfield==2.2.0",
     "django-bootstrap-icons==0.8.2",
     "django-bootstrap5==22.2",
-    "django-celery-beat==2.0.0",
+    "django-celery-beat==2.1.0",
     "django-cors-headers==3.13.0",
     "django-countries==7.2.1",
     "django-extensions==3.1.5",

--- a/uv.lock
+++ b/uv.lock
@@ -230,16 +230,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "3.2.25"
+version = "4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
-    { name = "pytz" },
     { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/68/0e744f07b57bfdf99abbb6b3eb14fcba188867021c05f4a104e04f6d56b8/Django-3.2.25.tar.gz", hash = "sha256:7ca38a78654aee72378594d63e51636c04b8e28574f5505dff630895b5472777", size = 9836336 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/32/390205123250b54438a6cb3e0c9b5fd0347c318df744f32b50d8e10260d0/Django-4.0.tar.gz", hash = "sha256:d5a8a14da819a8b9237ee4d8c78dfe056ff6e8a7511987be627192225113ee75", size = 9980403 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/8e/cc23c762c5dcd1d367d73cf006a326e0df2bd0e785cba18b658b39904c1e/Django-3.2.25-py3-none-any.whl", hash = "sha256:a52ea7fcf280b16f7b739cec38fa6d3f8953a5456986944c3ca97e79882b4e38", size = 7890550 },
+    { url = "https://files.pythonhosted.org/packages/80/70/52fce3520b7a1421685828b04f76d5a26aabc7603fdb7af26c4ca7bb0512/Django-4.0-py3-none-any.whl", hash = "sha256:59304646ebc6a77b9b6a59adc67d51ecb03c5e3d63ed1f14c909cdfda84e8010", size = 8014008 },
 ]
 
 [[package]]
@@ -249,16 +249,13 @@ source = { git = "https://github.com/lookit/django-ace-overlay.git?rev=master#4b
 
 [[package]]
 name = "django-bitfield"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/83/9415c6cdd77d6f7574ce55d9e7b8016f4194f290593c66e6e40592bcf69f/django-bitfield-2.1.0.tar.gz", hash = "sha256:a55859fd16ce4269d5ceed3e20cf8fc3c2df866f0a78b90c60a19a0e76aa5fd8", size = 15458 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/dc/bfcf2b9cc5dc3832430f0ca39a36caaa771234fdd7601a15bd0c25d1178f/django_bitfield-2.1.0-py2.py3-none-any.whl", hash = "sha256:158f1056e22cce450d0a49633ea77bfd84b85a2294b1ef03faa775a485f4065d", size = 18085 },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/fc/872e9c94107a7ed3b9534c76be29cdc6697cc27332075fccc384e8c30b93/django-bitfield-2.2.0.tar.gz", hash = "sha256:1b21262acc4ec0af3f82ed04498a056cd9d5452532ac02771e004835a34e0b1b", size = 17365 }
 
 [[package]]
 name = "django-bootstrap-icons"
@@ -287,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "django-celery-beat"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery" },
@@ -295,9 +292,9 @@ dependencies = [
     { name = "django-timezone-field" },
     { name = "python-crontab" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/c5/96827d3fc2d73ff542515abd1b39cab06c156e09092466532c7bf68a07f8/django-celery-beat-2.0.0.tar.gz", hash = "sha256:fdf1255eecfbeb770c6521fe3e69989dfc6373cd5a7f0fe62038d37f80f47e48", size = 84547 }
+sdist = { url = "https://files.pythonhosted.org/packages/23/f5/5e706413a77ffce06f874835487a84f2b7e5a6f8b18a010011473d35933f/django-celery-beat-2.1.0.tar.gz", hash = "sha256:4eb0e8412e2e05ba0029912a6f80d1054731001eecbcb4d59688c4e07cf4d9d3", size = 85573 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/f6/921b6859b7107efd2dabb7937b88162842034c3b93444d1322f44beb047a/django_celery_beat-2.0.0-py2.py3-none-any.whl", hash = "sha256:fe0b2a1b31d4a6234fea4b31986ddfd4644a48fab216ce1843f3ed0ddd2e9097", size = 37192 },
+    { url = "https://files.pythonhosted.org/packages/34/cb/e0e8200a57b8b7433448444749ca9be3561e6e029d227f21037f28123d6d/django_celery_beat-2.1.0-py2.py3-none-any.whl", hash = "sha256:8a169e11d96faed8b72d505ddbc70e7fe0b16cdc854df43cb209c153ed08d651", size = 38264 },
 ]
 
 [[package]]
@@ -809,12 +806,12 @@ requires-dist = [
     { name = "boto3", specifier = "==1.20.50" },
     { name = "celery", specifier = "==4.4.7" },
     { name = "ciso8601", specifier = "==2.1.3" },
-    { name = "django", specifier = "==3.2.25" },
+    { name = "django", specifier = "==4.0" },
     { name = "django-ace-overlay", git = "https://github.com/lookit/django-ace-overlay.git?rev=master" },
-    { name = "django-bitfield", specifier = "==2.1.0" },
+    { name = "django-bitfield", specifier = "==2.2.0" },
     { name = "django-bootstrap-icons", specifier = "==0.8.2" },
     { name = "django-bootstrap5", specifier = "==22.2" },
-    { name = "django-celery-beat", specifier = "==2.0.0" },
+    { name = "django-celery-beat", specifier = "==2.1.0" },
     { name = "django-cors-headers", specifier = "==3.13.0" },
     { name = "django-countries", specifier = "==7.2.1" },
     { name = "django-extensions", specifier = "==3.1.5" },
@@ -1274,11 +1271,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "76.0.0"
+version = "78.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/32/d2/7b171caf085ba0d40d8391f54e1c75a1cda9255f542becf84575cfd8a732/setuptools-76.0.0.tar.gz", hash = "sha256:43b4ee60e10b0d0ee98ad11918e114c70701bc6051662a9a675a0496c1a158f4", size = 1349387 }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54", size = 1367827 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/66/d2d7e6ad554f3a7c7297c3f8ef6e22643ad3d35ef5c63bf488bc89f32f31/setuptools-76.0.0-py3-none-any.whl", hash = "sha256:199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6", size = 1236106 },
+    { url = "https://files.pythonhosted.org/packages/54/21/f43f0a1fa8b06b32812e0975981f4677d28e0f3271601dc88ac5a5b83220/setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8", size = 1256108 },
 ]
 
 [[package]]
@@ -1336,6 +1333,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

This PR move Django to version 4.0

Changes:

- Celery-Beat's and Bitfield's version was also incremented.
- "Urls" was replaced with "re_path".
- For forms with JSON, there's a built in JSON field now.
- Postgres version needs to be higher then 10.