### PR TITLE
Fix "External studies" tab on Study History page

### DIFF
--- a/web/static/js/studies-history.js
+++ b/web/static/js/studies-history.js
@@ -24,7 +24,7 @@ document.querySelectorAll('[role=past_studies_tabs]').forEach(function (tab) {
         const radio = document.querySelector(`[name="past_studies_tabs"][value="${tab.dataset.value}"]`)
         if (!radio.hasAttribute('checked')) {
             radio.checked = true
-            document.querySelector('form').submit()
+            document.querySelector('form#past-studies-tabs-form').submit()
         }
     })
 })

--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -13,7 +13,7 @@
 {% block content %}
     {% bs_icon "arrow-right" as bs_icon_arrow_right %}
     {% trans "Next Video" as trans_next_video %}
-    <form action method="post" class="d-none">
+    <form id="past-studies-tabs-form" action="{% url 'web:studies-history' %}" method="post" class="d-none">
         {% csrf_token %}
         {{ form }}
     </form>


### PR DESCRIPTION
Fixes #1791 

This PR fixes a problem with the "External studies" tab on the Study History page. Clicking this tab would cause the user to be logged out. The problem was that the JavaScript that submits the form (which triggers the Lookit / External content change) was not specific enough, and so it was grabbing/submitting the logout form on the page instead. This was probably caused by the Django v3 to v5 updates, which changed the logout action from a GET to a POST (thereby requiring a form element that was not present on the page before).

The fix was to set an ID for the tab form and use that to grab/submit the correct form when a tab is clicked. 

I also updated the tab-switch form's `action` property to be set explicitly, which makes it more robust against causing unwanted actions (although that was not the cause of the problem in this case).