### PR TITLE
Add VU CCD lab to resources page

### DIFF
--- a/web/static/js/resources.js
+++ b/web/static/js/resources.js
@@ -551,6 +551,10 @@ const labsData = {
         {
             "url": "https://peabody.vanderbilt.edu/departments/psych/research/research_labs/educational_cognitive_neuroscience_lab/index.php",
             "name": "Vanderbilt Educational Cognitive Neuroscience Lab"
+        },
+        {
+            "url": "https://theccdlab.com/",
+            "name": "Vanderbilt University Computational Cognitive Development Lab"
         }
     ],
     "Texas": [


### PR DESCRIPTION
This PR adds the TN Vanderbilt University Computational Cognitive Development Lab (https://theccdlab.com/) to the Resources page. 

This addresses part of #1428 ([this comment](https://github.com/lookit/lookit-api/issues/1428#issuecomment-3386644952)) but does not close the issue.

<img width="1095" height="465" alt="Screenshot 2025-10-17 at 2 38 39 PM" src="https://github.com/user-attachments/assets/856c6461-0d38-42ae-bda3-b090f9c310c4" />
