### PR TITLE
Update `libc6-dev` version to fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
         git=1:2.39.5-0+deb12u2 \
         gcc=4:12.2.0-3 \
         wget=1.21.3-1+deb12u1 \
-        libc6-dev=2.36-9+deb12u10 \
+        libc6-dev=2.36-9+deb12u13 \
     && rm -rf /var/lib/apt/lists/*  
 
 RUN gosu nobody true  


### PR DESCRIPTION
This PR updates our pinned `libc6-dev` version from deb12u10 to deb12u13, in order to resolve a build error: "Version 2.36-9+deb12u10 for libc6-dev was not found".

`libc6-dev` is the GNU C Library development package that is needed to build C programs against glibc. It's needed to compile C extensions for Python packages (like psycopg2, gevent, etc.).

## Testing

I've tested this locally and the build succeeds. Updating from deb12u10 to deb12u13 is a security patch release, not a breaking change, and Debian guarantees backward compatibility within a stable release. So because the container builds successfully, the compiled extensions _should_ remain compatible.

I'll do some additional checks on staging, including: database connectivity (psycopg2 / C extensions), task and request concurrency (gevent / greenlet / uwsgi), security e.g. password hashing (cryptography / bcrypt / SSL), site translation.