### PR TITLE
Fix pipe webhook

### DIFF
--- a/exp/views/video.py
+++ b/exp/views/video.py
@@ -1,8 +1,7 @@
-import ast
 import base64
 import hashlib
 import hmac
-import urllib.parse
+import json
 
 from botocore.exceptions import ClientError
 from django.conf import settings
@@ -28,21 +27,17 @@ class RenameVideoView(View):
         # Parse the POST body ourselves to allow flexibility for using for other types
         # of events in the future; some of the Pipe event data includes semicolons which
         # throw the automatic parsing for a loop.
-        rawbody = list(request.body)  # bytes to ints
-        # rawbody = [45 if i==59 else i for i in rawbody] # semicolons -> dashes
-        postbody = urllib.parse.parse_qs(
-            bytes(rawbody).decode("utf-8")
-        )  # NOW parse the request string
 
         # Authenticate the webhook (see https://addpipe.com/docs#authenticating-webhooks)
         key = settings.PIPE_WEBHOOK_KEY
         # Append the JSON POST data received via webhook to the URL string.
         thisURL = request.scheme + "://" + request.headers["host"] + request.path
-        message = thisURL + postbody["payload"][0]  # TODO
-        key = bytes(key, "UTF-8")
-        message = bytes(message, "UTF-8")
+        payload = request.POST.get("payload")
+        message = thisURL + payload
         # Hash the resulting string with HMAC-SHA1, using the webhook authentication key; generate binary signature.
-        digester = hmac.new(key, message, hashlib.sha1)
+        keyBytes = bytes(key, "UTF-8")
+        messageBytes = bytes(message, "UTF-8")
+        digester = hmac.new(keyBytes, messageBytes, hashlib.sha1)
         signatureBinary = digester.digest()
         # Base64 encode the binary signature.
         signatureComputed = base64.b64encode(signatureBinary)
@@ -50,22 +45,21 @@ class RenameVideoView(View):
         signatureSent = bytes(request.headers["x-pipe-signature"], "UTF-8")
         authenticated = signatureComputed == signatureSent
 
-        d = ast.literal_eval(
-            postbody["payload"][0]
-        )  # convert from string representation of dict
+        # Convert data from string representation of dict to dict
+        payload_data = json.loads(payload)
 
         if authenticated and (
-            d["data"]["s3UploadStatus"] == "upload success"
+            payload_data["data"]["s3UploadStatus"] == "upload success"
         ):  # Go ahead and move the file
-            new_name = d["data"]["payload"]
+            new_name = payload_data["data"]["payload"]
 
             if not new_name:  # Make sure we don't have an empty payload string
                 return HttpResponseForbidden()
 
             try:
-                video_obj = Video.from_pipe_payload(d)
+                video_obj = Video.from_pipe_payload(payload_data)
                 return HttpResponse(
-                    (d["data"]["videoName"] + " --> " + video_obj.filename)
+                    (payload_data["data"]["videoName"] + " --> " + video_obj.filename)
                     if video_obj
                     else "Preview video not saved"
                 )

--- a/studies/models.py
+++ b/studies/models.py
@@ -1470,7 +1470,9 @@ class Video(models.Model):
         return cls.objects.create(
             pipe_name=old_pipe_name,
             pipe_numeric_id=data["id"],
-            s3_timestamp=datetime.fromtimestamp(int(timestamp) / 1000, tz=timezone.utc),
+            s3_timestamp=datetime.fromtimestamp(
+                int(timestamp) / 1000, tz=datetime.timezone.utc
+            ),
             frame_id=frame_id,
             full_name=new_full_name,
             study=study,


### PR DESCRIPTION
Fixes #1640

This PR fixes an issue with the pipe webhook returning 500 errors. 

## Changes

In the `RenameVideoView` API endpoint (`exp/views/video.py`) that we provide to Pipe:

- Get the POST payload from `request.POST` instead of `request.body`, since the former provides the data as a dictionary so no further parsing/conversion is needed.
- Remove the bytes to ints conversion, the use of `urlib.parse.parse_qs`, and the `[0]` indexing on the result because these no longer seem necessary
- 
  ```python
   rawbody = list(request.body)  # bytes to ints
   # rawbody = [45 if i==59 else i for i in rawbody] # semicolons -> dashes
   postbody = urllib.parse.parse_qs(
       bytes(rawbody).decode("utf-8")
   )  # NOW parse the request string
   ...
   message = thisURL + postbody["payload"][0]
  ```

In the `Video` class method `from_pipe_payload` (`studies/models.py`):

- Instead of specifying a UTC timezone via `timezone.utc`(from `django.utils`), we need to use `datetime.timezone.utc` from `datetime`. The django utils version has been [deprecated](https://github.com/django/django/commit/59ab3fd0e9e606d7f0f7ca26609c06ee679ece97). This fixes the "module 'django.utils.timezone' has no attribute 'utc'" error seen in this [Sentry issue](https://massachusetts-institute-of-technology.sentry.io/issues/6610561367/events/1e92de51872841dc8a04f9c88a651723/).

## To do

- Test on staging. It works locally, but there might be other issues, e.g. with the slash at the end of the `BASE_URL` and the way that we build the URL with this line: `thisURL = request.scheme + "://" + request.headers["host"] + request.path`. The URL is part of the data that is hashed for an authentication signature, so it needs to match the webhook URL that we give to Pipe.
- Add tests (we are skipping tests for this view - see [here](https://github.com/lookit/lookit-api/blob/b0c3a3b6de63502e8998b80d6b87fe6484c23cee/exp/tests/test_video_views.py#L49-L59))
- After fixing the endpoint, we can re-run all of the failed Pipe webhook calls (either via a script or individually re-running each one from the Pipe GUI).