### PR TITLE
Removed redundant consent__time column from RESPONSE_COLUMNS

### DIFF
--- a/exp/views/responses_data.py
+++ b/exp/views/responses_data.py
@@ -148,11 +148,6 @@ RESPONSE_COLUMNS = [
         extractor=lambda resp: resp.most_recent_ruling_comment,
     ),
     ResponseDataColumn(
-        id="consent__time",
-        description="Timestamp of most recent consent ruling, format e.g. 2019-12-09 20:40",
-        extractor=lambda resp: resp.most_recent_ruling_date,
-    ),
-    ResponseDataColumn(
         id="study__uuid",
         description="Unique identifier of study associated with this response. Same for all responses to a given Lookit study.",
         extractor=lambda resp: str(resp.study.uuid),


### PR DESCRIPTION
This turned out to be very simple when I looked into it. There are two completely identical `consent__time` columns in `RESPONSE_COLUMNS` (same id, description, and extractor). Unless there's some other unrepresented column that this extra `consent__time` column is supposed to be, it's okay to just remove this. I checked and this is the only redundant column in the response data.

