### PR TITLE
Download all videos: remove compression to reduce RAM usage

### DIFF
--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -381,7 +381,9 @@ def build_zipfile_of_videos(
         # if it doesn't exist build the zipfile
         with tempfile.TemporaryDirectory(dir="/code/scratch") as temp_directory:
             zip_file_path = os.path.join(temp_directory, zip_filename)
-            with zipfile.ZipFile(zip_file_path, "w") as zf:
+            with zipfile.ZipFile(
+                zip_file_path, "w", compression=zipfile.ZIP_STORED
+            ) as zf:
                 for video in video_qs:
                     temporary_file_path = os.path.join(temp_directory, video.full_name)
                     file_response = requests.get(video.view_url, stream=True)


### PR DESCRIPTION
This is one attempt at addressing #1727 (but should not close the issue).

This removes the file compression step from the download all videos task. This should reduce some of the task's memory usage, with the trade off that the resulting downloadable file will be a little larger (but not much, because the videos are already compressed). We will need to test this version to see if it actually makes much difference to the task's memory profile.