### PR TITLE
Paginate studies history page to fix 500 error

### DIFF
--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -141,6 +141,7 @@
                     </div>
                 {% endfor %}
                 {% if study.response_page.paginator.num_pages > 1 %}
+                    <div class="text-end px-5">Study responses</div>
                     <div class="text-end px-5">
                         {% if study.response_page.has_previous %}
                             <a class="text-decoration-none"
@@ -170,5 +171,6 @@
             {% endif %}
         </div>
     {% endfor %}
+    <div class="text-end px-5">Previous studies</div>
     {% include "studies/_paginator.html" with page=object_list %}
 {% endblock content %}

--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -141,7 +141,7 @@
                     </div>
                 {% endfor %}
                 {% if study.response_page.paginator.num_pages > 1 %}
-                    <div class="text-end px-5">Study responses</div>
+                    <div class="text-end px-5">{% trans "Study responses" %}</div>
                     <div class="text-end px-5">
                         {% if study.response_page.has_previous %}
                             <a class="text-decoration-none"
@@ -171,6 +171,8 @@
             {% endif %}
         </div>
     {% endfor %}
-    <div class="text-end px-5">Previous studies</div>
-    {% include "studies/_paginator.html" with page=object_list %}
+    {% if object_list.paginator.num_pages > 1 %}
+        <div class="text-end px-5">{% trans "Previous studies" %}</div>
+        {% include "studies/_paginator.html" with page=object_list %}
+    {% endif %}
 {% endblock content %}

--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -76,7 +76,7 @@
                     </div>
                 </div>
                 <h4 class="card-title">{% trans "Study Responses" %}</h4>
-                {% for response in study.responses.all %}
+                {% for response in study.response_page %}
                     <div class="row mb-3">
                         {% if form.past_studies_tabs|studies_tab_selected == "0" %}
                             <div class="col-3 d-flex flex-column">
@@ -140,6 +140,25 @@
                         </div>
                     </div>
                 {% endfor %}
+                {% if study.response_page.paginator.num_pages > 1 %}
+                    <div class="text-end px-5">
+                        {% if study.response_page.has_previous %}
+                            <a class="text-decoration-none"
+                               aria-label="{% trans "Go to previous page of responses" %}"
+                               href="?{% response_page_transform request study.pk study.response_page.previous_page_number %}">
+                                {% bs_icon "chevron-left" %}
+                            </a>
+                        {% endif %}
+                        {% trans "Page" %} {{ study.response_page.number }} {% trans "of" %} {{ study.response_page.paginator.num_pages }}
+                        {% if study.response_page.has_next %}
+                            <a class="text-decoration-none"
+                               aria-label="{% trans "Go to next page of responses" %}"
+                               href="?{% response_page_transform request study.pk study.response_page.next_page_number %}">
+                                {% bs_icon "chevron-right" %}
+                            </a>
+                        {% endif %}
+                    </div>
+                {% endif %}
             </div>
         </div>
     {% empty %}
@@ -151,4 +170,5 @@
             {% endif %}
         </div>
     {% endfor %}
+    {% include "studies/_paginator.html" with page=object_list %}
 {% endblock content %}

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -341,5 +341,9 @@ def response_page_transform(request, study_pk, page_number):
     (e.g. the study-level page number and tab selection).
     """
     updated = request.GET.copy()
-    updated[f"response_page_{study_pk}"] = str(page_number)
+    key = f"response_page_{study_pk}"
+    if page_number == 1:
+        updated.pop(key, None)
+    else:
+        updated[key] = str(page_number)
     return updated.urlencode()

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -331,3 +331,15 @@ def staff_profile(name, img, blurb, type="large"):
 @register.simple_tag
 def absolute_url(name, *args, **kwargs):
     return get_absolute_url(reverse(name, args=args, kwargs=kwargs))
+
+
+@register.simple_tag
+def response_page_transform(request, study_pk, page_number):
+    """Build a query string for per-study response pagination.
+
+    Updates response_page_<study_pk> while preserving all other GET params
+    (e.g. the study-level page number and tab selection).
+    """
+    updated = request.GET.copy()
+    updated[f"response_page_{study_pk}"] = str(page_number)
+    return updated.urlencode()

--- a/web/tests/test_views.py
+++ b/web/tests/test_views.py
@@ -839,11 +839,121 @@ class OneClickUnsubcribeTestCase(TestCase):
         )
 
 
+class StudiesHistoryViewTestCase(TestCase):
+    def setUp(self):
+        self.participant = G(User, is_active=True, is_researcher=False)
+        self.child = G(Child, user=self.participant)
+        self.second_child = G(Child, user=self.participant)
+        self.other_participant = G(User, is_active=True, is_researcher=False)
+        self.other_child = G(Child, user=self.other_participant)
+        self.study_type = StudyType.get_ember_frame_player()
+        self.study = self._make_study("Test Study")
+        self.url = reverse("web:studies-history")
+
+    def _make_study(self, name="Study"):
+        small_gif = (
+            b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x00\x00\x00\x21\xf9\x04"
+            b"\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02"
+            b"\x02\x4c\x01\x00\x3b"
+        )
+        thumbnail = SimpleUploadedFile(
+            name="small.gif", content=small_gif, content_type="image/gif"
+        )
+        return G(Study, study_type=self.study_type, name=name, image=thumbnail)
+
+    def _make_response(self, child=None, study=None, completed_consent_frame=True):
+        return G(
+            Response,
+            child=child or self.child,
+            study=study or self.study,
+            study_type=self.study_type,
+            completed_consent_frame=completed_consent_frame,
+        )
+
+    def test_shows_study_with_completed_consent_frame(self):
+        """A response with completed_consent_frame=True appears even without a consent ruling (pending)."""
+        self.client.force_login(self.participant)
+        self._make_response()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        studies = list(response.context["object_list"])
+        self.assertEqual(len(studies), 1)
+        self.assertEqual(studies[0].pk, self.study.pk)
+        self.assertEqual(len(list(studies[0].response_page)), 1)
+
+    def test_shows_shows_responses_for_multiple_children(self):
+        """If a user has multiple child accounts, they can see the responses for all of their children."""
+        self.client.force_login(self.participant)
+        self._make_response(child=self.child)
+        self._make_response(child=self.second_child)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        studies = list(response.context["object_list"])
+        self.assertEqual(len(studies), 1)
+        self.assertEqual(studies[0].pk, self.study.pk)
+        self.assertEqual(len(list(studies[0].response_page)), 2)
+
+    def test_excludes_response_without_completed_consent_frame(self):
+        """A response where the consent frame was not completed should not appear."""
+        self.client.force_login(self.participant)
+        self._make_response(completed_consent_frame=False)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(list(response.context["object_list"])), 0)
+
+    def test_excludes_other_users_responses(self):
+        """Responses for another user's child should not be visible."""
+        self.client.force_login(self.participant)
+        self._make_response(child=self.other_child)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(list(response.context["object_list"])), 0)
+
+    def test_study_pagination(self):
+        """Studies are paginated at 10 per page."""
+        self.client.force_login(self.participant)
+        for i in range(11):
+            self._make_response(study=self._make_study(f"Study {i}"))
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        page = response.context["object_list"]
+        self.assertEqual(len(list(page)), 10)
+        self.assertEqual(page.paginator.num_pages, 2)
+
+        response_p2 = self.client.get(self.url, {"page": 2})
+        self.assertEqual(len(list(response_p2.context["object_list"])), 1)
+
+    def test_response_pagination(self):
+        """Responses within a study are paginated at 10 per response page."""
+        self.client.force_login(self.participant)
+        for _ in range(11):
+            self._make_response()
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        studies = list(response.context["object_list"])
+        self.assertEqual(len(studies), 1)
+        self.assertEqual(studies[0].response_page.paginator.num_pages, 2)
+        self.assertEqual(len(list(studies[0].response_page)), 10)
+
+        response_p2 = self.client.get(self.url, {f"response_page_{self.study.pk}": 2})
+        studies_p2 = list(response_p2.context["object_list"])
+        self.assertEqual(len(list(studies_p2[0].response_page)), 1)
+
+
 # TODO: StudyDetailView
 # - check can see for public or private active study, unauthenticated or authenticated
 # - check context[children] has own children
 # TODO: StudiesHistoryView
-# - check can see several sessions where consent frame was completed (but consent not marked), not for someone else's
-# child, not for consent frame incomplete.
+# - external studies
 # TODO: ExperimentAssetsProxyView
 # - check have to be authenticated, maybe that's it for now?

--- a/web/views.py
+++ b/web/views.py
@@ -38,6 +38,7 @@ from accounts.queries import (
     get_child_eligibility_for_study,
 )
 from accounts.utils import hash_id
+from exp.mixins.paginator_mixin import PaginatorMixin
 from project import settings
 from studies.helpers import get_experiment_absolute_url
 from studies.models import Lab, Response, Study, StudyType, StudyTypeEnum, Video
@@ -654,7 +655,9 @@ class LabStudiesListView(StudiesListView):
             )
 
 
-class StudiesHistoryView(LoginRequiredMixin, generic.ListView, FormView):
+class StudiesHistoryView(
+    LoginRequiredMixin, PaginatorMixin, generic.ListView, FormView
+):
     """
     List all active, public studies.
     """
@@ -662,6 +665,7 @@ class StudiesHistoryView(LoginRequiredMixin, generic.ListView, FormView):
     template_name = "web/studies-history.html"
     model = Study
     form_class = PastStudiesForm
+    responses_per_study = 10
 
     def post(self, request, *args, **kwargs):
         form = self.get_form()
@@ -677,39 +681,58 @@ class StudiesHistoryView(LoginRequiredMixin, generic.ListView, FormView):
     def get_queryset(self):
         tab_value = self.request.session.get("past_studies_tabs", "0")
 
-        response_query = Q()
+        self._response_query = Q()
         study_query = Q()
 
         if tab_value == PastStudiesFormTabChoices.lookit_studies.value[0]:
             study_query = Q(
                 study_type__name=StudyTypeEnum.ember_frame_player.value
             ) | Q(study_type__name=StudyTypeEnum.jspsych.value)
-            response_query = Q(completed_consent_frame=True)
+            self._response_query = Q(completed_consent_frame=True)
         elif tab_value == PastStudiesFormTabChoices.external_studies.value[0]:
             study_query = Q(study_type__name=StudyTypeEnum.external.value)
 
-        children_ids = Child.objects.filter(user__id=self.request.user.id).values_list(
-            "id", flat=True
-        )
-        responses = (
-            Response.objects.filter(Q(child__id__in=children_ids) & response_query)
-            .select_related("child")
-            .prefetch_related(
-                Prefetch(
-                    "videos",
-                    queryset=Video.objects.order_by("pipe_numeric_id", "s3_timestamp"),
-                ),
-                "consent_rulings",
-                "feedback",
+        self._children_ids = Child.objects.filter(
+            user__id=self.request.user.id
+        ).values_list("id", flat=True)
+
+        study_ids = Response.objects.filter(
+            Q(child__id__in=self._children_ids) & self._response_query
+        ).values_list("study_id", flat=True)
+
+        return Study.objects.filter(Q(id__in=study_ids) & study_query)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        page = self.request.GET.get("page", 1)
+        studies_page = self.paginated_queryset(context["object_list"], page, 10)
+
+        for study in studies_page:
+            response_page_num = self.request.GET.get(f"response_page_{study.pk}", 1)
+            study_responses = (
+                Response.objects.filter(
+                    Q(child__id__in=self._children_ids) & self._response_query,
+                    study=study,
+                )
+                .select_related("child")
+                .prefetch_related(
+                    Prefetch(
+                        "videos",
+                        queryset=Video.objects.order_by(
+                            "pipe_numeric_id", "s3_timestamp"
+                        ),
+                    ),
+                    "consent_rulings",
+                    "feedback",
+                )
+                .order_by("-date_created")
             )
-            .order_by("-date_created")
-        )
+            study.response_page = self.paginated_queryset(
+                study_responses, response_page_num, self.responses_per_study
+            )
 
-        study_ids = responses.values_list("study_id", flat=True)
-
-        return Study.objects.filter(Q(id__in=study_ids) & study_query).prefetch_related(
-            Prefetch("responses", queryset=responses)
-        )
+        context["object_list"] = studies_page
+        return context
 
     def get_success_url(self):
         return reverse("web:studies-history")


### PR DESCRIPTION
Fixes #1801

This PR adds pagination to the family-facing studies history page (My Past Studies), in order to fix 500 response timeout errors when there are lots of previous studies/responses.
- The page now uses pagination for the study list. The first 10 studies are shown on the page, and the user can navigate forwards/backwards across sets of 10 studies, up to their total number of previous studies. 
- The page now uses pagination for responses within each study. The first set of 10 responses are shown, and the user can navigate across sets of 10 responses for any particular study. (Note that this feature probably won't apply to most family users, but it's helpful for researchers/developers who create a huge number of responses for the same study while testing).

Pagination of responses within studies: 

<img width="1135" height="357" alt="study_resp_pages" src="https://github.com/user-attachments/assets/b7370004-a869-459e-8d56-46909d0b5093" />


Pagination of studies:

<img width="1135" height="345" alt="study_pages" src="https://github.com/user-attachments/assets/183228e7-e177-4002-8bef-c8d2e46e150f" />


When there are fewer than 10 studies, there is no study pagination:

<img width="1153" height="310" alt="no_past_studies" src="https://github.com/user-attachments/assets/3238430d-4e24-4c5f-88a0-d06cbef91764" />


When there are fewer than 10 responses for a study, there is no response pagination:

<img width="1153" height="248" alt="no_resp_pages" src="https://github.com/user-attachments/assets/d55a5235-ad1c-4521-a21b-cbcb7e33be9e" />

