### PR TITLE
Add jsPsych fullscreen plugin v2.1.0

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -33,6 +33,7 @@
         <script src="https://unpkg.com/@jspsych/plugin-survey-multi-choice@2.1.0"
                 integrity="sha384-NDx/PP6brJOK2yI3xA9yYbsgRe6I7BUZ3jcBD9aiVRWNYiei88wLmzsMEdWGJXOr"
                 crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/@jspsych/plugin-fullscreen@2.1.0" integrity="sha384-JQEV9wMXFDbTpp1eYJSU9G7uQeyZcLGabno5ZHQJGytUBG19mTZ+ZBV5dsm7m6Mf" crossorigin="anonymous"></script>
         {% comment %} Data and templates packages are peer dependencies and should be listed first. {% endcomment %}
         <script src="https://unpkg.com/@lookit/data@0.2.0"
                 integrity="sha384-iMjDaQDmCTXe6XO59EktLBsg7KmDZZvT5jN/QMiP+ctA8YfQDT/hATDKM1EtoxBQ"


### PR DESCRIPTION
Fixes #1501

This PR loads the [jsPsych fullscreen plugin](https://www.jspsych.org/latest/plugins/fullscreen/) for use in CHS jsPsych experiments. This plugin allows researchers to add trials to their experiment that move participants in and out of fullscreen mode.

Example:

```js
// define trials for entering/exiting fullscreen mode
const enter_fullscreen = {
    type: jsPsychFullscreen,
    fullscreen_mode: true
};

const exit_fullscreen = {
    type: jsPsychFullscreen,
    fullscreen_mode: false,
    delay_after: 0
};

... rest of experiment ...

// put fullscreen trials in the jsPsych timeline
jsPsych.run([enter_fullscreen, ... other trials ..., exit_fullscreen, exit_survey]);
```