### PR TITLE
update chs jspsych record to v4.1.0 and chs jspsych surveys to 4.0.1

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -54,11 +54,11 @@
         <script src="https://unpkg.com/@lookit/lookit-initjspsych@2.1.0"
                 integrity="sha384-57tffibjHG+dqyEOLLeNY18jNHuOzQPmYiOB+m20j6+/vBNP91YeP1Nb6Krk2cmk"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/record@4.0.0"
-                integrity="sha384-HrMs0UB84ZN9bnwP68DgBY5GVtjziBbG2Jqw4pl3O88DDCNjfIZSilPBFjomtBtB"
+        <script src="https://unpkg.com/@lookit/record@4.1.0"
+                integrity="sha384-DxWDXLMg/gkElFfpqPzd7tCXey6RPcraAB881PbJZm/LfpZbu/J8AsaT4IH3YjTR"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/surveys@4.0.0"
-                integrity="sha384-l9H2U0jaAJi2bZTIkanZZuVX/nPvo8Mgf7EJrzBJPwY3JxRxlfiyb2Ol/Jst8WC1"
+        <script src="https://unpkg.com/@lookit/surveys@4.0.1"
+                integrity="sha384-y5ZVd6DNQBV6mg7BLNyjgqGCXA81bqySLwFy407dhgc1UUjFaKRRqZ2X7u6MZgza"
                 crossorigin="anonymous"></script>
         <link rel="stylesheet"
               href="https://unpkg.com/jspsych@8.0.3/css/jspsych.css"


### PR DESCRIPTION
This PR updates the jsPsych study template with the latest versions of the CHS record and surveys packages:
- record v4.1.0
- surveys v4.0.1

See https://github.com/lookit/lookit-jspsych/pull/191 for details about these package releases.