### PR TITLE
Convert logout request from GET to POST

### DIFF
--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -118,7 +118,6 @@ def nav_link(
     Returns:
         SafeText: HTML of navigation item
     """
-    request = context["request"]
     if html_classes is None:
         html_classes = [
             "nav-link",


### PR DESCRIPTION
Fixes #1664 

As of Django 4.1, the logout action must come from a POST request rather than GET. This PR modifies our `nav_link` template tag so that, when the URL is `/logout/`, we generate the necessary form with `method=post` rather than a simple ink to `/logout/`. 

In order to access the CSRF token, I had to edit both the `nav_link` and `dropdown_item` template tags so that they receive the context and can access the CSRF token from there.

There are lot of different solutions to this problem. I decided to extend our existing template tags for nav items so that they handle logout because I wanted to keep our HTML classes and related logic in one place. I'm open to other approaches and suggestions for improvement!