### PR TITLE
ignore `boto3` patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "boto3"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
The `boto3` package is undergoing very frequent patch updates, which is cluttering up the PRs and my GH alerts with dependabot updates. I'd like to ignore the patch updates. We'll still get alerts for minor/major updates.