### PR TITLE
Fix `'datetime.timezone' has no attribute 'now'`

### DIFF
--- a/studies/models.py
+++ b/studies/models.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 
 import boto3
@@ -15,6 +15,7 @@ from django.db import models
 from django.db.models.signals import post_save, pre_delete, pre_save
 from django.dispatch import receiver
 from django.shortcuts import reverse
+from django.utils import timezone
 from django.utils.translation import gettext as _
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
 from guardian.shortcuts import get_users_with_perms


### PR DESCRIPTION
This PR fixes the following error on `develop`/staging: `type object 'datetime.timezone' has no attribute 'now'`. I'm not sure but I'm guessing this came up because of the `datetime` package updates included in our Python version updates and the `pytz`-> `zoneinfo` change.

This PR fixes the problem by using `timezone.now` from `django.utils` instead of `datetime`. There are other ways to fix this, but this approach is consistent with our other timezone-aware timestamps in `studies/tasks.py` and a few other test and migration files.

This change affects the following:
- Study state changes (e.g. submit, approve, etc.) 
- `days_submitted` study property, which is shown at `exp/studies/submitted/`

## Screenshots

### Current errors

Study state change error:

![Screenshot 2025-05-02 at 2 24 47 PM](https://github.com/user-attachments/assets/dfe9b693-83b0-48e2-bf4f-7de48b2b4933)

Submitted study list page load error:

![Screenshot 2025-05-02 at 2 24 07 PM](https://github.com/user-attachments/assets/de8e3f7f-33d2-44c8-9e6e-3dbf244bd126)

### After this fix

Study state change is successful:

![Screenshot 2025-05-02 at 2 25 45 PM](https://github.com/user-attachments/assets/0061902d-36c4-4828-96ef-a12fbfdc20e2)

Submitted study list loads and shows days in queue (computed using days_submitted):

![Screenshot 2025-05-02 at 2 26 23 PM](https://github.com/user-attachments/assets/427d0f44-fef0-470f-a256-f0eddb1a7e3b)
