### PR TITLE
Possible fix for `uv` build error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ dependencies = [
     "docker==4.2.1",
     "drf-nested-routers==0.93.3",
     "fleep==1.0.1",
-    "gevent==21.12.0",
+    "gevent==23.9.1",
     "google-cloud-storage==2.1.0",
-    "greenlet==1.1.2",
+    "greenlet==2.0.0",
     "kombu==4.6.11",
     "lark-parser==0.12.0",
     "more-itertools==8.8.0",
@@ -71,3 +71,6 @@ django-revproxy = { git = "https://github.com/Innovativity/django-revproxy.git",
 
 [tool.ruff]
 lint.select = ["F", "I", "TID"]
+
+[tool.setuptools.packages.find]
+include = ["accounts", "api", "exp", "project", "studies", "web"]

--- a/uv.lock
+++ b/uv.lock
@@ -533,23 +533,22 @@ sdist = { url = "https://files.pythonhosted.org/packages/7e/dc/4ff28535d084c2cbb
 
 [[package]]
 name = "gevent"
-version = "21.12.0"
+version = "23.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
     { name = "greenlet", marker = "platform_python_implementation == 'CPython'" },
-    { name = "setuptools" },
     { name = "zope-event" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/18/631398e45c109987f2d8e57f3adda161cc5ff2bd8738ca830c3a2dd41a85/gevent-21.12.0.tar.gz", hash = "sha256:f48b64578c367b91fa793bf8eaaaf4995cb93c8bc45860e473bf868070ad094e", size = 6201851 }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ce/d2b9a376ee010f6d548bf1b6b6eddc372a175e6e100896e607c57e37f7cf/gevent-23.9.1.tar.gz", hash = "sha256:72c002235390d46f94938a96920d8856d4ffd9ddf62a303a0d7c118894097e34", size = 5847705 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/82/291bb4e2fa64a2845d38cb0021f357ae2bce6a41ee9851b0d9494de2d21b/gevent-21.12.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:ec21f9eaaa6a7b1e62da786132d6788675b314f25f98d9541f1bf00584ed4749", size = 1871313 },
-    { url = "https://files.pythonhosted.org/packages/e8/40/826e541d8fec71a3725bdd0a45fbb66999a3c9031145d36580f233fa96c4/gevent-21.12.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:22ce1f38fdfe2149ffe8ec2131ca45281791c1e464db34b3b4321ae9d8d2efbb", size = 6164236 },
-    { url = "https://files.pythonhosted.org/packages/14/6a/c39a5c3cc3c2f924b3b4a3571a5a7f926a1f32bdadc19f9731907c6b20af/gevent-21.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ccffcf708094564e442ac6fde46f0ae9e40015cb69d995f4b39cc29a7643881", size = 4819073 },
-    { url = "https://files.pythonhosted.org/packages/0f/30/ca9a6aabca8c6a2b9b0c8559751b4383e9bc91a7c6aff33650a2cfe8817d/gevent-21.12.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:24d3550fbaeef5fddd794819c2853bca45a86c3d64a056a2c268d981518220d1", size = 6473175 },
-    { url = "https://files.pythonhosted.org/packages/37/b8/c24f05f8116021b90ce5ea98d1da161b6c5f3794d32ae1671485be2b9f81/gevent-21.12.0-cp39-cp39-win32.whl", hash = "sha256:2bcec9f80196c751fdcf389ca9f7141e7b0db960d8465ed79be5e685bfcad682", size = 1454787 },
-    { url = "https://files.pythonhosted.org/packages/83/6c/8850930977a298679c03ad597650976e109d00c2c10021975e37f2f2eebf/gevent-21.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:3dad62f55fad839d498c801e139481348991cee6e1c7706041b5fe096cb6a279", size = 1621236 },
+    { url = "https://files.pythonhosted.org/packages/85/b3/fdce683ff8f560c4f205d766d3d24f4663d25f8ab4fb13bda1f8e0023a45/gevent-23.9.1-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:bf456bd6b992eb0e1e869e2fd0caf817f0253e55ca7977fd0e72d0336a8c1c6a", size = 2944107 },
+    { url = "https://files.pythonhosted.org/packages/b0/84/5100b62b0985f9c81f954f489b26be9a38e01e66e546ba3e6655f637457b/gevent-23.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43daf68496c03a35287b8b617f9f91e0e7c0d042aebcc060cadc3f049aadd653", size = 6441187 },
+    { url = "https://files.pythonhosted.org/packages/c3/49/2a85e786cdd1e22e639d3e014579992bbc715719c0a03e93b8c2037ed810/gevent-23.9.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:7c28e38dcde327c217fdafb9d5d17d3e772f636f35df15ffae2d933a5587addd", size = 6394657 },
+    { url = "https://files.pythonhosted.org/packages/38/83/f112044e77edf472ae7ff290e75c44ee2ddb6052582bb31bffc3a36e800e/gevent-23.9.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:fae8d5b5b8fa2a8f63b39f5447168b02db10c888a3e387ed7af2bd1b8612e543", size = 6577275 },
+    { url = "https://files.pythonhosted.org/packages/be/1f/8ec315e9d2d76513e5530caca1ee293db5343036c8dbe360ff50b484f0f8/gevent-23.9.1-cp39-cp39-win32.whl", hash = "sha256:2c7b5c9912378e5f5ccf180d1fdb1e83f42b71823483066eddbe10ef1a2fcaa2", size = 1453456 },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/9f4fc6527017260baf7b0756396fb272a3a3d2cd0932f519f4c4dd44003c/gevent-23.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:a2898b7048771917d85a1d548fd378e8a7b2ca963db8e17c6d90c76b495e0e2b", size = 1542758 },
 ]
 
 [[package]]
@@ -654,19 +653,19 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "1.1.2"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/10/754e21b5bea89d0e73f99d60c83754df7cc64db74f47d98ab187669ce341/greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a", size = 91224 }
+sdist = { url = "https://files.pythonhosted.org/packages/23/6f/f72865c589d0c79f03b51520a4cdd65647de0513e9ad107a5731df89c235/greenlet-2.0.0.tar.gz", hash = "sha256:6c66f0da8049ee3c126b762768179820d4c0ae0ca46ae489039e4da2fae39a52", size = 161272 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/e1/37db23293372c8b077675832b2f6a4ff3168a451c40bd329588825aa02dd/greenlet-1.1.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67", size = 92793 },
-    { url = "https://files.pythonhosted.org/packages/08/c6/0bd71c28d7f318ce4a73c6d8d26130233863070f418e5c340ffb7fa609da/greenlet-1.1.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:572e1787d1460da79590bf44304abbc0a2da944ea64ec549188fa84d89bba7ab", size = 169154 },
-    { url = "https://files.pythonhosted.org/packages/c5/c8/9f41dabc0542f6d1d9e746bd530666ba44b2609533de22e723dc3c160273/greenlet-1.1.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:be5f425ff1f5f4b3c1e33ad64ab994eed12fc284a6ea71c5243fd564502ecbe5", size = 169156 },
-    { url = "https://files.pythonhosted.org/packages/4d/70/8bc33ca00820dcae9ad0c7cae19088a45faf386e6d467de015655de395ce/greenlet-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88", size = 154772 },
-    { url = "https://files.pythonhosted.org/packages/2f/5a/28d7f5d3afddf2669f68f9779b71946a6903c89af1dcfd750a14ce3b55c7/greenlet-1.1.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b", size = 158263 },
-    { url = "https://files.pythonhosted.org/packages/af/55/e60bc4c2bd7cad081a29f2e046f1e28e45e8529025c07ce725a84d235312/greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3", size = 153625 },
-    { url = "https://files.pythonhosted.org/packages/61/f1/314caccf5e024d43801d9efff6facef52528bdfe2f3f3ef0883ae53c17cb/greenlet-1.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3", size = 708646 },
-    { url = "https://files.pythonhosted.org/packages/9c/aa/49ab5629df48b08c9e509b98a7b2b9f67c923ae800c8d09d7af31e49ecb7/greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf", size = 98982 },
-    { url = "https://files.pythonhosted.org/packages/bb/7b/2ac66aa5f9b7e07d62cd6c2c95d44036b609bda80e8739202e3551ee7bf3/greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd", size = 101904 },
+    { url = "https://files.pythonhosted.org/packages/26/74/5acabb08ff6c8c8a77111ce98477a922cdec5a647a779895537747a97083/greenlet-2.0.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:e7ec3f2465ba9b7d25895307abe1c1c101a257c54b9ea1522bbcbe8ca8793735", size = 200619 },
+    { url = "https://files.pythonhosted.org/packages/95/f8/a0eb1dc3d03e8a28f7b2d0fe0f34523c2672ae5162c3cdbd45360473f804/greenlet-2.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:99e9851e40150504474915605649edcde259a4cd9bce2fcdeb4cf33ad0b5c293", size = 550472 },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/63af587c72d79d61873374a49394671cabfe9c3cf3e73a2dae5256303a33/greenlet-2.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20bf68672ae14ef2e2e6d3ac1f308834db1d0b920b3b0674eef48b2dce0498dd", size = 523255 },
+    { url = "https://files.pythonhosted.org/packages/40/26/b5463da35ea95fb1f3eaf2d26fcc959c71e73a6f2a5d069bb1809dbec48c/greenlet-2.0.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30198bccd774f9b6b1ba7564a0d02a79dd1fe926cfeb4107856fe16c9dfb441c", size = 535855 },
+    { url = "https://files.pythonhosted.org/packages/86/a9/1733b6f1432147afcfe6e0e98160775c91053c3a835ae7779b9e922196cb/greenlet-2.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d65d7d1ff64fb300127d2ffd27db909de4d21712a5dde59a3ad241fb65ee83d7", size = 532953 },
+    { url = "https://files.pythonhosted.org/packages/a4/66/c017f3db3df59ed8a78736fbced77c1fbefebd57ad154a578308788e5991/greenlet-2.0.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2f5d396a5457458460b0c28f738fc8ab2738ee61b00c3f845c7047a333acd96c", size = 1038641 },
+    { url = "https://files.pythonhosted.org/packages/1d/38/4483fd00e2dfdc1b87a76d25853b3b706fc66060274abbac7d5a9024911b/greenlet-2.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:09f00f9938eb5ae1fe203558b56081feb0ca34a2895f8374cd01129ddf4d111c", size = 1062278 },
+    { url = "https://files.pythonhosted.org/packages/96/1f/3e97a9bd8daa8139a4a0e9442a775e231be02504f7e35d4d25df777567f7/greenlet-2.0.0-cp39-cp39-win32.whl", hash = "sha256:089e123d80dbc6f61fff1ff0eae547b02c343d50968832716a7b0a33bea5f792", size = 184653 },
+    { url = "https://files.pythonhosted.org/packages/7f/1a/cf6f11c92dac40d685e89a2610a33e3415c5a1c03dc7e8d3c110f9f07cd1/greenlet-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc283f99a4815ef70cad537110e3e03abcef56ab7d005ba9a8c6ec33054ce9c0", size = 187864 },
 ]
 
 [[package]]
@@ -832,9 +831,9 @@ requires-dist = [
     { name = "docker", specifier = "==4.2.1" },
     { name = "drf-nested-routers", specifier = "==0.93.3" },
     { name = "fleep", specifier = "==1.0.1" },
-    { name = "gevent", specifier = "==21.12.0" },
+    { name = "gevent", specifier = "==23.9.1" },
     { name = "google-cloud-storage", specifier = "==2.1.0" },
-    { name = "greenlet", specifier = "==1.1.2" },
+    { name = "greenlet", specifier = "==2.0.0" },
     { name = "kombu", specifier = "==4.6.11" },
     { name = "lark-parser", specifier = "==0.12.0" },
     { name = "more-itertools", specifier = "==8.8.0" },


### PR DESCRIPTION
### Description

This PR makes a few changes that fix some errors that I get on `develop` when I run `uv sync` (errors pasted below). 

The first error was about being unable to build the `gevent` package (pinned version 21.12.0) because of incompatibility with Cython (not listed/pinned). I tried downgrading my Cython version, but that didn't fix it. Upgrading my `gevent` version to 23.9.1 did fix the problem, but I also had to upgrade `greenlet` to 2.0.0.

The second error was related to setuptools trying to treat all top-level directories as Python packages. This just required adding `tool.setuptools.packages.find` to `pyproject.toml` with a list of the top-level directories that are actually Python packages.

### Changes in this PR

- Update `gevent` to 23.9.1 and `greenlet` to 2.0.0.
- Add `setuptools.packages.find` with the list of our top-level directories that are Python package.

### `gevent` build error

```zsh
% make uv
uv self update
info: Checking for updates...
success: You're on the latest version of uv (v0.6.14)
uv sync
Using CPython 3.9.22 interpreter at: /Users/beckygilbert/.pyenv/versions/3.9.22/bin/python3.9
Creating virtual environment at: .venv
Resolved 107 packages in 0.58ms
    Updated https://github.com/lookit/django-ace-overlay.git (4b174f78c6d6aaaee961e220c9461cbe74c861da)
    Updated https://github.com/Innovativity/django-revproxy.git (b9fa8375d03fd68747dcb7273a97c19d788aa51b)
      Built fleep==1.0.1
      Built pydenticon==0.3.1
      Built ciso8601==2.1.3
      Built sendgrid-django==4.2.0
      Built psycogreen==1.0.2
      Built greenlet==1.1.2
      Built django-revproxy @ git+https://github.com/Innovativity/django-revproxy.git@b9fa8375d03fd68747dcb7273a97c1
      Built uwsgi==2.0.22
      Built django-ace-overlay @ git+https://github.com/lookit/django-ace-overlay.git@4b174f78c6d6aaaee961e220c9461c                                                                                                              × Failed to build `gevent==21.12.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stdout]
      Compiling src/gevent/resolver/cares.pyx because it changed.
      [1/1] Cythonizing src/gevent/resolver/cares.pyx
      Compiling src/gevent/libev/corecext.pyx because it changed.
      [1/1] Cythonizing src/gevent/libev/corecext.pyx

      [stderr]
      performance hint: src/gevent/libev/corecext.pyx:1325:0: Exception check on '_syserr_cb' will always
      require the GIL to be acquired.
      Possible solutions:
      	1. Declare '_syserr_cb' as 'noexcept' if you control the definition and you're sure you don't want the
      function to raise exceptions.
      	2. Use an 'int' return type on '_syserr_cb' to allow an error code to be returned.

      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      cdef tuple integer_types

      if sys.version_info[0] >= 3:
          integer_types = int,
      else:
          integer_types = (int, long)
                                ^
      ------------------------------------------------------------

      src/gevent/libev/corecext.pyx:60:26: undeclared name not builtin: long
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File
      "/Users/beckygilbert/.cache/uv/builds-v0/.tmp6s4QZF/lib/python3.9/site-packages/setuptools/build_meta.py",
      line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File
      "/Users/beckygilbert/.cache/uv/builds-v0/.tmp6s4QZF/lib/python3.9/site-packages/setuptools/build_meta.py",
      line 304, in _get_build_requires
          self.run_setup()
        File
      "/Users/beckygilbert/.cache/uv/builds-v0/.tmp6s4QZF/lib/python3.9/site-packages/setuptools/build_meta.py",
      line 522, in run_setup
          super().run_setup(setup_script=setup_script)
        File
      "/Users/beckygilbert/.cache/uv/builds-v0/.tmp6s4QZF/lib/python3.9/site-packages/setuptools/build_meta.py",
      line 320, in run_setup
          exec(code, locals())
        File "<string>", line 50, in <module>
        File
      "/Users/beckygilbert/.cache/uv/sdists-v9/pypi/gevent/21.12.0/3FGa2vaxl5gJm2bt_0dOv/src/_setuputils.py",
      line 237, in cythonize1
          new_ext = cythonize(
        File
      "/Users/beckygilbert/.cache/uv/builds-v0/.tmp6s4QZF/lib/python3.9/site-packages/Cython/Build/Dependencies.py",
      line 1112, in cythonize
          cythonize_one(*args)
        File
      "/Users/beckygilbert/.cache/uv/builds-v0/.tmp6s4QZF/lib/python3.9/site-packages/Cython/Build/Dependencies.py",
      line 1255, in cythonize_one
          raise CompileError(None, pyx_file)
      Cython.Compiler.Errors.CompileError: src/gevent/libev/corecext.pyx

      hint: This usually indicates a problem with the package or the build environment.
  help: `gevent` (v21.12.0) was included because `lookit-api` (v0.1.0) depends on `gevent`
make: *** [uv] Error 1
```

### Automatic package detection error

```zsh
% uv sync

Resolved 107 packages in 1.93s
  × Failed to build `lookit-api @ file:///Users/beckygilbert/projects/lookit-api`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_editable` failed (exit status: 1)

      [stderr]
      error: Multiple top-level packages discovered in a flat-layout: ['web', 'api', 'exp', 'scss', 'data',
      'certs', 'locale', 'studies', 'project', 'accounts', 'ember_build', 'my_localstack_init'].

      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.

      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:

      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names

      To find more information, look for "package discovery" on setuptools docs.

      hint: This usually indicates a problem with the package or the build environment.
```

### Bonus: virtual environment warning

This was just a warning so not a big deal, but in case anyone else sees the same thing: after running `uv sync`, I get a warning that I have a `VIRTUAL_ENV` value set that will be ignored in favor of my local `.venv`:

```zsh
uv sync
warning: `VIRTUAL_ENV=/Users/beckygilbert/Library/Caches/pypoetry/virtualenvs/lookit-api-KxWcQ2Jc-py3.9` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
```

to get rid of this warning, just run `unset VIRTUAL_ENV`.