### PR TITLE
Some fixes into Production

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -116,8 +116,8 @@ MIDDLEWARE = [
 ]
 
 if DEBUG:
-    INSTALLED_APPS += ["sslserver"]
-    MIDDLEWARE += ["pyinstrument.middleware.ProfilerMiddleware"]
+    # MIDDLEWARE += ["pyinstrument.middleware.ProfilerMiddleware"]
+    pass
 else:
     import sentry_sdk
     from sentry_sdk.integrations.celery import CeleryIntegration

--- a/project/settings.py
+++ b/project/settings.py
@@ -116,8 +116,7 @@ MIDDLEWARE = [
 ]
 
 if DEBUG:
-    # MIDDLEWARE += ["pyinstrument.middleware.ProfilerMiddleware"]
-    pass
+    MIDDLEWARE += ["pyinstrument.middleware.ProfilerMiddleware"]
 else:
     import sentry_sdk
     from sentry_sdk.integrations.celery import CeleryIntegration
@@ -306,7 +305,7 @@ if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
             },
         },
         "staticfiles": {
-            "BACKEND": "project.storages.LowercaseGoogleCloudStorage",
+            "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
             "OPTIONS": {
                 "location": "static",
                 "custom_endpoint": os.environ.get("BASE_URL", "/static/")[:-1],
@@ -410,17 +409,3 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-SESSION_COOKIE_HTTPONLY
 # Per the above documentation setting SESSION_COOKIE_HTTPONLY might break JavaScript.
 SESSION_COOKIE_HTTPONLY = True
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-        },
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": "WARNING",
-    },
-}

--- a/project/settings.py
+++ b/project/settings.py
@@ -286,16 +286,16 @@ CORS_ORIGIN_WHITELIST = [
 EXPERIMENT_LOCATION = "experiments"
 
 if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
-    # if we're trying to use cloud storage
-    STATICFILES_LOCATION = "static"
-    STATICFILES_STORAGE = "project.storages.LookitStaticStorage"
-    # STATIC_URL = os.environ.get("STATIC_URL", "/static/")
-    STATIC_URL = "/static/"
+    # # if we're trying to use cloud storage
+    # STATICFILES_LOCATION = "static"
+    # STATICFILES_STORAGE = "project.storages.LookitStaticStorage"
+    # # STATIC_URL = os.environ.get("STATIC_URL", "/static/")
+    # STATIC_URL = "static/"
 
-    MEDIAFILES_LOCATION = "media"
-    DEFAULT_FILE_STORAGE = "project.storages.LookitMediaStorage"
-    # MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
-    MEDIA_URL = "/media/"
+    # MEDIAFILES_LOCATION = "media"
+    # DEFAULT_FILE_STORAGE = "project.storages.LookitMediaStorage"
+    # # MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
+    # MEDIA_URL = "/media/"
 
     GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME", "")
     GS_PROJECT_ID = os.environ.get("GS_PROJECT_ID", "")
@@ -306,11 +306,18 @@ if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
     STORAGES = {
         "default": {
             "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
-            "OPTIONS": {"location": "media"},
+            "OPTIONS": {
+                "location": "media",
+                "file_overwrite": False,
+                "custom_endpoint": os.environ.get("BASE_URL", "/media/"),
+            },
         },
         "staticfiles": {
             "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
-            "OPTIONS": {"location": "static"},
+            "OPTIONS": {
+                "location": "static",
+                "custom_endpoint": os.environ.get("BASE_URL", "/static/"),
+            },
         },
     }
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -302,14 +302,14 @@ if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
             "OPTIONS": {
                 "location": "media",
                 "file_overwrite": False,
-                "custom_endpoint": MEDIA_URL,
+                "custom_endpoint": MEDIA_URL[:-1],
             },
         },
         "staticfiles": {
             "BACKEND": "project.storages.LowercaseGoogleCloudStorage",
             "OPTIONS": {
                 "location": "static",
-                "custom_endpoint": os.environ.get("BASE_URL", "/static/"),
+                "custom_endpoint": os.environ.get("BASE_URL", "/static/")[:-1],
             },
         },
     }

--- a/project/settings.py
+++ b/project/settings.py
@@ -286,16 +286,7 @@ CORS_ORIGIN_WHITELIST = [
 EXPERIMENT_LOCATION = "experiments"
 
 if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
-    # # if we're trying to use cloud storage
-    # STATICFILES_LOCATION = "static"
-    # STATICFILES_STORAGE = "project.storages.LookitStaticStorage"
-    # # STATIC_URL = os.environ.get("STATIC_URL", "/static/")
-    # STATIC_URL = "static/"
-
-    # MEDIAFILES_LOCATION = "media"
-    # DEFAULT_FILE_STORAGE = "project.storages.LookitMediaStorage"
-    # # MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
-    # MEDIA_URL = "/media/"
+    # if we're trying to use cloud storage
 
     GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME", "")
     GS_PROJECT_ID = os.environ.get("GS_PROJECT_ID", "")

--- a/project/settings.py
+++ b/project/settings.py
@@ -303,6 +303,17 @@ if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
     GS_PRIVATE_BUCKET_NAME = os.environ.get("GS_PRIVATE_BUCKET_NAME", "")
     GS_QUERYSTRING_AUTH = False
 
+    STORAGES = {
+        "default": {
+            "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+            "OPTIONS": {"location": "media"},
+        },
+        "staticfiles": {
+            "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+            "OPTIONS": {"location": "static"},
+        },
+    }
+
 else:
     # we know nothing about cloud storage
     print(

--- a/project/settings.py
+++ b/project/settings.py
@@ -269,7 +269,7 @@ SITE_NAME = os.environ.get("SITE_NAME", "Lookit")
 EXPERIMENT_BASE_URL = os.environ.get("EXPERIMENT_BASE_URL")
 
 BASE_URL = os.environ.get(
-    "BASE_URL", "https://localhost:8000"
+    "BASE_URL", "https://localhost:8000/"
 )  # default to ember base url
 
 LOGIN_REDIRECT_URL = "web:home"
@@ -294,17 +294,19 @@ if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
     GS_PRIVATE_BUCKET_NAME = os.environ.get("GS_PRIVATE_BUCKET_NAME", "")
     GS_QUERYSTRING_AUTH = False
 
+    MEDIA_URL = os.environ.get("BASE_URL", "/media/")
+
     STORAGES = {
         "default": {
-            "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+            "BACKEND": "project.storages.LowercaseGoogleCloudStorage",
             "OPTIONS": {
                 "location": "media",
                 "file_overwrite": False,
-                "custom_endpoint": os.environ.get("BASE_URL", "/media/"),
+                "custom_endpoint": MEDIA_URL,
             },
         },
         "staticfiles": {
-            "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+            "BACKEND": "project.storages.LowercaseGoogleCloudStorage",
             "OPTIONS": {
                 "location": "static",
                 "custom_endpoint": os.environ.get("BASE_URL", "/static/"),

--- a/project/settings.py
+++ b/project/settings.py
@@ -289,11 +289,13 @@ if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
     # if we're trying to use cloud storage
     STATICFILES_LOCATION = "static"
     STATICFILES_STORAGE = "project.storages.LookitStaticStorage"
-    STATIC_URL = os.environ.get("STATIC_URL", "/static/")
+    # STATIC_URL = os.environ.get("STATIC_URL", "/static/")
+    STATIC_URL = "/static/"
 
     MEDIAFILES_LOCATION = "media"
     DEFAULT_FILE_STORAGE = "project.storages.LookitMediaStorage"
-    MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
+    # MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
+    MEDIA_URL = "/media/"
 
     GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME", "")
     GS_PROJECT_ID = os.environ.get("GS_PROJECT_ID", "")
@@ -397,3 +399,17 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-SESSION_COOKIE_HTTPONLY
 # Per the above documentation setting SESSION_COOKIE_HTTPONLY might break JavaScript.
 SESSION_COOKIE_HTTPONLY = True
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "WARNING",
+    },
+}

--- a/project/storages.py
+++ b/project/storages.py
@@ -33,4 +33,6 @@ class LookitExperimentStorage(LookitGoogleCloudStorage):
 
 class LowercaseGoogleCloudStorage(GoogleCloudStorage):
     def get_available_name(self, name, max_length=None):
-        return super().get_available_name(name.lower(), max_length)
+        # Lowercase the file name and the additional text google adds when
+        # there's a name collision.
+        return super().get_available_name(name.lower(), max_length).lower()

--- a/project/storages.py
+++ b/project/storages.py
@@ -1,34 +1,6 @@
-from django.contrib.staticfiles.storage import ManifestFilesMixin
 from storages.backends.gcloud import GoogleCloudStorage
 
-
-class LookitGoogleCloudStorage(GoogleCloudStorage):
-    """Overrides to compensate for the fact that we're proxying requests through nginx's proxypass."""
-
-    def _normalize_name(self, name):
-        return super()._normalize_name(name.lower())
-
-    def url(self, name):
-        """Override for the URL getter function.
-
-        Since we're proxying requests through nginx's proxy_pass to GCS, we can avoid blob
-        creation and the signed url generation that might happen otherwise (see parent implementation for details).
-        """
-        name = self._normalize_name(name)
-        return f"/{name.lstrip('/')}"
-
-
-class LookitStaticStorage(ManifestFilesMixin, LookitGoogleCloudStorage):
-    pass
-
-
-class LookitMediaStorage(LookitGoogleCloudStorage):
-    pass
-
-
-class LookitExperimentStorage(LookitGoogleCloudStorage):
-    # location = settings.EXPERIMENT_LOCATION
-    pass
+from project import settings
 
 
 class LowercaseGoogleCloudStorage(GoogleCloudStorage):
@@ -36,3 +8,7 @@ class LowercaseGoogleCloudStorage(GoogleCloudStorage):
         # Lowercase the file name and the additional text google adds when
         # there's a name collision.
         return super().get_available_name(name.lower(), max_length).lower()
+
+
+class LookitExperimentStorage(LowercaseGoogleCloudStorage):
+    location = settings.EXPERIMENT_LOCATION

--- a/project/storages.py
+++ b/project/storages.py
@@ -19,17 +19,18 @@ class LookitGoogleCloudStorage(GoogleCloudStorage):
 
 
 class LookitStaticStorage(ManifestFilesMixin, LookitGoogleCloudStorage):
-    # location = settings.STATICFILES_LOCATION
     pass
 
 
 class LookitMediaStorage(LookitGoogleCloudStorage):
-    # location = settings.MEDIAFILES_LOCATION
-    # See https://github.com/lookit/lookit-api/issues/570
-    # file_overwrite = False
     pass
 
 
 class LookitExperimentStorage(LookitGoogleCloudStorage):
     # location = settings.EXPERIMENT_LOCATION
     pass
+
+
+class LowercaseGoogleCloudStorage(GoogleCloudStorage):
+    def get_available_name(self, name, max_length=None):
+        return super().get_available_name(name.lower(), max_length)

--- a/project/storages.py
+++ b/project/storages.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestFilesMixin
 from storages.backends.gcloud import GoogleCloudStorage
 
@@ -20,14 +19,17 @@ class LookitGoogleCloudStorage(GoogleCloudStorage):
 
 
 class LookitStaticStorage(ManifestFilesMixin, LookitGoogleCloudStorage):
-    location = settings.STATICFILES_LOCATION
+    # location = settings.STATICFILES_LOCATION
+    pass
 
 
 class LookitMediaStorage(LookitGoogleCloudStorage):
-    location = settings.MEDIAFILES_LOCATION
+    # location = settings.MEDIAFILES_LOCATION
     # See https://github.com/lookit/lookit-api/issues/570
-    file_overwrite = False
+    # file_overwrite = False
+    pass
 
 
 class LookitExperimentStorage(LookitGoogleCloudStorage):
-    location = settings.EXPERIMENT_LOCATION
+    # location = settings.EXPERIMENT_LOCATION
+    pass

--- a/project/urls.py
+++ b/project/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 """
 
 from django.conf.urls.i18n import i18n_patterns
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.auth.urls import urlpatterns as auth_urls
@@ -26,6 +27,7 @@ from accounts import urls as accounts_urls
 from accounts.views import LoginWithRedirectToTwoFactorAuthView
 from api import urls as api_urls
 from exp import urls as exp_urls
+from project import settings
 from web import urls as web_urls
 
 # Don't want to depend on the login always being the first view...
@@ -60,5 +62,5 @@ urlpatterns = i18n_patterns(
     prefix_default_language=False,
 )
 
-# if settings.DEBUG:
-#     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/project/urls.py
+++ b/project/urls.py
@@ -16,7 +16,6 @@ Including another URLconf
 """
 
 from django.conf.urls.i18n import i18n_patterns
-from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.auth.urls import urlpatterns as auth_urls
@@ -27,7 +26,6 @@ from accounts import urls as accounts_urls
 from accounts.views import LoginWithRedirectToTwoFactorAuthView
 from api import urls as api_urls
 from exp import urls as exp_urls
-from project import settings
 from web import urls as web_urls
 
 # Don't want to depend on the login always being the first view...
@@ -62,5 +60,5 @@ urlpatterns = i18n_patterns(
     prefix_default_language=False,
 )
 
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+# if settings.DEBUG:
+#     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dev = [
     "beautifulsoup4==4.13.3",
     "coverage==7.6.12",
     "django-dynamic-fixture==4.0.1",
-    "django-sslserver==0.22",
     "libsass==0.23.0",
     "parameterized==0.9.0",
     "pre-commit==4.2.0",

--- a/studies/experiment_builder.py
+++ b/studies/experiment_builder.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import logging
 import os
 import re
 import zipfile
@@ -16,6 +17,8 @@ from project import storages
 from studies.helpers import send_mail
 
 DOCKER_CLIENT = docker.from_env()
+
+logger = logging.getLogger(__name__)
 
 
 class DirectoryTargets(NamedTuple):
@@ -170,6 +173,7 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
     def get_study(self, study_uuid):
         from studies.models import Study
 
+        logger.error("get study")
         study = Study.objects.get(uuid=study_uuid)
         # Set this here (in addition to in view) in case re-trying
         study.is_building = True
@@ -179,10 +183,12 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
     def get_researcher(self, researcher_uuid):
         from accounts.models import User
 
+        logger.error("get researcher")
         self.build_context["researcher"] = User.objects.get(uuid=researcher_uuid)
 
     def get_player_sha(self, study):
         """Gets the player sha, if it's been explicitly declared. If not, mark metadata as an update field."""
+        logger.error("get player sha")
         self.build_context["player_sha"] = player_sha = study.metadata.get(
             "last_known_player_sha", None
         )
@@ -190,6 +196,7 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
             self.build_context["update_fields"] += ["metadata"]
 
     def build_docker_image(self):
+        logger.error("build docker image")
         image, _image_log_gen = DOCKER_CLIENT.images.build(
             path=settings.EMBER_BUILD_ROOT_PATH,
             pull=True,
@@ -199,6 +206,7 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
         self.build_context["docker_image"] = image
 
     def get_container_directories(self, study, study_uuid, player_sha):
+        logger.error("get container directories")
         player_repo_url = study.metadata.get(
             "player_repo_url", settings.EMBER_EXP_PLAYER_REPO
         )
@@ -219,6 +227,7 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
         )
 
     def run_docker_container(self, container_paths, study_uuid, local_paths):
+        logger.error("run docker container")
         stdout_and_stderr = DOCKER_CLIENT.containers.run(
             "ember_build",
             command="bash build.sh",
@@ -246,6 +255,7 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
         return {"success": True, "logs": stdout_and_stderr.decode("utf-8")}
 
     def deploy_study(self, local_paths, destination_directory):
+        logger.error("deploy study")
         storage = storages.LookitExperimentStorage()
 
         cloud_deployment_directory = os.path.join(
@@ -255,6 +265,7 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
         deploy_to_remote(cloud_deployment_directory, storage)
 
     def save_study_and_log_results(self, study, update_fields):
+        logger.error("save study and log results")
         # Only update field for particular build, in case we have parallel builds running
         study.built = True
         study.is_building = False
@@ -327,13 +338,19 @@ def deploy_to_remote(local_path, storage):
 def _upload_in_serial(local_path, storage):
     """Inner worker function for storage uploads in serial.  This should be skipped when
     developing locally."""
+    logger.error("upload in serial")
     if not settings.DEBUG:
+        logger.error(f"local path: {local_path}")
         for root_directory, dirs, files in os.walk(local_path, topdown=True):
             for filename in files:
                 full_path = os.path.join(root_directory, filename)
+                logger.error(f"filename: {filename}")
+                logger.error(f"file path: {full_path}")
                 with open(full_path, mode="rb") as f:
                     remote_path = full_path.split("/ember_build/deployments/")[1]
-                    storage.save(remote_path, File(f))
+                    logger.error(f"remote path: {remote_path}")
+                    filename = storage.save(remote_path, File(f))
+                    logger.error(f"filename post save: {filename}")
 
 
 def download_repos(player_repo_url, player_sha=None):

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -44,7 +44,7 @@ def send_mail(
     :param str custom_message Custom email message - for use instead of a template
     :kwargs: Context vars for the email template
     """
-    context["base_url"] = BASE_URL
+    context["base_url"] = BASE_URL[-1] == "/" and BASE_URL[:-1] or BASE_URL
 
     # For text version: replace images with [IMAGE] so they're not removed entirely
     context_plain_text = copy.deepcopy(context)

--- a/studies/templates/studies/_image_display.html
+++ b/studies/templates/studies/_image_display.html
@@ -10,7 +10,7 @@
         <img class="study-detail-thumbnail"
              alt="{{ object.name }}"
              onerror="imgError(this)"
-             src="{{ object.image.url | lower}}"
+             src="{{ object.image.url }}"
              width="100%" />
     {% endif %}
     <div style="display:none"

--- a/studies/templates/studies/_study_fields.html
+++ b/studies/templates/studies/_study_fields.html
@@ -14,15 +14,7 @@
         {% bootstrap_field form.shared_preview wrapper_class="" %}
     </div>
 </div>
-{% comment %} {% bootstrap_field form.image label_class="form-label fw-bold" wrapper_class="mb-4" %} {% endcomment %}
-<div class="mb-4"><label class="form-label fw-bold" for="id_image">Study Image</label><input type="file" name="image" accept="image/*" class="form-control" aria-describedby="id_image_helptext" id="id_image">
-    <div class="row mt-1">
-        <div class="col-auto">
-            Currently:&nbsp;<a href="{{ form.instance.image.url | lower}}">{{ form.instance.image | lower}}</a>
-        </div>
-    </div>
-    <div class="form-text">{{form.image.help_text}}</div>
-</div>
+{% bootstrap_field form.image label_class="form-label fw-bold" wrapper_class="mb-4" %}
 {% bootstrap_field form.preview_summary label_class="form-label fw-bold" wrapper_class="mb-4" %}
 {% bootstrap_field form.short_description label_class="form-label fw-bold" wrapper_class="mb-4" %}
 {% bootstrap_field form.purpose label_class="form-label fw-bold" wrapper_class="mb-4" %}

--- a/studies/templates/studies/options/recipients.html
+++ b/studies/templates/studies/options/recipients.html
@@ -1,9 +1,10 @@
-{% with widget.label as person %}
-    <option value="{{ widget.value|stringformat:'s' }}"
-            {% include "django/forms/widgets/attrs.html" %}
-            {% if person.email_next_session %}data-next-session{% endif %}
-            {% if person.email_new_studies %}data-new-studies{% endif %}
-            {% if person.email_study_updates %}data-study-updates{% endif %}
-            {% if person.email_response_questions %}data-response-questions{% endif %}
-            data-transactional-message>{{ person.slug }}</option>
-{% endwith %}
+<option value="{{ option.value }}"
+    {% for name, value in option.attrs.items %}
+        {% if value is not False %}{{ name }}
+            {% if value is not True %}
+                ="{{ value|stringformat:'s' }}"
+            {% endif %}
+        {% endif %}
+    {% endfor %}>
+    {{ option.label }}
+</option>

--- a/uv.lock
+++ b/uv.lock
@@ -61,16 +61,16 @@ wheels = [
 
 [[package]]
 name = "botocore"
-version = "1.38.14"
+version = "1.38.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/b1/9dc1989ffcc2f9c85612a92a212b018c7ad1e219e0d4bfbb627080317278/botocore-1.38.14.tar.gz", hash = "sha256:8ac91de6c33651a5c699268f1d22fadd5e99f370230dbea97d29e4164de4e5f2", size = 13890928, upload-time = "2025-05-12T19:29:09.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/78/c1b2fa6a267018062a66470e6e779366b4e64ab1178de8870ccc3a393cac/botocore-1.38.19.tar.gz", hash = "sha256:796b948c05017eb33385b798990cd91ed4af0e881eb9eb1ee6e17666be02abc9", size = 13913334, upload-time = "2025-05-19T19:31:07.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/99/a0f520346615707fe48e547d9942723812bc2bc6064c1a9a40714ec6c414/botocore-1.38.14-py3-none-any.whl", hash = "sha256:3125ed92e9ee6137c28fd32c56934a531a372346a7b13cb86de4328d7629e156", size = 13552896, upload-time = "2025-05-12T19:29:03.532Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4d/168137542d007a2beb7df8147edce6c5ab1155dd13e8533e74e3ac8ec030/botocore-1.38.19-py3-none-any.whl", hash = "sha256:f937a20e75889215a99280ea0fdd4e1716ffede23e4f9af7bc9c64af9bc63e61", size = 13573222, upload-time = "2025-05-19T19:31:01.52Z" },
 ]
 
 [[package]]
@@ -521,17 +521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "django-sslserver"
-version = "0.22"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/97/e4011f3944f83a7d2aaaf893c3689ad70e8d2ae46fb6e14fd0e3b0c6ce0b/django_sslserver-0.22-py3-none-any.whl", hash = "sha256:c598a363d2ccdc2421c08ddb3d8b0973f80e8e47a3a5b74e4a2896f21c2947c5", size = 10295, upload-time = "2019-12-10T02:30:03.76Z" },
-]
-
-[[package]]
 name = "django-storages"
 version = "1.14.6"
 source = { registry = "https://pypi.org/simple" }
@@ -892,7 +881,6 @@ dev = [
     { name = "beautifulsoup4" },
     { name = "coverage" },
     { name = "django-dynamic-fixture" },
-    { name = "django-sslserver" },
     { name = "libsass" },
     { name = "parameterized" },
     { name = "pre-commit" },
@@ -951,7 +939,6 @@ dev = [
     { name = "beautifulsoup4", specifier = "==4.13.3" },
     { name = "coverage", specifier = "==7.6.12" },
     { name = "django-dynamic-fixture", specifier = "==4.0.1" },
-    { name = "django-sslserver", specifier = "==0.22" },
     { name = "libsass", specifier = "==0.23.0" },
     { name = "parameterized", specifier = "==0.9.0" },
     { name = "pre-commit", specifier = "==4.2.0" },
@@ -1098,16 +1085,16 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.30.2"
+version = "6.31.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/8c/cf2ac658216eebe49eaedf1e06bc06cbf6a143469236294a1171a51357c3/protobuf-6.30.2.tar.gz", hash = "sha256:35c859ae076d8c56054c25b59e5e59638d86545ed6e2b6efac6be0b6ea3ba048", size = 429315, upload-time = "2025-03-26T19:12:57.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/48/718c1e104a2e89970a8ff3b06d87e152834b576c570a6908f8c17ba88d65/protobuf-6.31.0.tar.gz", hash = "sha256:314fab1a6a316469dc2dd46f993cbbe95c861ea6807da910becfe7475bc26ffe", size = 441644, upload-time = "2025-05-14T17:58:27.862Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/85/cd53abe6a6cbf2e0029243d6ae5fb4335da2996f6c177bb2ce685068e43d/protobuf-6.30.2-cp310-abi3-win32.whl", hash = "sha256:b12ef7df7b9329886e66404bef5e9ce6a26b54069d7f7436a0853ccdeb91c103", size = 419148, upload-time = "2025-03-26T19:12:41.359Z" },
-    { url = "https://files.pythonhosted.org/packages/97/e9/7b9f1b259d509aef2b833c29a1f3c39185e2bf21c9c1be1cd11c22cb2149/protobuf-6.30.2-cp310-abi3-win_amd64.whl", hash = "sha256:7653c99774f73fe6b9301b87da52af0e69783a2e371e8b599b3e9cb4da4b12b9", size = 431003, upload-time = "2025-03-26T19:12:44.156Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/66/7f3b121f59097c93267e7f497f10e52ced7161b38295137a12a266b6c149/protobuf-6.30.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:0eb523c550a66a09a0c20f86dd554afbf4d32b02af34ae53d93268c1f73bc65b", size = 417579, upload-time = "2025-03-26T19:12:45.447Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/89/bbb1bff09600e662ad5b384420ad92de61cab2ed0f12ace1fd081fd4c295/protobuf-6.30.2-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:50f32cc9fd9cb09c783ebc275611b4f19dfdfb68d1ee55d2f0c7fa040df96815", size = 317319, upload-time = "2025-03-26T19:12:46.999Z" },
-    { url = "https://files.pythonhosted.org/packages/28/50/1925de813499546bc8ab3ae857e3ec84efe7d2f19b34529d0c7c3d02d11d/protobuf-6.30.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4f6c687ae8efae6cf6093389a596548214467778146b7245e886f35e1485315d", size = 316212, upload-time = "2025-03-26T19:12:48.458Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/a1/93c2acf4ade3c5b557d02d500b06798f4ed2c176fa03e3c34973ca92df7f/protobuf-6.30.2-py3-none-any.whl", hash = "sha256:ae86b030e69a98e08c77beab574cbcb9fff6d031d57209f574a5aea1445f4b51", size = 167062, upload-time = "2025-03-26T19:12:55.892Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/77/8671682038b08237c927215fa3296bc1c54e4086fe542c87017c1b626663/protobuf-6.31.0-cp310-abi3-win32.whl", hash = "sha256:10bd62802dfa0588649740a59354090eaf54b8322f772fbdcca19bc78d27f0d6", size = 423437, upload-time = "2025-05-14T17:58:16.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/07/cc9b0cbf7593f6ef8cf87fa9b0e55cd74c5cb526dd89ad84aa7d6547ef8d/protobuf-6.31.0-cp310-abi3-win_amd64.whl", hash = "sha256:3e987c99fd634be8347246a02123250f394ba20573c953de133dc8b2c107dd71", size = 435118, upload-time = "2025-05-14T17:58:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/21/46/33f884aa8bc59114dc97e0d954ca4618c556483670236008c88fbb7e834f/protobuf-6.31.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2c812f0f96ceb6b514448cefeb1df54ec06dde456783f5099c0e2f8a0f2caa89", size = 425439, upload-time = "2025-05-14T17:58:19.709Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/9a676b50229ce37b12777d7b21de90ae7bc0f9505d07e72e2e8d47b8d165/protobuf-6.31.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:67ce50195e4e584275623b8e6bc6d3d3dfd93924bf6116b86b3b8975ab9e4571", size = 321950, upload-time = "2025-05-14T17:58:22.04Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a7/243fa2d3c1b7675d54744b32dacf30356f4c27c0d3ad940ca8745a1c6b2c/protobuf-6.31.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:5353e38844168a327acd2b2aa440044411cd8d1b6774d5701008bd1dba067c79", size = 320904, upload-time = "2025-05-14T17:58:23.438Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/01/1ed1d482960a5718fd99c82f6d79120181947cfd4667ec3944d448ed44a3/protobuf-6.31.0-py3-none-any.whl", hash = "sha256:6ac2e82556e822c17a8d23aa1190bbc1d06efb9c261981da95c71c9da09e9e23", size = 168558, upload-time = "2025-05-14T17:58:26.923Z" },
 ]
 
 [[package]]
@@ -1269,11 +1256,11 @@ wheels = [
 
 [[package]]
 name = "python-stdnum"
-version = "2.0"
+version = "2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/85/fcda36244de80c201a82714f85fc24ffc52c407cc0dd640ccf5c78e38b64/python_stdnum-2.0.tar.gz", hash = "sha256:78c0ce3837e0b725c4e86f17319c24f6772d69b15abca1600c2ad64a0a42ca40", size = 1237342, upload-time = "2025-05-05T21:22:57.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/60/fd8299c7d8990a7d802286ac604862387bcac3df08be7cb1c932c33ef7da/python_stdnum-2.1.tar.gz", hash = "sha256:6b01645969eb3dfd55061a0114d593753cd9e653cea9083198b7eea12644397a", size = 1238596, upload-time = "2025-05-17T13:18:43.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/36/04bd294f8ad4a17548c8f98026debd58055a0d6a1945376fc9ca32f35a8f/python_stdnum-2.0-py3-none-any.whl", hash = "sha256:c99d569d178d1361d9a79fb0f5d7f8569a325898f0e3ea1816ac8216481e72e1", size = 1119237, upload-time = "2025-05-05T21:22:55.194Z" },
+    { url = "https://files.pythonhosted.org/packages/67/04/730f619b5b8470adf0e029ee2f0a060689145ea64dec001c8bac3c3959e2/python_stdnum-2.1-py3-none-any.whl", hash = "sha256:25eabcf5f307dd4150fd8f1c03f4512a6caeb84c9f09be1448711f5803373c58", size = 1120175, upload-time = "2025-05-17T13:18:41.193Z" },
 ]
 
 [[package]]
@@ -1415,11 +1402,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.4.0"
+version = "80.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/32/0cc40fe41fd2adb80a2f388987f4f8db3c866c69e33e0b4c8b093fdf700e/setuptools-80.4.0.tar.gz", hash = "sha256:5a78f61820bc088c8e4add52932ae6b8cf423da2aff268c23f813cfbb13b4006", size = 1315008, upload-time = "2025-05-09T20:42:27.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/ec1acaaff45caed5c2dedb33b67055ba9d4e96b091094df90762e60135fe/setuptools-80.8.0.tar.gz", hash = "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257", size = 1319720, upload-time = "2025-05-20T14:02:53.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/93/dba5ed08c2e31ec7cdc2ce75705a484ef0be1a2fecac8a58272489349de8/setuptools-80.4.0-py3-none-any.whl", hash = "sha256:6cdc8cb9a7d590b237dbe4493614a9b75d0559b888047c1f67d49ba50fc3edb2", size = 1200812, upload-time = "2025-05-09T20:42:25.325Z" },
+    { url = "https://files.pythonhosted.org/packages/58/29/93c53c098d301132196c3238c312825324740851d77a8500a2462c0fd888/setuptools-80.8.0-py3-none-any.whl", hash = "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0", size = 1201470, upload-time = "2025-05-20T14:02:51.348Z" },
 ]
 
 [[package]]

--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -47,7 +47,7 @@
                     <div class="col-3">
                         <img class="img-fluid"
                              alt="{% trans "Study Thumbnail" %}"
-                             src="{{ study.image.url | lower }}" />
+                             src="{{ study.image.url }}" />
                     </div>
                     <div class="col-9">
                         {{ study.short_description|linebreaks }}

--- a/web/templates/web/studies-list.html
+++ b/web/templates/web/studies-list.html
@@ -50,7 +50,7 @@
             <div class="col-12 px-5 col-lg-3 px-lg-2">
                 <a class="text-decoration-none link-dark p-3"
                    href="{% url 'web:study-detail' uuid=study.uuid %}">
-                    <img src="{{ study.image.url | lower }}"
+                    <img src="{{ study.image.url }}"
                          class="w-100 h-auto mx-auto d-block"
                          alt="{{ study.name }}" />
                     <p>{{ study.name }}</p>

--- a/web/templates/web/study-detail.html
+++ b/web/templates/web/study-detail.html
@@ -38,7 +38,7 @@
                     <div class="col-9 col-md-5 ps-0">
                         <img class="img-responsive"
                              alt="{{ study.name }}"
-                             src="{{ study.image.url | lower }}"
+                             src="{{ study.image.url }}"
                              width="100%" />
                     </div>
                     <div class="col-9 col-md-5 px-5">


### PR DESCRIPTION
This PR fixes some issues that came up after a production release containing package updates (https://github.com/lookit/lookit-api/pull/1585).

## Fixes

- Updates `django-storages` settings and our custom storages classes for GCP storage and file paths/URLs. This affects static files, user media (e.g. study images), and built EFP experiment files. This should fix #1615.
   - Media files will now always be converted to lowercase before being saved to the database and GCP. 
   - Static files keep their original case, because some are generated from packages and we do not have control over them.
- Reverts the temporary fix to image file names in template files (no longer needed).
- Fixes the problem with selecting recipients for new messages on the contact participants (#1618 , #1626)

## Other/minor things

- Adds a log message to the experiment builder task when debug is true, because this prevents the task from deploying to the cloud but currently there is no indication of this difference in the logs.
- Removes `django-sslserver` package and removes `sslserver` from `INSTALLED_APPS` (only affects dev environments)
- Package updates:
  - botocore (patch)
  - protobuf (minor)
  - python-stdnum (patch)
  - setuptools (minor)

## Manual tests and screenshots

- Recipients field in contact participants works as expected. Slugs are formatted correctly, you can select one or more recipient, the participant choice is enabled/disabled based on the current message type and their email settings, messages send successfully.

![Screenshot 2025-05-21 at 3 13 12 PM](https://github.com/user-attachments/assets/5943677c-8162-410c-95ac-ab8aef29bb0d)

![Screenshot 2025-05-21 at 3 13 35 PM](https://github.com/user-attachments/assets/0d86ca4d-cf82-47a5-9fb9-7a237df23b63)

![Screenshot 2025-05-21 at 3 17 00 PM](https://github.com/user-attachments/assets/442a1b4c-4aa0-42eb-b0c0-356ab5a635bc)

- Study Ad page does not throw errors when saving, with or without updating image. You can use lowercase/uppercase in filenames, and the images save and load as expected. Proxying works and the hash is lowercase.

![Screenshot 2025-05-21 at 3 36 19 PM](https://github.com/user-attachments/assets/7e3225bc-6ea7-42ab-8ced-6a969094f66f)

![Screenshot 2025-05-21 at 3 36 36 PM](https://github.com/user-attachments/assets/35cc480b-b720-44b5-b961-83489ae41a4b)

![Screenshot 2025-05-21 at 3 37 34 PM](https://github.com/user-attachments/assets/c7bac335-bcd1-4b71-ba55-294bb24ae903)

- EFP studies are built and deployed successfully, and the files are stored/accessed correctly (tested by building a study and previewing it).

![Screenshot 2025-05-21 at 3 32 42 PM](https://github.com/user-attachments/assets/9959926a-11fd-457e-b610-83d9a36fc887)

- Static files are proxied and load correctly, including files with uppercase letters in file name (e.g. GARDEN images).

![Screenshot 2025-05-21 at 3 29 22 PM](https://github.com/user-attachments/assets/33fa8906-55da-47eb-91fc-d4a6434486a9)

## Unit tests

We still need to add unit tests for the issues that came up in the production release: incorrect media file names/URLs, incorrect rendering of email recipient choices on contact participants form. That will go into a separate PR so that we can get these fixes out ASAP.

