### PR TITLE
compute frame/trial `sequence` for jsPsych responses

### DIFF
--- a/api/tests/test_responses.py
+++ b/api/tests/test_responses.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIClient, APITestCase
 from accounts.models import Child, DemographicData, User
 from studies.models import ConsentRuling, Lab, Response, Study, StudyType
 from studies.permissions import LabPermission, StudyPermission
+from studies.serializers import ResponseWriteableSerializer
 
 
 class ResponseTestCase(APITestCase):
@@ -78,6 +79,14 @@ class ResponseTestCase(APITestCase):
                 "id": str(self.response.uuid),
             }
         }
+
+        # for testing response API with jsPsych studies
+        self.study_jspsych = G(
+            Study,
+            creator=self.researcher,
+            lab=self.lab,
+            study_type=StudyType.get_jspsych(),
+        )
 
     # Response List test
     def testGetResponseListUnauthenticated(self):
@@ -491,6 +500,163 @@ class ResponseTestCase(APITestCase):
             },
         )
 
+    # Test sequence values for jsPsych response patches.
+    # Unlike EFP, the response sequence is created server-side for jsPsych responses.
+    def testPatchJsPsychResponseNoData(self):
+        # If exp data is missing and there is no data saved yet, the sequence should be empty
+        self.client.force_authenticate(user=self.participant)
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            completed=False,
+        )
+        patch_url = f"{self.url}{response.uuid}/"
+        data = {
+            "data": {  # no exp_data
+                "relationships": {
+                    "child": {"data": {"type": "children", "id": str(self.child.uuid)}},
+                    "study": {
+                        "data": {"type": "studies", "id": str(self.study_jspsych.uuid)}
+                    },
+                },
+                "type": "responses",
+                "id": str(response.uuid),
+            }
+        }
+        api_response = self.client.patch(
+            patch_url,
+            json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+        self.assertEqual(
+            api_response.status_code, status.HTTP_200_OK, msg=api_response.data
+        )
+        self.assertEqual(api_response.data["sequence"], [])
+
+    def testPatchJsPsychResponseWithData(self):
+        # If exp_data is valid, the sequence should be created from the updated data.
+        self.client.force_authenticate(user=self.participant)
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            completed=False,
+        )
+        patch_url = f"{self.url}{response.uuid}/"
+        data = {
+            "data": {
+                "attributes": {
+                    "exp_data": [
+                        {"trial_index": 10, "trial_type": "video-config"},
+                        {"trial_index": 11, "trial_type": "video-consent"},
+                    ]
+                },
+                "relationships": {
+                    "child": {"data": {"type": "children", "id": str(self.child.uuid)}},
+                    "study": {
+                        "data": {"type": "studies", "id": str(self.study_jspsych.uuid)}
+                    },
+                },
+                "type": "responses",
+                "id": str(response.uuid),
+            }
+        }
+        api_response = self.client.patch(
+            patch_url,
+            json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+        self.assertEqual(api_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            api_response.data["sequence"], ["10-video-config", "11-video-consent"]
+        )
+
+    def testPatchJsPsychResponseSequenceIsIgnored(self):
+        # If the patch request sends a sequence value, it should be ignored
+        self.client.force_authenticate(user=self.participant)
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            completed=False,
+        )
+        patch_url = f"{self.url}{response.uuid}/"
+        data = {
+            "data": {
+                "attributes": {
+                    "exp_data": [
+                        {"trial_index": 20, "trial_type": "video-config"},
+                        {"trial_index": 21, "trial_type": "video-consent"},
+                    ],
+                    "sequence": ["this", "should", "be", "ignored"],
+                },
+                "relationships": {
+                    "child": {"data": {"type": "children", "id": str(self.child.uuid)}},
+                    "study": {
+                        "data": {"type": "studies", "id": str(self.study_jspsych.uuid)}
+                    },
+                },
+                "type": "responses",
+                "id": str(response.uuid),
+            }
+        }
+        api_response = self.client.patch(
+            patch_url,
+            json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+        self.assertEqual(api_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            api_response.data["sequence"], ["20-video-config", "21-video-consent"]
+        )
+
+    def testPatchJsPsychResponseKeepsExistingExpDataValueIfMissing(self):
+        # If patch request does not contain exp_data, then any existing exp_data for this object should be kept, and the sequence should be based on that data.
+        self.client.force_authenticate(user=self.participant)
+        existing_exp_data = [
+            {"trial_index": 40, "trial_type": "video-config"},
+            {"trial_index": 41, "trial_type": "video-consent"},
+        ]
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            exp_data=existing_exp_data,
+            sequence=[],
+            completed=False,
+        )
+        patch_url = f"{self.url}{response.uuid}/"
+        data = {
+            "data": {
+                "attributes": {  # no exp_data
+                    "sequence": ["this", "should", "be", "ignored"]
+                },
+                "relationships": {
+                    "child": {"data": {"type": "children", "id": str(self.child.uuid)}},
+                    "study": {
+                        "data": {"type": "studies", "id": str(self.study_jspsych.uuid)}
+                    },
+                },
+                "type": "responses",
+                "id": str(response.uuid),
+            }
+        }
+        api_response = self.client.patch(
+            patch_url,
+            json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+        self.assertEqual(api_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(api_response.data["exp_data"], existing_exp_data)
+        self.assertEqual(
+            api_response.data["sequence"], ["40-video-config", "41-video-consent"]
+        )
+
     # Delete responses
     def testDeleteResponse(self):
         self.client.force_authenticate(user=self.superuser)
@@ -498,3 +664,132 @@ class ResponseTestCase(APITestCase):
             self.response_detail_url, content_type="application/vnd.api+json"
         )
         self.assertEqual(api_response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    # Response writeable serializer - PATCH/update jsPsych response object.
+    def testResponseWriteableSerializerComputesJsPsychSequence(self):
+        # If exp data is formatted correctly, the serializer will generate the sequence array from the data
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            completed=False,
+        )
+        exp_data = [
+            {"trial_index": 7, "trial_type": "video-config"},
+            {"trial_index": 8, "trial_type": "video-consent"},
+        ]
+        serializer = ResponseWriteableSerializer(
+            instance=response,
+            data={"exp_data": exp_data},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertEqual(updated.sequence, ["7-video-config", "8-video-consent"])
+
+    def testResponseWriteableSerializerDataIsMissing(self):
+        # If exp data is missing and there is no existing exp_data for this response object, the sequence should be an empty array
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            completed=False,
+        )
+        serializer = ResponseWriteableSerializer(
+            instance=response,
+            data={},  # no exp_data
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertEqual(updated.sequence, [])
+
+    def testResponseWriteableSerializerDataWrongType(self):
+        # If exp data is the wrong type (not a list), the sequence should be an empty array
+        response = G(
+            Response, child=self.child, study=self.study_jspsych, completed=False
+        )
+        serializer = ResponseWriteableSerializer(
+            instance=response,
+            data={"exp_data": 42},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertEqual(updated.sequence, [])
+
+    def testResponseWriteableSerializerDataElementsNotDicts(self):
+        # If an element in the exp_data list is not a dict, the sequence should skip it
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            completed=False,
+        )
+        exp_data = [
+            {"trial_index": 1, "trial_type": "html-button-response"},
+            "not-a-dict",
+            {"trial_index": 2, "trial_type": "instructions"},
+        ]
+        serializer = ResponseWriteableSerializer(
+            instance=response,
+            data={"exp_data": exp_data},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertEqual(updated.sequence, ["1-html-button-response", "2-instructions"])
+
+    def testResponseWriteableSerializerDataMissingKeys(self):
+        # If a required key is missing from a trial object, the sequence should skip it
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            completed=False,
+        )
+        exp_data = [
+            {"trial_index": 1},  # missing trial_type
+            {"trial_index": 2, "trial_type": "video-consent"},
+            {"trial_type": "html-button-response"},  # missing trial_index
+        ]
+        serializer = ResponseWriteableSerializer(
+            instance=response,
+            data={"exp_data": exp_data},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertEqual(updated.sequence, ["2-video-consent"])
+
+    def testResponseWriteableSerializerKeepsExistingExpDataIfMissing(self):
+        # If exp_data is missing from the validated data that the serializer receives, then any existing exp_data for the response object should be kept and used to compute the sequence value
+        existing_exp_data = [
+            {"trial_index": 0, "trial_type": "html-button-response"},
+            {"trial_index": 1, "trial_type": "start-recording"},
+        ]
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study_jspsych,
+            study_type=self.study_jspsych.study_type,
+            exp_data=existing_exp_data,
+            sequence=[],
+            completed=False,
+        )
+
+        serializer = ResponseWriteableSerializer(
+            instance=response,
+            data={},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertEqual(updated.exp_data, existing_exp_data)
+        self.assertEqual(
+            updated.sequence, ["0-html-button-response", "1-start-recording"]
+        )


### PR DESCRIPTION
Partially addresses [#170](https://github.com/lookit/lookit-jspsych/issues/170)

This PR modifies the response API so that it computes the response object's `sequence` value when:
- the response is for a jsPsych study, and
- the response object already exists (partial/PATCH update) 
 
It does not affect response handling for EFP or external studies. It also does not affect the creation of new jsPsych response objects.

## Reason for this change

This is to address a problem with missing and out-of-sync data for jsPsych study responses. This was due to retrieving the previously-saved values (for both `exp_data` and `sequence`) and then appending new data to those values, which was not robust to intermittent failed API requests. The `exp_data` can just be re-sent in full on each update. However, there is no ground-truth storage for the `sequence` on the client side, so instead we are deriving it from the `exp_data` server-side on each update.

## Edge case handling 

Let me know if I should change any of this behavior or if I'm missing edge cases.

- If the PATCH request is missing `exp_data` then the serializer will use the `exp_data` that already exists (if any) for that response object.
- If the PATCH request contains a `sequence` value, it will ignore that and use the value computed from the data (this is for backwards compatibility with our own jsPsych package versions).
- If the `exp_data` in the PATCH request is the wrong type (not a list), the `sequence` will be an empty array.
- If the `exp_data` in the PATCH request is a list but an element (a) is not a dict, or (b) does not contain the two required keys ("trial_index", "trial_type"), then this element will be skipped.

## Data length check to prevent data loss

This PR also contains #1789, which was based off of this branch and merged separately.