### PR TITLE
bump all lookit-jspsych versions

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -36,8 +36,8 @@
             integrity="sha384-JNNpz6XWsC9uPPHlCuf9rr6LrSD2uYvbkApP5kAp6g/lFBue51K1kMzxGawS50nK"
             crossorigin="anonymous">
         <link rel="stylesheet"
-            href="https://unpkg.com/@lookit/style@0.2.0"
-            integrity="sha384-miw7AsL+cxLi4XSZ0X8OL6ef4v2/sWTYoWqRSDj4AzEMJzCCL8up7TCFqL4XgrVf"
+            href="https://unpkg.com/@lookit/style@0.3.0"
+            integrity="sha384-kmN9wmXS/lsT78dPkfu99YiznGYo4lNUhB5tLUJWL82ScmPucLsOrYj5np/FM/vC"
             crossorigin="anonymous">
     </head>
     <body>
@@ -84,21 +84,21 @@
                 crossorigin="anonymous"></script>
         <script src="https://unpkg.com/@jspsych/plugin-fullscreen@2.1.0" integrity="sha384-JQEV9wMXFDbTpp1eYJSU9G7uQeyZcLGabno5ZHQJGytUBG19mTZ+ZBV5dsm7m6Mf" crossorigin="anonymous"></script>
         {% comment %} Data and templates packages are peer dependencies and should be listed first. {% endcomment %}
-        <script src="https://unpkg.com/@lookit/data@0.2.0"
-                integrity="sha384-iMjDaQDmCTXe6XO59EktLBsg7KmDZZvT5jN/QMiP+ctA8YfQDT/hATDKM1EtoxBQ"
+        <script src="https://unpkg.com/@lookit/data@0.3.0"
+                integrity="sha384-kpjDWFQo7CQk9i6Bq58NNCC8i5mFCMAbapMhF3xxLmEc2vD6wHqMc/aI0w1u/fTh"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/templates@2.1.0"
-                integrity="sha384-9RZZJpDYP42tyQa4nwroWarnZ815GNnaR8dEyt2UvYokn8TJpkK/Ddl2NgLhCCBK"
+        <script src="https://unpkg.com/@lookit/templates@3.0.0"
+                integrity="sha384-pIAOVEQIg3xJ2GqUcOasib4l2WGBtEDJvdO4tv1f+mIkboyXqTpuRJlXEVy8K3qL"
                 crossorigin="anonymous"></script>
         {% comment %} End peer dependencies. {% endcomment %}
-        <script src="https://unpkg.com/@lookit/lookit-initjspsych@2.1.0"
-                integrity="sha384-57tffibjHG+dqyEOLLeNY18jNHuOzQPmYiOB+m20j6+/vBNP91YeP1Nb6Krk2cmk"
+        <script src="https://unpkg.com/@lookit/lookit-initjspsych@3.0.0"
+                integrity="sha384-DfIlRlOvuxLal1x5aNa2A7Z7bT7aicnGeuLWp6kSaF/MP1kH4b6NFSGT7ucmkVaN"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/record@4.1.0"
-                integrity="sha384-DxWDXLMg/gkElFfpqPzd7tCXey6RPcraAB881PbJZm/LfpZbu/J8AsaT4IH3YjTR"
+        <script src="https://unpkg.com/@lookit/record@5.0.0"
+                integrity="sha384-FtTGYc7PNqvbjsEFtFjrmcbs8JWbJNOPMj4WMc8D6aQT6ZeBSesES98wvqxZo/Tr"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@lookit/surveys@4.0.1"
-                integrity="sha384-y5ZVd6DNQBV6mg7BLNyjgqGCXA81bqySLwFy407dhgc1UUjFaKRRqZ2X7u6MZgza"
+        <script src="https://unpkg.com/@lookit/surveys@5.0.0"
+                integrity="sha384-khBuMGRD2HA6lF3nmRuPepPuryCbcmtbS+H1nAgWVV2dzm3hnM/edNG2WISl/+M4"
                 crossorigin="anonymous"></script>
         <!-- Once everything has loaded, run experiment and remove loader div -->
         <script type="module">


### PR DESCRIPTION
This PR bumps our lookit-jspsych packages to the latest versions.
- style: 0.2.0 -> 0.3.0
- data: 0.2.0 -> 0.3.0
- templates: 2.1.0 -> 3.0.0
- lookit-initjspsych: 2.1.0 -> 3.0.0
- record: 4.1.0 -> 5.0.0
- surveys: 4.0.1 -> 5.0.0