### PR TITLE
Download all videos task: fix incorrect arg in stream_zip

### DIFF
--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -382,11 +382,12 @@ def build_zipfile_of_videos(
                         chunk_size=8192
                     ),  # 8 kb, could be increased to e.g. 65536 / 64 kb or 262144
                     datetime.now(),
+                    0,  # compression method (0=STORE, 8=DEFLATE)
                 )
 
         # Stream zip directly to GCS (no temp file)
         with gs_blob.open("wb") as f:
-            for chunk in stream_zip(file_iter(), compression=None):
+            for chunk in stream_zip(file_iter()):
                 f.write(chunk)
 
     # then send the email with a 30m link


### PR DESCRIPTION
This is another change related to switching to stream-zip to address #1727. This fixes an error in #1737 - the compression argument should have been in the file-specific arguments rather than in the global stream_zip call.