### PR TITLE
bump jspsych-contrib image/video hotspots plugin versions 

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -67,11 +67,11 @@
         <script src="https://unpkg.com/@jspsych/plugin-video-button-response@2.0.0"
                 integrity="sha384-u1N4HtXTAx8IPaZxRLKurCoPhFnSQ+TrF+33Lr1ORBhnRogBnU8Fd7tbPkFh1uUj"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@jspsych-contrib/plugin-image-hotspots@1.0.0"
-                integrity="sha384-5FFtjOjpPAEX7u5oCl4/EIA79s5PCUgxFlQJV48+FaiDcZNkPgIULQiU2g2LEkrp"
+        <script src="https://unpkg.com/@jspsych-contrib/plugin-image-hotspots@1.1.0"
+                integrity="sha384-7AhLUtRbC1B+Xy/IvMrbPwOq6HljuZNa73fxtKSPix5U/fRpljnK/hkcJGtKsTRJ"
                 crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@jspsych-contrib/plugin-video-hotspots@1.0.0"
-                integrity="sha384-rt4050E4IgezDryQLHWQQ2R/MifIghArPZ09ovDSwWB6n46Kviwidtl3nMHVyEOE"
+        <script src="https://unpkg.com/@jspsych-contrib/plugin-video-hotspots@1.1.0"
+                integrity="sha384-us3mQaYVUiroiiS/C+w4pJnlRl7E65KWAPC/zqIXWJxpHQhXfn06a2C+fxhkVLbd"
                 crossorigin="anonymous"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@2.0.0"
                 integrity="sha384-veBuhHbf5WLQIFlG9N6a+5E/kRYJcBTDKkqJRTkc7wuGwptljsBa2fYuTseMkOBI"


### PR DESCRIPTION
Bumps jspsych-contrib image-hotspots and video-hotspots plugins: 1.0.0 -> 1.1.0. This adds the `prompt` parameter to both plugins, and the `show_prompt_on_video_end` parameter to the latter.