### PR TITLE
Set Dependabot's ecosystem to UV

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Summary

Let Dependabot know that we're using UV as our package manager.  