### PR TITLE
Add `--no-cache` arg to build image steps

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,6 +40,7 @@ steps:
   name: gcr.io/cloud-builders/docker
   args: [
     'build',
+    '--no-cache',
     '--tag',
     'lookit',
     '--build-arg',
@@ -54,6 +55,7 @@ steps:
   name: gcr.io/cloud-builders/docker
   args: [
     'build',
+    '--no-cache',
     '--tag',
     'lookit-test',
     '--build-arg',


### PR DESCRIPTION
This PR adds `--no-cache` to our two build image steps. 

The most recent build/deploy on staging was not clean (it still resulted in server 500 errors despite the fact that the rebuild was successful and I was reverting to a known working version). Adding the `--no-cache` argument seems to have helped - staging worked again after rebuilding with this change to `cloudbuild.yaml`. It's possible that triggering another rebuild without this change would also have worked, but even if so, this shouldn't cause any problems. 