### PR TITLE
Add admin-only search/filter options on Manage Studies

### DIFF
--- a/exp/templatetags/exp_extras.py
+++ b/exp/templatetags/exp_extras.py
@@ -70,3 +70,9 @@ def get_bit_label(bit_handler, bit_number):
 @register.filter
 def pretty_json(value):
     return json.dumps(value, indent=4, default=str)
+
+
+@register.filter
+def before_paren(value):
+    """Return the portion of a string before the first '(', stripped of whitespace."""
+    return value.partition("(")[0].strip()

--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -1450,6 +1450,12 @@ class StudyListViewTestCase(TestCase):
         self.assertContains(response, self.study1.name)
         self.assertNotContains(response, self.study2.name)
 
+    def test_superuser_filter_by_creator_full_name(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"creator": "Alice Anderson"})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
     def test_superuser_combined_name_and_lab_filter(self):
         self.client.force_login(self.superuser)
         # Both studies match "Study" but only study1 is in Alpha Lab

--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -10,7 +10,9 @@ from unittest.mock import (
     patch,
     sentinel,
 )
+from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms.models import model_to_dict
@@ -31,7 +33,7 @@ from exp.views.study import (
     StudyDetailView,
     StudyPreviewDetailView,
 )
-from studies.models import Lab, Study, StudyType
+from studies.models import Lab, Study, StudyLog, StudyType
 from studies.permissions import LabPermission, StudyPermission
 
 
@@ -1479,6 +1481,44 @@ class StudyListViewTestCase(TestCase):
         # Sending study2's UUID should not make it visible to creator1
         response = self.client.get(self.url, {"uuid": str(self.study2.uuid)})
         self.assertNotContains(response, self.study2.name)
+
+    def test_status_change_date_display_shows_status_change_date(self):
+        """Study with non-null status_change_date shows it formatted in the list."""
+        known_date = datetime.datetime(2020, 6, 15, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        self.study1.status_change_date = known_date
+        self.study1.save()
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, "Jun 15, 2020")
+
+    def test_status_change_date_display_falls_back_to_studylog(self):
+        """Study with null status_change_date shows date from matching StudyLog entry."""
+        known_date = datetime.datetime(2021, 3, 15, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        # Explicitly set state to "created" so we know the matching StudyLog action.
+        # The post_save signal always creates a StudyLog(action="created") on study creation.
+        self.study1.state = "created"
+        self.study1.status_change_date = None
+        self.study1.save()
+        StudyLog.objects.filter(study=self.study1, action="created").update(
+            created_at=known_date
+        )
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, "Mar 15, 2021")
+
+    def test_status_change_date_display_is_na_without_date_or_log(self):
+        """Study with null status_change_date and no matching StudyLog shows N/A."""
+        # Set state to "submitted" so the fallback looks for action="submitted" logs,
+        # but no such log exists (only the action="created" log from the post_save signal).
+        self.study1.state = "submitted"
+        self.study1.status_change_date = None
+        self.study1.save()
+        # Use the submitted-state tab so only study1 is visible.
+        submitted_url = reverse("exp:study-list-submitted")
+        self.client.force_login(self.superuser)
+        response = self.client.get(submitted_url)
+        self.assertContains(response, self.study1.name)
+        self.assertContains(response, "N/A")
 
 
 # TODO: StudyCreateView

--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -1321,6 +1321,166 @@ class StudyParticipatedViewTestCase(TestCase):
         self.assertSetEqual(set(study.must_not_have_participated.all()), set())
 
 
+class StudyListViewTestCase(TestCase):
+    """Tests for StudyListView (Manage Studies page), including admin-only search/filter inputs and queries."""
+
+    def setUp(self):
+        self.client = Force2FAClient()
+        self.url = reverse("exp:study-list")
+
+        self.lab1 = G(Lab, name="Alpha Lab", approved_to_test=True)
+        self.lab2 = G(Lab, name="Beta Lab", approved_to_test=True)
+
+        self.study_type_efp = StudyType.objects.get(id=1)
+        self.study_type_jspsych = StudyType.objects.get(id=3)
+
+        self.creator1 = G(
+            User,
+            is_active=True,
+            is_researcher=True,
+            given_name="Alice",
+            family_name="Anderson",
+        )
+        self.creator2 = G(
+            User,
+            is_active=True,
+            is_researcher=True,
+            given_name="Bob",
+            family_name="Brown",
+        )
+        self.superuser = G(
+            User,
+            is_active=True,
+            is_researcher=True,
+            is_superuser=True,
+        )
+
+        self.study1 = G(
+            Study,
+            name="Apples Study",
+            lab=self.lab1,
+            public=True,
+            creator=self.creator1,
+            study_type=self.study_type_efp,
+        )
+        self.study2 = G(
+            Study,
+            name="Bananas Study",
+            lab=self.lab2,
+            public=False,
+            creator=self.creator2,
+            study_type=self.study_type_jspsych,
+        )
+
+        # Give creator1 READ_STUDY_DETAILS on study1 only
+        assign_perm(
+            StudyPermission.READ_STUDY_DETAILS.prefixed_codename,
+            self.creator1,
+            self.study1,
+        )
+
+    def test_superuser_sees_admin_filter_section(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Admin filters")
+        self.assertContains(response, 'name="uuid"')
+        self.assertContains(response, 'name="study_type"')
+        self.assertContains(response, 'name="lab"')
+        self.assertContains(response, 'name="public"')
+        self.assertContains(response, 'name="creator"')
+
+    def test_non_superuser_does_not_see_admin_filter_section(self):
+        self.client.force_login(self.creator1)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'name="match"')
+        self.assertNotContains(response, "Admin filters")
+        self.assertNotContains(response, 'name="uuid"')
+        self.assertNotContains(response, 'name="creator"')
+
+    def test_superuser_filter_by_uuid(self):
+        self.client.force_login(self.superuser)
+        partial_uuid = str(self.study1.uuid)[:8]
+        response = self.client.get(self.url, {"uuid": partial_uuid})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_study_type(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"study_type": self.study_type_efp.id})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_lab_name(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"lab": "Beta"})
+        self.assertContains(response, self.study2.name)
+        self.assertNotContains(response, self.study1.name)
+
+    def test_superuser_filter_by_public_true(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"public": "true"})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_public_false(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"public": "false"})
+        self.assertNotContains(response, self.study1.name)
+        self.assertContains(response, self.study2.name)
+
+    def test_superuser_filter_by_creator_given_name(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"creator": "Alice"})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_creator_family_name(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"creator": "Brown"})
+        self.assertNotContains(response, self.study1.name)
+        self.assertContains(response, self.study2.name)
+
+    def test_superuser_filter_by_creator_email(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"creator": self.creator1.username})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_combined_name_and_lab_filter(self):
+        self.client.force_login(self.superuser)
+        # Both studies match "Study" but only study1 is in Alpha Lab
+        response = self.client.get(self.url, {"match": "Study", "lab": "Alpha"})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_invalid_public_value_ignored(self):
+        self.client.force_login(self.superuser)
+        # Values other than "true"/"false" should be ignored
+        response = self.client.get(self.url, {"public": "maybe"})
+        self.assertContains(response, self.study1.name)
+        self.assertContains(response, self.study2.name)
+
+    def test_non_superuser_admin_filter_params_are_ignored(self):
+        self.client.force_login(self.creator1)
+        # creator1 only has permission on study1; filtering by lab2 should be ignored
+        response = self.client.get(self.url, {"lab": self.lab2.name})
+        self.assertContains(response, self.study1.name)
+
+    def test_non_superuser_cannot_see_study_outside_permissions(self):
+        self.client.force_login(self.creator1)
+        # study2 is not in creator1's permissions — should never appear
+        response = self.client.get(self.url)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_non_superuser_uuid_param_does_not_expand_visible_studies(self):
+        self.client.force_login(self.creator1)
+        # Sending study2's UUID should not make it visible to creator1
+        response = self.client.get(self.url, {"uuid": str(self.study2.uuid)})
+        self.assertNotContains(response, self.study2.name)
+
+
 # TODO: StudyCreateView
 # - check user has to be in a lab with perms to create study to get
 # TODO: StudyUpdateView
@@ -1328,9 +1488,6 @@ class StudyParticipatedViewTestCase(TestCase):
 # - check posting change works
 # - check invalid metadata not saved
 # - check can't change lab to one you're not in, or at all w/o perms to change lab
-# TODO: StudyListView
-# - check can get as researcher only
-# - check you see exactly studies you have view details perms for
 # TODO: StudyPreviewProxyView
 # - add checks analogous to preview detail view
 # - check for correct redirect

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -291,6 +291,13 @@ class StudyListView(
         context["sort"] = self.request.GET.get("sort", "name")
         context["page"] = self.request.GET.get("page", "1")
         context["can_create_study"] = self.request.user.can_create_study()
+        if self.request.user.is_superuser:
+            context["study_types"] = StudyType.objects.all()
+            context["admin_uuid"] = self.request.GET.get("uuid", "")
+            context["admin_study_type"] = self.request.GET.get("study_type", "")
+            context["admin_lab"] = self.request.GET.get("lab", "")
+            context["admin_public"] = self.request.GET.get("public", "")
+            context["admin_creator"] = self.request.GET.get("creator", "")
         return context
 
 

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -298,6 +298,10 @@ class StudyListView(
             context["admin_lab"] = self.request.GET.get("lab", "")
             context["admin_public"] = self.request.GET.get("public", "")
             context["admin_creator"] = self.request.GET.get("creator", "")
+            if self.state == "submitted":
+                context["admin_submission_history"] = self.request.GET.get(
+                    "submission_history", ""
+                )
         return context
 
 

--- a/studies/models.py
+++ b/studies/models.py
@@ -607,8 +607,23 @@ class Study(models.Model):
 
     @property
     def days_submitted(self):
-        if self.status_change_date:
-            return (dutimezone.now() - self.status_change_date).days
+        if self.state != "submitted":
+            return None
+        # status_change_date is set on every workflow state transition, so for a submitted study it is the submission date.
+        # It was added in a migration without a backfill, so it may be null for older studies.
+        date = self.status_change_date
+        if not date:
+            log = (
+                StudyLog.objects.filter(study=self, action="submitted")
+                .order_by("-created_at")
+                .first()
+            )
+            if log:
+                date = log.created_at
+        if date:
+            return (dutimezone.now() - date).days
+        else:
+            return None
 
     @property
     def approved_by(self):

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -357,6 +357,16 @@ def get_study_list_qs(user, query_dict):
                 .filter(action="deactivated")
                 .values("created_at")[:1]
             ),
+            status_change_date_display=Coalesce(
+                F("status_change_date"),
+                Subquery(
+                    StudyLog.objects.filter(
+                        study=OuterRef("pk"), action=OuterRef("state")
+                    )
+                    .order_by("-created_at")
+                    .values("created_at")[:1]
+                ),
+            ),
         )
     )
 

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -372,6 +372,31 @@ def get_study_list_qs(user, query_dict):
             )
         )
 
+    if user.is_superuser:
+        uuid_filter = "".join(query_dict.get("uuid", []))
+        if uuid_filter:
+            queryset = queryset.filter(uuid__icontains=uuid_filter)
+
+        study_type_filter = "".join(query_dict.get("study_type", []))
+        if study_type_filter:
+            queryset = queryset.filter(study_type_id=study_type_filter)
+
+        lab_filter = "".join(query_dict.get("lab", []))
+        if lab_filter:
+            queryset = queryset.filter(lab__name__icontains=lab_filter)
+
+        public_filter = "".join(query_dict.get("public", []))
+        if public_filter in ("true", "false"):
+            queryset = queryset.filter(public=(public_filter == "true"))
+
+        creator_filter = "".join(query_dict.get("creator", []))
+        if creator_filter:
+            queryset = queryset.filter(
+                Q(creator__given_name__icontains=creator_filter)
+                | Q(creator__family_name__icontains=creator_filter)
+                | Q(creator__username__icontains=creator_filter)
+            )
+
     # Sort value is in a list
     sort = "".join(query_dict.get("sort", []))
     if sort:

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -433,6 +433,7 @@ def _apply_superuser_filters(queryset, state, query_dict):
             Q(creator__given_name__icontains=creator_filter)
             | Q(creator__family_name__icontains=creator_filter)
             | Q(creator__username__icontains=creator_filter)
+            | Q(creator_name__icontains=creator_filter)
         )
 
     if state == "submitted":

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -273,19 +273,8 @@ def get_pending_responses_qs():
     )
 
 
-def get_study_list_qs(user, query_dict):
-    """Gets a study list query set annotated with response counts.
-
-    TODO: Factor in all the query mutation from the (view) caller.
-    TODO: Upgrade to Django 2.x and use the improved query mechanisms to clean this up.
-
-    Args:
-        user: django.utils.functional.SimpleLazyObject masquerading as a user.
-        query_dict: django.http.QueryDict from the self.request.GET property.
-
-    Returns:
-        A heavily annotated queryset for the list of studies.
-    """
+def _build_study_list_base_qs(user):
+    """Build the base annotated queryset for the study list."""
     annotated_responses_qs = get_annotated_responses_qs().only(
         "id",
         "completed",
@@ -295,7 +284,7 @@ def get_study_list_qs(user, query_dict):
         "is_preview",
     )
 
-    queryset = (
+    return (
         studies_for_which_user_has_perm(user, StudyPermission.READ_STUDY_DETAILS)
         # .select_related("lab")
         # .select_related("creator")
@@ -370,16 +359,18 @@ def get_study_list_qs(user, query_dict):
         )
     )
 
-    # Request filtering
 
-    state = query_dict.get("state")
+def _apply_state_filter(queryset, user, state):
+    """Filter queryset by state or restrict to the current user's studies."""
     if state and state != "all":
         if state == "myStudies":
-            queryset = queryset.filter(creator=user)
-        else:
-            queryset = queryset.filter(state=state)
+            return queryset.filter(creator=user)
+        return queryset.filter(state=state)
+    return queryset
 
-    match = query_dict.get("match")
+
+def _apply_match_filter(queryset, match):
+    """Filter queryset to studies whose name or description contain all search terms."""
     if match:
         queryset = queryset.filter(
             reduce(
@@ -390,63 +381,94 @@ def get_study_list_qs(user, query_dict):
                 ),
             )
         )
+    return queryset
 
-    if user.is_superuser:
-        uuid_filter = "".join(query_dict.get("uuid", []))
-        if uuid_filter:
-            queryset = queryset.filter(uuid__icontains=uuid_filter)
 
-        study_type_filter = "".join(query_dict.get("study_type", []))
-        if study_type_filter:
-            queryset = queryset.filter(study_type_id=study_type_filter)
+def _apply_submission_history_filter(queryset, submission_history):
+    """Filter submitted studies by their approval/rejection history."""
+    ever_approved = Exists(
+        StudyLog.objects.filter(study=OuterRef("pk"), action="approved")
+    )
+    ever_rejected = Exists(
+        StudyLog.objects.filter(study=OuterRef("pk"), action="rejected")
+    )
+    if submission_history == "first_submission":
+        return queryset.filter(~ever_approved, ~ever_rejected)
+    elif submission_history == "previously_rejected":
+        return queryset.filter(~ever_approved, ever_rejected)
+    elif submission_history == "previously_approved":
+        return queryset.filter(ever_approved)
+    elif submission_history == "other":
+        # Complement of the three exhaustive categories above — always empty
+        # in practice, but kept as a filter option for data anomalies
+        return queryset.exclude(
+            Q(~ever_approved, ~ever_rejected)
+            | Q(~ever_approved, ever_rejected)
+            | Q(ever_approved)
+        )
+    return queryset
 
-        lab_filter = "".join(query_dict.get("lab", []))
-        if lab_filter:
-            queryset = queryset.filter(lab__name__icontains=lab_filter)
 
-        public_filter = "".join(query_dict.get("public", []))
-        if public_filter in ("true", "false"):
-            queryset = queryset.filter(public=(public_filter == "true"))
+def _apply_superuser_filters(queryset, state, query_dict):
+    """Apply admin-only search filters from the query string."""
+    uuid_filter = "".join(query_dict.get("uuid", []))
+    if uuid_filter:
+        queryset = queryset.filter(uuid__icontains=uuid_filter)
 
-        creator_filter = "".join(query_dict.get("creator", []))
-        if creator_filter:
-            queryset = queryset.filter(
-                Q(creator__given_name__icontains=creator_filter)
-                | Q(creator__family_name__icontains=creator_filter)
-                | Q(creator__username__icontains=creator_filter)
-            )
+    study_type_filter = "".join(query_dict.get("study_type", []))
+    if study_type_filter:
+        queryset = queryset.filter(study_type_id=study_type_filter)
 
-        if state == "submitted":
-            submission_history = "".join(query_dict.get("submission_history", []))
-            if submission_history:
-                ever_approved = Exists(
-                    StudyLog.objects.filter(study=OuterRef("pk"), action="approved")
-                )
-                ever_rejected = Exists(
-                    StudyLog.objects.filter(study=OuterRef("pk"), action="rejected")
-                )
-                if submission_history == "first_submission":
-                    queryset = queryset.filter(~ever_approved, ~ever_rejected)
-                elif submission_history == "previously_rejected":
-                    queryset = queryset.filter(~ever_approved, ever_rejected)
-                elif submission_history == "previously_approved":
-                    queryset = queryset.filter(ever_approved)
-                elif submission_history == "other":
-                    # Complement of the three exhaustive categories above — always empty
-                    # in practice, but kept as a filter option for data anomalies
-                    queryset = queryset.exclude(
-                        Q(~ever_approved, ~ever_rejected)
-                        | Q(~ever_approved, ever_rejected)
-                        | Q(ever_approved)
-                    )
+    lab_filter = "".join(query_dict.get("lab", []))
+    if lab_filter:
+        queryset = queryset.filter(lab__name__icontains=lab_filter)
 
-    # Sort value is in a list
-    sort = "".join(query_dict.get("sort", []))
+    public_filter = "".join(query_dict.get("public", []))
+    if public_filter in ("true", "false"):
+        queryset = queryset.filter(public=(public_filter == "true"))
+
+    creator_filter = "".join(query_dict.get("creator", []))
+    if creator_filter:
+        queryset = queryset.filter(
+            Q(creator__given_name__icontains=creator_filter)
+            | Q(creator__family_name__icontains=creator_filter)
+            | Q(creator__username__icontains=creator_filter)
+        )
+
+    if state == "submitted":
+        submission_history = "".join(query_dict.get("submission_history", []))
+        if submission_history:
+            queryset = _apply_submission_history_filter(queryset, submission_history)
+
+    return queryset
+
+
+def _apply_sort(queryset, sort):
+    """Sort queryset by the given field name, ignoring invalid field names."""
     if sort:
         try:
             queryset = queryset.order_by(sort)
         except FieldError:
             # if someone attempts to manually enter a field that doesn't exist
             pass
+    return queryset
 
+
+def get_study_list_qs(user, query_dict):
+    """Gets a study list query set annotated with response counts.
+
+    Args:
+        user: django.utils.functional.SimpleLazyObject masquerading as a user.
+        query_dict: django.http.QueryDict from the self.request.GET property.
+
+    Returns:
+        A heavily annotated queryset for the list of studies.
+    """
+    state = query_dict.get("state")
+    queryset = _build_study_list_base_qs(user)
+    queryset = _apply_state_filter(queryset, user, state)
+    queryset = _apply_match_filter(queryset, query_dict.get("match"))
+    if user.is_superuser:
+        queryset = _apply_superuser_filters(queryset, state, query_dict)
+    queryset = _apply_sort(queryset, "".join(query_dict.get("sort", [])))
     return queryset

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -5,7 +5,16 @@ from functools import reduce
 
 from django.core.exceptions import FieldError
 from django.db import models
-from django.db.models import Count, F, IntegerField, OuterRef, Q, Subquery, Value
+from django.db.models import (
+    Count,
+    Exists,
+    F,
+    IntegerField,
+    OuterRef,
+    Q,
+    Subquery,
+    Value,
+)
 from django.db.models.fields import CharField
 from django.db.models.functions import Coalesce, Concat
 from django.utils.timezone import now
@@ -396,6 +405,30 @@ def get_study_list_qs(user, query_dict):
                 | Q(creator__family_name__icontains=creator_filter)
                 | Q(creator__username__icontains=creator_filter)
             )
+
+        if state == "submitted":
+            submission_history = "".join(query_dict.get("submission_history", []))
+            if submission_history:
+                ever_approved = Exists(
+                    StudyLog.objects.filter(study=OuterRef("pk"), action="approved")
+                )
+                ever_rejected = Exists(
+                    StudyLog.objects.filter(study=OuterRef("pk"), action="rejected")
+                )
+                if submission_history == "first_submission":
+                    queryset = queryset.filter(~ever_approved, ~ever_rejected)
+                elif submission_history == "previously_rejected":
+                    queryset = queryset.filter(~ever_approved, ever_rejected)
+                elif submission_history == "previously_approved":
+                    queryset = queryset.filter(ever_approved)
+                elif submission_history == "other":
+                    # Complement of the three exhaustive categories above — always empty
+                    # in practice, but kept as a filter option for data anomalies
+                    queryset = queryset.exclude(
+                        Q(~ever_approved, ~ever_rejected)
+                        | Q(~ever_approved, ever_rejected)
+                        | Q(ever_approved)
+                    )
 
     # Sort value is in a list
     sort = "".join(query_dict.get("sort", []))

--- a/studies/templates/studies/study_detail/_manage_researchers.html
+++ b/studies/templates/studies/study_detail/_manage_researchers.html
@@ -49,14 +49,14 @@
                     Researchers belonging to this study's access groups. {{ study.lab.name }} Admins will automatically be able to edit this study, regardless of study group.
                 </div>
                 <div class="row mb-1">
-                    <div class="col-4 fw-bold">Name</div>
-                    <div class="col-6 fw-bold">Permissions</div>
+                    <div class="col-5 fw-bold">Name</div>
+                    <div class="col-5 fw-bold">Permissions</div>
                 </div>
                 {% for researcher in current_researchers %}
                     <div class="row mb-1">
-                        <div class="col-4">{{ researcher.user.identicon_small_html }} {{ researcher.user.get_short_name }}</div>
+                        <div class="col-5">{{ researcher.user.identicon_small_html }} {{ researcher.user.get_short_name }} ({{ researcher.user.username }})</div>
                         {% if can_manage_researchers %}
-                            <div class="col-6">
+                            <div class="col-5">
                                 <div class="permissionDisplay">
                                     <a href="#"
                                        data-name="update_user"
@@ -69,7 +69,7 @@
                                        data-title="Select researcher permissions">{{ researcher.current_group }}</a>
                                 </div>
                             </div>
-                            <div class="col-2">
+                            <div class="col-2 text-center">
                                 <form method="post"
                                       action="{% url 'exp:manage-researcher-permissions' study.id %}">
                                     {% csrf_token %}

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -130,10 +130,10 @@
             <strong>Last Status Change</strong>
             <a class="text-decoration-none"
                aria-label="Sort studies by end date"
-               href="?{% query_transform request page='1' sort='status_change_date' %}">{% bs_icon "chevron-up" %}</a>
+               href="?{% query_transform request page='1' sort='status_change_date_display' %}">{% bs_icon "chevron-up" %}</a>
             <a class="text-decoration-none"
                aria-label="Reverse sort studies by end date"
-               href="?{% query_transform request page='1' sort='-status_change_date' %}">{% bs_icon "chevron-down" %}</a>
+               href="?{% query_transform request page='1' sort='-status_change_date_display' %}">{% bs_icon "chevron-down" %}</a>
         </div>
     </div>
     {% for study in object_list %}
@@ -155,7 +155,7 @@
                             {% endblock status_change_label %}
                         </strong>
                         {% block status_change_date %}
-                            {{ study.status_change_date|date:"M d, Y"|default:"N/A" }}
+                            {{ study.status_change_date_display|date:"M d, Y"|default:"N/A" }}
                         {% endblock status_change_date %}
                     </div>
                 </div>

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -76,6 +76,17 @@
                                type="text"
                                value="{{ admin_creator }}" />
                     </div>
+                    {% if state == "submitted" %}
+                        <div class="col-lg-6">
+                            <select class="form-select" name="submission_history">
+                                <option value="">Submission history: all</option>
+                                <option value="first_submission" {% if admin_submission_history == "first_submission" %}selected{% endif %}>First submission</option>
+                                <option value="previously_rejected" {% if admin_submission_history == "previously_rejected" %}selected{% endif %}>Previously rejected</option>
+                                <option value="previously_approved" {% if admin_submission_history == "previously_approved" %}selected{% endif %}>Previously approved</option>
+                                <option value="other" {% if admin_submission_history == "other" %}selected{% endif %}>Other</option>
+                            </select>
+                        </div>
+                    {% endif %}
                 </div>
             {% endif %}
         </form>

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -10,24 +10,76 @@
     {% bs_icon "plus" as bs_icon_plus %}
     {% url 'exp:study-create' as url_study_create %}
     {% button_primary_classes as btn_primary_classes %}
+    {% button_primary_light_classes as btn_primary_lgt_classes %}
     {% bootstrap_button bs_icon_plus|add:"Create Study" href=url_study_create button_class=btn_primary_classes as btn_create_study %}
     {% if can_create_study %}
         {% page_title "Manage Studies" right_side_elements=btn_create_study %}
     {% else %}
         {% page_title "Manage Studies" %}
     {% endif %}
-    <form method="get" class="search-bar">
-        <input id="search-studies"
-               class="form-control"
-               name="match"
-               placeholder="Filter name or description"
-               size="50"
-               type="text"
-               value="{{ match }}" />
-        <input type="hidden" name="sort" value="{{ sort }}" />
-        <input type="hidden" name="state" value="{{ state }}" />
-        <input type="hidden" name="page" value="1" />
-    </form>
+    <div class="mt-2 p-2 border rounded bg-white">
+        <form method="get" class="search-bar">
+            <div class="row g-2">
+                <div class="col-lg-10">
+                    <input id="search-studies"
+                        class="form-control"
+                        name="match"
+                        placeholder="Filter name or description"
+                        size="50"
+                        type="text"
+                        value="{{ match }}" />
+                </div>
+                <div class="col-lg-2 text-center text-lg-end">
+                    {% bootstrap_button "Search" button_type="submit" button_class=btn_primary_lgt_classes %}
+                </div>
+            </div>
+            <input type="hidden" name="sort" value="{{ sort }}" />
+            <input type="hidden" name="state" value="{{ state }}" />
+            <input type="hidden" name="page" value="1" />
+            {% if request.user.is_superuser %}
+                <div class="text-muted d-block mb-1 mt-3">Admin filters</div>
+                <div class="row g-2 mb-3">
+                    <div class="col-lg-6">
+                        <input class="form-control"
+                               name="uuid"
+                               placeholder="Study UUID"
+                               size="35"
+                               type="text"
+                               value="{{ admin_uuid }}" />
+                    </div>
+                    <div class="col-lg-3">
+                        <select class="form-select" name="study_type">
+                            <option value="">All study types</option>
+                            {% for st in study_types %}
+                                <option value="{{ st.id }}" {% if admin_study_type == st.id|stringformat:"s" %}selected{% endif %}>{{ st.name|before_paren }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-lg-3">
+                        <select class="form-select" name="public">
+                            <option value="">Public: any</option>
+                            <option value="true" {% if admin_public == "true" %}selected{% endif %}>Public: yes</option>
+                            <option value="false" {% if admin_public == "false" %}selected{% endif %}>Public: no</option>
+                        </select>
+                    </div>
+                    <div class="col-lg-6">
+                        <input class="form-control"
+                               name="lab"
+                               placeholder="Lab name"
+                               type="text"
+                               value="{{ admin_lab }}" />
+                    </div>
+                    <div class="col-lg-6">
+                        <input class="form-control"
+                               name="creator"
+                               placeholder="Study creator name or email"
+                               type="text"
+                               value="{{ admin_creator }}" />
+                    </div>
+                </div>
+            {% endif %}
+        </form>
+    </div>
     <div class="row text-center mb-5 mt-2">
         <ul class="nav nav-pills justify-content-center">
             {% nav_link request 'exp:study-list-active' 'Active' %}

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -17,7 +17,7 @@
     {% else %}
         {% page_title "Manage Studies" %}
     {% endif %}
-    <div class="mt-2 p-2 border rounded bg-white">
+    <div class="mt-2 p-2 pb-4 border rounded bg-white">
         <form method="get" class="search-bar">
             <div class="row g-2">
                 <div class="col-lg-10">
@@ -38,7 +38,7 @@
             <input type="hidden" name="page" value="1" />
             {% if request.user.is_superuser %}
                 <div class="text-muted d-block mb-1 mt-3">Admin filters</div>
-                <div class="row g-2 mb-3">
+                <div class="row g-2">
                     <div class="col-lg-6">
                         <input class="form-control"
                                name="uuid"

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -22,7 +22,15 @@ from studies.helpers import (
     get_experiment_absolute_url,
     send_mail,
 )
-from studies.models import Lab, Response, Study, StudyType, StudyTypeEnum, Video
+from studies.models import (
+    Lab,
+    Response,
+    Study,
+    StudyLog,
+    StudyType,
+    StudyTypeEnum,
+    Video,
+)
 from studies.permissions import StudyPermission
 from studies.tasks import (
     MessageTarget,
@@ -860,6 +868,48 @@ class StudyModelTestCase(TestCase):
         assign_perm(StudyPermission.READ_STUDY_RESPONSE_DATA.codename, user, study)
 
         self.assertIn(response, study.responses_for_researcher(user))
+
+
+class DaysSubmittedTestCase(TestCase):
+    def setUp(self):
+        self.study = G(
+            Study,
+            study_type=StudyType.get_ember_frame_player(),
+            state="created",
+            status_change_date=None,
+        )
+
+    def test_non_submitted_state_returns_none(self):
+        self.study.state = "active"
+        self.assertIsNone(self.study.days_submitted)
+
+    def test_submitted_with_status_change_date(self):
+        ten_days_ago = datetime.now(timezone.utc) - timedelta(days=10)
+        self.study.state = "submitted"
+        self.study.status_change_date = ten_days_ago
+        self.study.save()
+        self.assertEqual(self.study.days_submitted, 10)
+
+    def test_submitted_null_status_change_date_falls_back_to_studylog(self):
+        five_days_ago = datetime.now(timezone.utc) - timedelta(days=5)
+        self.study.state = "submitted"
+        self.study.status_change_date = None
+        self.study.save()
+        log = StudyLog.objects.create(study=self.study, action="submitted")
+        StudyLog.objects.filter(pk=log.pk).update(created_at=five_days_ago)
+        self.assertEqual(self.study.days_submitted, 5)
+
+    def test_submitted_multiple_studylogs_uses_most_recent(self):
+        ten_days_ago = datetime.now(timezone.utc) - timedelta(days=10)
+        three_days_ago = datetime.now(timezone.utc) - timedelta(days=3)
+        self.study.state = "submitted"
+        self.study.status_change_date = None
+        self.study.save()
+        log_old = StudyLog.objects.create(study=self.study, action="submitted")
+        StudyLog.objects.filter(pk=log_old.pk).update(created_at=ten_days_ago)
+        log_recent = StudyLog.objects.create(study=self.study, action="submitted")
+        StudyLog.objects.filter(pk=log_recent.pk).update(created_at=three_days_ago)
+        self.assertEqual(self.study.days_submitted, 3)
 
 
 class VideoModelTestCase(TestCase):

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -264,6 +264,15 @@ def button_secondary_classes(extra_classes=None):
 
 
 @register.simple_tag
+def button_primary_light_classes(extra_classes=None):
+    classes = ["btn", "btn-light", "link-primary", "border-primary"]
+    if extra_classes:
+        classes.extend([extra_classes])
+
+    return " ".join(classes)
+
+
+@register.simple_tag
 def page_title(title, right_side_elements=None):
     if right_side_elements:
         html = f"""<div class="d-flex flex-row bd-highlight mb-4 align-items-center">


### PR DESCRIPTION
Fixes #1254, fixes #1862, fixes #1834, fixes #1718

This PR does the following:

- **Adds superuser-only search/filter options to the Manage Studies page**.  These will apply on top of the tab filters (all, my studies, submitted etc.) so you need to make sure that you're in the appropriate tab when using these  search/filter elements.
  - Study UUID
  - Lab name
  - Study type (all, Lookit, jsPsych, external)
  - Public (all, true, false)
  - Study creator name/email

- **Adds a submission history filter for Submitted studies**. These options are only displayed in the Submitted tab.
  - first submission
  - previously rejected (and never approved)
  - previously approved
  - other (should always be empty, but included in case of weird edge cases)

- **Fixes an issue with the study status change date**, where older studies would have an N/A value because this field was added to the database but never back-filled for existing studies. I think this will fix the problem with sorting not working on the status change date (#1862).

- **Displays the researcher's email address** in the list of researchers with study access on the study details page. This makes it easier to find the researcher(s) associated with a particular study.

- **Adds tests** for the study's submission date, the study's status change date, the Manage Studies view, and researcher permissions on the Manage Studies page.

Study details page, all users:

<img width="575" height="327" alt="Screenshot 2026-04-02 at 2 02 18 PM" src="https://github.com/user-attachments/assets/bff02daa-b571-4725-8691-9b4e2e85ce4e" />

Manage studies, superuser views:

<img width="1365" height="410" alt="Screenshot 2026-03-30 at 1 56 31 PM" src="https://github.com/user-attachments/assets/d6e37cc2-7476-4f5c-95f4-0b0d37e63fcf" />

<img width="1365" height="533" alt="Screenshot 2026-04-01 at 2 06 47 PM" src="https://github.com/user-attachments/assets/1a9ac89e-0891-4845-a501-b41922f16f69" />

<img width="1365" height="533" alt="Screenshot 2026-04-01 at 2 07 02 PM" src="https://github.com/user-attachments/assets/a6e15e40-1ee5-4994-88cb-1e41f8d70c50" />

Manage studies, researcher view:

<img width="1365" height="478" alt="Screenshot 2026-04-01 at 2 39 37 PM" src="https://github.com/user-attachments/assets/62a5fb32-050b-426a-8d1d-da9abc1eb19c" />

