### PR TITLE
Add management commands

### DIFF
--- a/accounts/management/commands/get_user_data.py
+++ b/accounts/management/commands/get_user_data.py
@@ -1,0 +1,130 @@
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+# This query generates the following:
+# User
+#  ├ Child
+#  │  └ Response
+#  │      ├ Feedback
+#  │      ├ Video
+#  │      └ ConsentRuling
+#  │  └ MessageChildrenOfInterest
+#  │      └ Message
+#  ├ MessageRecipients
+#  │   └ Message
+#  └ DemographicData
+
+SQL_QUERY = """
+WITH target_user AS (
+    SELECT * FROM accounts_user WHERE id = %(user_id)s
+),
+
+children AS (
+    SELECT * FROM accounts_child WHERE user_id = %(user_id)s
+),
+
+responses AS (
+    SELECT * FROM studies_response
+    WHERE child_id IN (SELECT id FROM children)
+),
+
+feedback AS (
+    SELECT * FROM studies_feedback
+    WHERE response_id IN (SELECT id FROM responses)
+),
+
+videos AS (
+    SELECT * FROM studies_video
+    WHERE response_id IN (SELECT id FROM responses)
+),
+
+consent_rulings AS (
+    SELECT * FROM studies_consentruling
+    WHERE response_id IN (SELECT id FROM responses)
+),
+
+demographics AS (
+    SELECT * FROM accounts_demographicdata
+    WHERE user_id = %(user_id)s
+),
+
+messages_to_user AS (
+    SELECT m.*
+    FROM accounts_message m
+    JOIN accounts_message_recipients r
+      ON m.id = r.message_id
+    WHERE r.user_id = %(user_id)s
+),
+
+messages_about_children AS (
+    SELECT m.*
+    FROM accounts_message m
+    JOIN accounts_message_children_of_interest c
+      ON m.id = c.message_id
+    WHERE c.child_id IN (SELECT id FROM children)
+),
+
+messages AS (
+    SELECT * FROM messages_to_user
+    UNION
+    SELECT * FROM messages_about_children
+)
+
+SELECT json_build_object(
+    'User', (SELECT json_agg(t) FROM target_user t),
+    'Child', (SELECT json_agg(c) FROM children c),
+    'DemographicData', (SELECT json_agg(d) FROM demographics d),
+    'Response', (SELECT json_agg(r) FROM responses r),
+    'Feedback', (SELECT json_agg(f) FROM feedback f),
+    'Video', (SELECT json_agg(v) FROM videos v),
+    'ConsentRuling', (SELECT json_agg(c) FROM consent_rulings c),
+    'Message', (SELECT json_agg(m) FROM messages m)
+);
+"""
+
+
+class Command(BaseCommand):
+    help = "Export objects related to a User and their Children"
+
+    def add_arguments(self, parser):
+        parser.add_argument("user_id", type=int)
+        parser.add_argument(
+            "--summary",
+            action="store_true",
+            help="Print counts of related objects instead of full export",
+        )
+        parser.add_argument(
+            "--output",
+            type=str,
+            help="Write export JSON to a file",
+        )
+
+    def handle(self, *args, **options):
+        user_id = options["user_id"]
+        summary = options["summary"]
+        output_file = options.get("output")
+
+        with connection.cursor() as cursor:
+            cursor.execute(SQL_QUERY, {"user_id": user_id})
+            result = cursor.fetchone()[0]
+
+        # normalize nulls
+        result = {k: (v or []) for k, v in result.items()}
+
+        if summary:
+            self.stdout.write("\nObject counts:\n")
+            for table, rows in result.items():
+                self.stdout.write(f"{table}: {len(rows)}")
+            return
+
+        json_output = json.dumps(result, indent=2, default=str)
+
+        if output_file:
+            path = Path(output_file)
+            path.write_text(json_output)
+            self.stdout.write(f"\nExport written to {path.resolve()}")
+        else:
+            print(json_output)

--- a/studies/management/commands/delete_video.py
+++ b/studies/management/commands/delete_video.py
@@ -1,0 +1,128 @@
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models.deletion import Collector
+from django.db.models.signals import pre_delete
+
+from studies.models import Video, delete_video_on_s3
+from studies.tasks import delete_video_from_cloud
+
+
+class Command(BaseCommand):
+    help = "Safely delete a Video from the database, and optionally trigger immediate S3 deletion rather than waiting 7 days."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--uuid", type=str, help="UUID of the Video.")
+        parser.add_argument("--full-name", type=str, help="Full name of the Video.")
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview deletion without deleting.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Actually perform deletion.",
+        )
+        parser.add_argument(
+            "--immediate-s3",
+            action="store_true",
+            help="Delete from S3 immediately instead of waiting 7 days.",
+        )
+
+    def handle(self, *args, **options):
+        uuid = options.get("uuid")
+        full_name = options.get("full_name")
+        dry_run = options.get("dry_run")
+        force = options.get("force")
+        immediate_s3 = options.get("immediate_s3")
+
+        if not uuid and not full_name:
+            raise CommandError("Provide either --uuid or --full-name.")
+
+        if not dry_run and not force:
+            raise CommandError(
+                "Refusing to delete without --force. Use --dry-run to preview."
+            )
+
+        # Find the video
+        try:
+            if uuid:
+                video = Video.objects.get(uuid=uuid)
+            else:
+                video = Video.objects.get(full_name=full_name)
+        except Video.DoesNotExist:
+            raise CommandError("Video not found.")
+        except Video.MultipleObjectsReturned:
+            raise CommandError("Multiple matches found. Use UUID.")
+
+        self.stdout.write(self.style.WARNING("\nVideo found:"))
+        self.stdout.write(f"  ID: {video.id}")
+        self.stdout.write(f"  UUID: {video.uuid}")
+        self.stdout.write(f"  Full name: {video.full_name}")
+
+        # Check for cascading deletions due to related objects
+        collector = Collector(using="default")
+        collector.collect([video])
+
+        related_counts = defaultdict(int)
+        for model, objs in collector.data.items():
+            related_counts[model._meta.label] += len(objs)
+
+        self.stdout.write(self.style.WARNING("\nObjects that will be deleted:"))
+        total = 0
+        for model_label, count in sorted(related_counts.items()):
+            self.stdout.write(f"  {model_label}: {count}")
+            total += count
+
+        self.stdout.write(f"\n  TOTAL objects deleted: {total}")
+
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS("\nDry run complete. No deletion performed.")
+            )
+            return
+
+        # Perform deletion
+        with transaction.atomic():
+            if immediate_s3:
+                self.stdout.write(
+                    self.style.WARNING("\nTriggering immediate S3 deletion...")
+                )
+                # Disconnect pre_delete signal temporarily to avoid scheduling delayed S3 deletion task
+                pre_delete.disconnect(
+                    receiver=delete_video_on_s3,
+                    sender=Video,
+                )
+                try:
+                    # Trigger immediate S3 deletion
+                    delete_video_from_cloud.apply_async(
+                        args=(
+                            video.full_name,
+                            video.recording_method_is_pipe,
+                            video.study_type_is_jspsych,
+                        ),
+                        queue="cleanup",
+                    )
+                    # Delete without triggering delayed signal
+                    video.delete()
+                finally:
+                    # Reconnect the signal
+                    pre_delete.connect(
+                        receiver=delete_video_on_s3,
+                        sender=Video,
+                    )
+            else:
+                video.delete()
+
+        self.stdout.write(self.style.SUCCESS("\nVideo deleted successfully."))
+
+        if immediate_s3:
+            self.stdout.write(self.style.SUCCESS("S3 deletion triggered immediately."))
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "S3 deletion scheduled via pre_delete signal (7-day delay)."
+                )
+            )


### PR DESCRIPTION
This PR adds two management commands:

- `get_user_data`: This takes a User ID and generates all of the data that is directly associated with that User object and their related Child objects. This includes: the User object, related Demographic Data objects, related Child objects, Response objects for each Child, Feedback/Video/ConsentRuling objects for each Child/Response, and Message objects that were sent to the User and/or related to one of the Child objects.
- `delete_video`: This takes a video file name and/or UUID and safely deletes it from the database. You can also optionally immediately delete it from S3, otherwise the database deletion will trigger the S3 deletion in 7 days.
