### PR TITLE
Fix "recipients" dropdown on contact participants page

### DIFF
--- a/exp/views/contact.py
+++ b/exp/views/contact.py
@@ -47,12 +47,6 @@ class StudyParticipantContactView(
 
     test_func = can_contact_participants
 
-    def slug_from_user_object(self, user):
-        study = self.object
-        user_hash_id = hash_id(user.uuid, study.uuid, study.salt)
-        user_slug = slugify(user.nickname or "anonymous")
-        return f"{user_hash_id}-{user_slug}"
-
     def get_context_data(self, **kwargs):
         """Gets the required data for emailing participants."""
         ctx = super().get_context_data(**kwargs)
@@ -78,7 +72,7 @@ class StudyParticipantContactView(
                     {
                         "uuid": recipient.uuid,
                         "nickname": recipient.nickname,
-                        "slug": self.slug_from_user_object(recipient),
+                        "slug": participant_slug(recipient, ctx["study"]),
                     }
                     for recipient in message.recipients.all()
                 ],

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -363,7 +363,32 @@ class StudyCreateForm(StudyForm):
 
 
 class EmailRecipientSelectMultiple(forms.SelectMultiple):
+    """
+    Extend forms.SelectMutliple for selecting multiple email recipients. forms.SelectMultiple lets you set attrs on the form field level, but not for individual choices. This custom class allows us to inject the data attributes for each specific choice (participant) with their individual email preferences so that these become available in the template and are added to the option element's data attributes.
+    """
+
     option_template_name = "studies/options/recipients.html"
+
+    def __init__(self, *args, **kwargs):
+        self.data_attrs = kwargs.pop("data_attrs", {})
+        super().__init__(*args, **kwargs)
+
+    def create_option(
+        self, name, value, label, selected, index, subindex=None, attrs=None
+    ):
+        option = super().create_option(
+            name, value, label, selected, index, subindex=subindex, attrs=attrs
+        )
+
+        # Merge global widget.attrs
+        option["attrs"].update(self.attrs or {})
+
+        # Merge option-specific data-attrs
+        data_attrs = self.data_attrs.get(str(value), {})
+        if data_attrs:
+            option["attrs"].update({f"data-{k}": v for k, v in data_attrs.items()})
+
+        return option
 
 
 class EmailParticipantsForm(forms.Form):

--- a/studies/templates/studies/options/recipients.html
+++ b/studies/templates/studies/options/recipients.html
@@ -1,9 +1,10 @@
-{% with widget.label as person %}
-    <option value="{{ widget.value|stringformat:'s' }}"
-            {% include "django/forms/widgets/attrs.html" %}
-            {% if person.email_next_session %}data-next-session{% endif %}
-            {% if person.email_new_studies %}data-new-studies{% endif %}
-            {% if person.email_study_updates %}data-study-updates{% endif %}
-            {% if person.email_response_questions %}data-response-questions{% endif %}
-            data-transactional-message>{{ person.slug }}</option>
-{% endwith %}
+<option value="{{ option.value }}"
+    {% for name, value in option.attrs.items %}
+        {% if value is not False %}{{ name }}
+            {% if value is not True %}
+                ="{{ value|stringformat:'s' }}"
+            {% endif %}
+        {% endif %}
+    {% endfor %}>
+    {{ option.label }}
+</option>


### PR DESCRIPTION
Fixes #1618

## Description

This PR fixes a problem with the Contact Participants page "recipients" drop-down choices. The participant choices are rendering incorrectly and it is not possible to select them, which means that researchers cannot send messages. 

The PR restructures the choices and data that we use for the email/message "recipients" field on the Contact Participants page. We used to use a nested tuple for each participant/recipient option, where the first element was the UUID and the second contained all of the other info we needed to create the dropdown option element. However, after our package updates, this nested tuple structure is being treated as a set of _grouped_ choices, where the first element is the group name and the second contains the choices in that group (see #1618). Because of this rendering problem and the way the page is set up, it is not possible to select any participants for the "recipients" field.

## Solution

I think the "right" way to do this (i.e. the way that was intended by Django devs) is to:
1. Move the dynamic injection of the recipient field `choices` out of `get_context_data` and into `get_form`.
2. In `get_form`, set the recipient `choices` (previously done in `get_context_data`) and pass in a mapping of each choice (participant) and associated HTML data attributes.
3. Customize `create_option` in our custom `EmailRecipientSelectMultiple` widget class so that it takes the choice-attributes dictionary passed in through the form class, and attaches the appropriate set of data attributes to each `option` object that is returned from `create_option`. 
4. In the option template, we can now access the data attributes in `option.attrs`.

Other changes:
- Fixed failing test. 
   - The test was trying to get the choices from the context, but they're no longer there so I updated this to get them from the form itself. 
   - I moved the `participant_slug` method out of the `StudyParticipantContactView` class so that I could import it and use it in tests. 
   - I modified the `participant_slug `method to take a User object instead of a dict.
   - The changes to `participant_slug` meant that I also had to change how this method is called within the form view (previously in `get_context_data`, now in `get_form`).

## Manual tests

So far I've manually tested the following:
- Recipients options render correctly.
- Recipients option is disabled when the data attribute is absent for the selected email filter.
- Choice disabled/enabled status is updated when a new email type is selected.
- None of the recipient options are disabled when the 'transaction' email type is selected.
- Can email a participant if they allow the selected email type.
- Cannot select a participant as a recipient if they do not allow the selected email type.
- Link from Individual Responses page still works (automatically adds the participant in the recipients field).
- Link from Individual Responses page works when the participant does not allow the default email type (warning banner message is shown).

## Unit tests

I still need to add tests to cover this choice/data attributes rendering issue. I can do that in this PR or a separate one.