### PR TITLE
Where image name is hardcoded in the database, we force it to lower case

### DIFF
--- a/studies/templates/studies/_image_display.html
+++ b/studies/templates/studies/_image_display.html
@@ -10,7 +10,7 @@
         <img class="study-detail-thumbnail"
              alt="{{ object.name }}"
              onerror="imgError(this)"
-             src="{{ object.image.url }}"
+             src="{{ object.image.url | lower}}"
              width="100%" />
     {% endif %}
     <div style="display:none"

--- a/studies/templates/studies/_study_fields.html
+++ b/studies/templates/studies/_study_fields.html
@@ -14,7 +14,15 @@
         {% bootstrap_field form.shared_preview wrapper_class="" %}
     </div>
 </div>
-{% bootstrap_field form.image label_class="form-label fw-bold" wrapper_class="mb-4" %}
+{% comment %} {% bootstrap_field form.image label_class="form-label fw-bold" wrapper_class="mb-4" %} {% endcomment %}
+<div class="mb-4"><label class="form-label fw-bold" for="id_image">Study Image</label><input type="file" name="image" accept="image/*" class="form-control" aria-describedby="id_image_helptext" id="id_image">
+    <div class="row mt-1">
+        <div class="col-auto">
+            Currently:&nbsp;<a href="{{ form.instance.image.url | lower}}">{{ form.instance.image | lower}}</a>
+        </div>
+    </div>
+    <div class="form-text">{{form.image.help_text}}</div>
+</div>
 {% bootstrap_field form.preview_summary label_class="form-label fw-bold" wrapper_class="mb-4" %}
 {% bootstrap_field form.short_description label_class="form-label fw-bold" wrapper_class="mb-4" %}
 {% bootstrap_field form.purpose label_class="form-label fw-bold" wrapper_class="mb-4" %}

--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -47,7 +47,7 @@
                     <div class="col-3">
                         <img class="img-fluid"
                              alt="{% trans "Study Thumbnail" %}"
-                             src="{{ study.image.url }}" />
+                             src="{{ study.image.url | lower }}" />
                     </div>
                     <div class="col-9">
                         {{ study.short_description|linebreaks }}

--- a/web/templates/web/studies-list.html
+++ b/web/templates/web/studies-list.html
@@ -50,7 +50,7 @@
             <div class="col-12 px-5 col-lg-3 px-lg-2">
                 <a class="text-decoration-none link-dark p-3"
                    href="{% url 'web:study-detail' uuid=study.uuid %}">
-                    <img src="{{ study.image.url }}"
+                    <img src="{{ study.image.url | lower }}"
                          class="w-100 h-auto mx-auto d-block"
                          alt="{{ study.name }}" />
                     <p>{{ study.name }}</p>

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -38,7 +38,7 @@
                     <div class="col-9 col-md-5 ps-0">
                         <img class="img-responsive"
                              alt="{{ study.name }}"
-                             src="{{ study.image.url }}"
+                             src="{{ study.image.url | lower }}"
                              width="100%" />
                     </div>
                     <div class="col-9 col-md-5 px-5">


### PR DESCRIPTION
# Summary

Some images aren't loading on CHS.  These image names are hard-coded in the database with mixed casing.  Google thinks they're all lowercase.  I am unsure of what changed, but this PR will get us back up and running.   

When study ads are updated, the study image is checked for size.  If the image cannot be found, the site will respond with a "file not found" error.  This is why some people are unable to update their studies.  