### PR TITLE
Add pipe video processing command

### DIFF
--- a/develop_test_payloads.csv
+++ b/develop_test_payloads.csv
@@ -1,0 +1,6 @@
+id,env_id,region,"datetime (UTC)",recovered,name,original_container,length,orig_size,orig_width,orig_height,payload
+4257755,3,us1,"2019-08-12 19:40:53",0,eF6bbQ57wdGsJkYTwK4wCqvNeqGAP32s,webm,3.98,690058,960,720,videoStream_2c3b8103-efef-437b-8b95-c0ad5ea5e69e_1-video-consent_5617cff3-9d95-4e52-8a0a-c25a941ab525_1565638844143_29
+4257767,3,us1,"2019-08-12 19:43:23",0,5YqRuozeov7prxq1y7fBf62rIwnacGYp,webm,121.67,20122874,960,720,videoStream_2c3b8103-efef-437b-8b95-c0ad5ea5e69e_8-pref-phys-videos_5617cff3-9d95-4e52-8a0a-c25a941ab525_1565638880542_787
+4257770,3,us1,"2019-08-12 19:44:02",0,brdhpVSSaqe2NAGVkSqgkvbPEBGBMODy,webm,37.05,6281193,960,720,videoStream_2c3b8103-efef-437b-8b95-c0ad5ea5e69e_9-pref-phys-videos_5617cff3-9d95-4e52-8a0a-c25a941ab525_1565639003668_891
+4270581,2,us1,"2019-08-13 22:55:20",0,xxDcCHRPhFWwyDTTJuqUkHlxJY254lr1,webm,12.62,348034,640,480,videoStream_1e9157cd-b898-4098-9429-a599720d0c0a_1-video-consent_77e2ff44-6454-4387-a610-d7fca726f716_1565736838054_188
+4270598,2,us1,"2019-08-13 22:58:19",0,5aLxjDYcNDH7kdFGi6M4XhDdqGvMzQpf,webm,42.83,1208264,640,480,videoStream_1e9157cd-b898-4098-9429-a599720d0c0a_5-story-intro-2_77e2ff44-6454-4387-a610-d7fca726f716_1565737054099_27

--- a/studies/management/commands/add_pipe_video_objects_without_S3.py
+++ b/studies/management/commands/add_pipe_video_objects_without_S3.py
@@ -1,0 +1,87 @@
+import csv
+from unittest.mock import MagicMock, patch
+
+from django.core.management.base import BaseCommand
+
+from studies.models import Video
+
+
+class Command(BaseCommand):
+    help = "Move info about Pipe recordings into our database from the exported recordings CSV file, without running any S3 actions. This command is meant to be used for Pipe webhook failures that occurred after the S3 file renaming step. WARNING: this command does NOT check whether the new filename exists in the appropriate S3 bucket, which means it is possible to add an invalid video object/filename using this command. This command does check that the associated study and response objects (UUIDs taken from the new filenames) exist in the database."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "csv_file",
+            type=str,
+            help="Path to CSV file with exported Pipe recording data",
+        )
+
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Try processing the CSV file and print the logs, without adding any objects to the database.",
+        )
+
+    def handle(self, *args, **options):
+        path = options["csv_file"]
+        dry_run = options["dry_run"]
+
+        with patch("studies.models.S3_RESOURCE.Object") as mock_s3_object:
+            # We need to mock the S3 object and return values for copy_from/delete so that this part of the Pipe webhook processing is skipped and does not throw errors when the old Pipe file cannot be found (because it has already been renamed).
+            mock_obj = MagicMock()
+            mock_obj.copy_from.return_value = None
+            mock_obj.delete.return_value = None
+            mock_s3_object.return_value = mock_obj
+
+            log_prefix = "[DRY RUN] " if dry_run else ""
+
+            with open(path, newline="", encoding="utf-8") as csvfile:
+                reader = csv.DictReader(csvfile)
+                for row in reader:
+                    if (
+                        not row.get("payload")
+                        or not row.get("name")
+                        or not row.get("id")
+                    ):
+                        self.stderr.write(
+                            self.style.WARNING(
+                                f"{log_prefix}Skipping invalid row: {row}"
+                            )
+                        )
+                        continue
+
+                    try:
+                        # mimic the format of data that comes in via the Pipe webhook POST to pass to Video.from_pipe_payload
+                        payload = {
+                            "data": {
+                                "id": int(row["id"]),
+                                "videoName": row["name"],
+                                "type": "MP4",
+                                "payload": row["payload"],
+                            }
+                        }
+
+                        full_name = f"{payload['data']['payload']}.{payload['data']['type'].lower()}"
+
+                        # Log and skip any videos that already exist in the database
+                        if Video.objects.filter(full_name=full_name).exists():
+                            self.stdout.write(
+                                f"{log_prefix}Skipped existing video: {full_name}"
+                            )
+                            continue
+
+                        if not dry_run:
+                            Video.from_pipe_payload(payload)
+
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"{log_prefix}Created video: {full_name}"
+                            )
+                        )
+
+                    except Exception as e:
+                        self.stderr.write(
+                            self.style.ERROR(
+                                f"{log_prefix}Failed to process row {row.get('id', '')}: {e}"
+                            )
+                        )


### PR DESCRIPTION
This PR adds a management command to the 'studies' app. This script only runs when called manually via `manage.py`, and it must be given a CSV file that contains the exported Pipe recordings for processing. The CSV should be located at the project root and deleted after processing.

This can be used to add Pipe videos to the database while bypassing the AWS S3 actions (renaming the video with the Pipe name to our custom name). This is useful for adding Pipe videos to the database when the Pipe webhook processing failed _after_ the S3 naming step (which means that re-running the webhook no longer works because the file with the original Pipe name no longer exists in S3).

## How to test locally

Here's how to run the command from docker:
```
docker-compose exec web uv run ./manage.py add_pipe_video_objects_without_S3 develop_test_payloads.csv
```

With dry-run flag (no video object creation):
```
docker-compose exec web uv run ./manage.py add_pipe_video_objects_without_S3 develop_test_payloads.csv --dry-run
```

The result will depend on the contents of your local database vs the contents of the CSV file. For each row in the CSV file:
- If the video does not exist in your database, but the study/response UUIDs do exist, then it will create the new video object.
- If the video does exist in your database (matching full_name), then it will log and skip that row.
- If any of the required information is missing from the row, then it will log and skip that row.
- If the `Video.from_pipe_payload` call throws an error, e.g. because the database does not contain the study or response UUID, it will skip the video and provide a 'failed to process' log.

You can test the video creation process by finding a video that was skipped because it already exists in the database, delete the row, and re-run the command. A new video object should be created that matches the original (except for new Video object ID/UUID values).

Example logs:

Created video: videoStream_...mp4
Skipped existing video: videoStream_...mp4
Skipped existing video: videoStream_....mp4
Study with uuid 1e9157cd-b898-4098-9429-a599720d0c0a does not exist. Study matching query does not exist.
Failed to process row 4270581: Study matching query does not exist.
Study with uuid 1e9157cd-b898-4098-9429-a599720d0c0a does not exist. Study matching query does not exist.
Failed to process row 4270598: Study matching query does not exist.