### PR TITLE
Fix EFP build error

### DIFF
--- a/studies/experiment_builder.py
+++ b/studies/experiment_builder.py
@@ -211,7 +211,7 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
         study.metadata["last_known_player_sha"] = player_sha
 
         container_checkout_directory = os.path.join("/checkouts/", checkout_directory)
-        container_destination_directory = os.path.join("/deployments/", study_uuid)
+        container_destination_directory = os.path.join("/deployments/", str(study_uuid))
 
         self.build_context["container_paths"] = DirectoryTargets(
             checkouts=container_checkout_directory,

--- a/studies/experiment_builder.py
+++ b/studies/experiment_builder.py
@@ -164,7 +164,7 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
     )
 
     def __init__(self, *args, **kwargs):
-        kwargs["destination_directory"] = kwargs["study_uuid"]
+        kwargs["destination_directory"] = str(kwargs["study_uuid"])
         super().__init__(*args, **kwargs)
 
     def get_study(self, study_uuid):


### PR DESCRIPTION
Fixes #1588

Following some package updates, the EFP builds have started failing. Specifically, the 'get_container_directories' step fails with a type error: "join() argument must be str, bytes, or os.PathLike object, not 'UUID'". It seems that `os.path.join` used to coerce non-strings into strings, and does not do that anymore, so we need to explicitly convert any non-string arguments to strings. 

I had a look through the other places where we use `os.path.join` and couldn't see other cases that look like they'll produce the same error. 