### PR TITLE
Fix large data downloads

### DIFF
--- a/exp/tests/test_response_views.py
+++ b/exp/tests/test_response_views.py
@@ -3,6 +3,7 @@ import datetime
 import io
 import json
 import re
+import zipfile
 
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
@@ -1372,6 +1373,95 @@ class ResponseDataDownloadTestCase(TestCase):
 
         # Assumes n_previews fit on one page
         self.assertEqual(n_matches, self.n_previews)
+
+    def _get_psychds_zip(self, query_string=""):
+        url = reverse(
+            "exp:study-responses-download-frame-data-zip-psychds",
+            kwargs={"pk": self.study.pk},
+        )
+        response = self.client.get(f"{url}?{query_string}" if query_string else url)
+        zip_bytes = b"".join(response.streaming_content)
+        return response, zip_bytes
+
+    def test_psychds_download_returns_zip(self):
+        self.client.force_login(self.study_reader)
+        response, zip_bytes = self._get_psychds_zip()
+        self.assertEqual(response.status_code, 200)
+        self.assertRegex(
+            response.get("Content-Disposition"),
+            r'^attachment; filename=".*--psychds\.zip"',
+        )
+        # Verify content is a valid zip file
+        zipfile.ZipFile(io.BytesIO(zip_bytes))
+
+    def test_psychds_download_zip_structure(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+        self.assertIn("dataset_description.json", names)
+        self.assertIn("README.md", names)
+        self.assertIn(".psychds-ignore", names)
+        self.assertTrue(
+            any(n.startswith("data/framedata-per-response/") for n in names)
+        )
+        self.assertTrue(any(n.startswith("data/overview/") for n in names))
+        self.assertTrue(
+            any(n.startswith("data/raw/") and n.endswith(".json") for n in names)
+        )
+
+    def test_psychds_download_dataset_description_has_variables_measured(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            metadata = json.loads(zf.read("dataset_description.json"))
+        self.assertIn("variableMeasured", metadata)
+        self.assertIsInstance(metadata["variableMeasured"], list)
+        self.assertGreater(len(metadata["variableMeasured"]), 0)
+
+    def test_psychds_download_frame_data_file_per_response(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            framedata_csv_files = [
+                n
+                for n in zf.namelist()
+                if n.startswith("data/framedata-per-response/") and n.endswith(".csv")
+            ]
+        self.assertEqual(
+            len(framedata_csv_files),
+            self.n_responses + self.n_previews,
+            "Expected one frame data CSV file per consented response",
+        )
+
+    def test_psychds_download_all_responses_json_count(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            all_responses_json = [
+                n
+                for n in zf.namelist()
+                if n.startswith("data/raw/") and n.endswith(".json")
+            ]
+            self.assertEqual(len(all_responses_json), 1)
+            all_responses = json.loads(zf.read(all_responses_json[0]))
+        self.assertEqual(
+            len(all_responses),
+            self.n_responses + self.n_previews,
+            "Unexpected number of responses in all_responses JSON",
+        )
+
+    def test_psychds_download_excludes_unconsented_responses(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            for name in zf.namelist():
+                content = zf.read(name).decode("utf-8", errors="replace")
+                self.assertNotIn(
+                    self.poison_string,
+                    content,
+                    f"Data from unconsented response found in {name}",
+                )
 
 
 class ResponseViewResearcherUpdateFieldsTestCase(TestCase):

--- a/exp/tests/test_response_views.py
+++ b/exp/tests/test_response_views.py
@@ -400,6 +400,12 @@ class ResponseViewsTestCase(TestCase):
 
 
 class ResponseDataDownloadTestCase(TestCase):
+    def _decode_response(self, response):
+        """Read content from either a streaming or regular response."""
+        if hasattr(response, "streaming_content"):
+            return b"".join(response.streaming_content).decode("utf-8")
+        return response.content.decode("utf-8")
+
     def setUp(self):
         self.client = Force2FAClient()
 
@@ -689,7 +695,7 @@ class ResponseDataDownloadTestCase(TestCase):
         self.client.force_login(self.study_reader)
         query_string = urlencode({"data_options": self.optionset_1}, doseq=True)
         response = self.client.get(f"{self.response_summary_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -800,7 +806,7 @@ class ResponseDataDownloadTestCase(TestCase):
         self.client.force_login(self.study_reader)
         query_string = urlencode({"data_options": self.optionset_2}, doseq=True)
         response = self.client.get(f"{self.response_summary_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -933,7 +939,7 @@ class ResponseDataDownloadTestCase(TestCase):
         ]
 
         csv_response = self.client.get(self.response_summary_url)
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1107,7 +1113,7 @@ class ResponseDataDownloadTestCase(TestCase):
         self.client.force_login(self.study_reader)
         query_string = urlencode({"data_options": self.optionset_1}, doseq=True)
         response = self.client.get(f"{self.response_summary_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1138,7 +1144,7 @@ class ResponseDataDownloadTestCase(TestCase):
                 "exp:study-responses-children-summary-csv", kwargs={"pk": self.study.pk}
             )
         )
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_body.pop(0)
@@ -1161,7 +1167,7 @@ class ResponseDataDownloadTestCase(TestCase):
                 "exp:study-responses-children-summary-csv", kwargs={"pk": self.study.pk}
             )
         )
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_body.pop(0)
@@ -1178,7 +1184,7 @@ class ResponseDataDownloadTestCase(TestCase):
         response = self.client.get(
             reverse("exp:study-demographics", kwargs={"pk": self.study.pk})
         )
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         self.assertIn(
             f"{self.n_previews + self.n_responses} snapshot",
             content,
@@ -1191,7 +1197,7 @@ class ResponseDataDownloadTestCase(TestCase):
         response = self.client.get(
             reverse("exp:study-demographics", kwargs={"pk": self.study.pk})
         )
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         self.assertIn(
             f"{self.n_previews} snapshot",
             content,
@@ -1208,7 +1214,7 @@ class ResponseDataDownloadTestCase(TestCase):
         csv_response = self.client.get(
             reverse("exp:study-demographics-download-csv", kwargs={"pk": self.study.pk})
         )
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1235,7 +1241,7 @@ class ResponseDataDownloadTestCase(TestCase):
         csv_response = self.client.get(
             reverse("exp:study-demographics-download-csv", kwargs={"pk": self.study.pk})
         )
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1268,7 +1274,7 @@ class ResponseDataDownloadTestCase(TestCase):
             {"demo_options": ["participant__global_id"]}, doseq=True
         )
         csv_response = self.client.get(f"{demographic_csv_url}?{query_string}")
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1278,7 +1284,7 @@ class ResponseDataDownloadTestCase(TestCase):
         # Without participant__global_id selected, should not be in header and data should not be included
         query_string = urlencode({"demo_options": []}, doseq=True)
         csv_response = self.client.get(f"{demographic_csv_url}?{query_string}")
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1296,7 +1302,7 @@ class ResponseDataDownloadTestCase(TestCase):
             {"demo_options": ["participant__global_id"]}, doseq=True
         )
         response = self.client.get(f"{demographic_json_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         data = json.loads(content)
         for demo in data:
             self.assertIn("global_id", demo["participant"])
@@ -1310,7 +1316,7 @@ class ResponseDataDownloadTestCase(TestCase):
         # Without participant__global_id selected, this info is absent
         query_string = urlencode({"demo_options": []}, doseq=True)
         response = self.client.get(f"{demographic_json_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         data = json.loads(content)
         for demo in data:
             self.assertNotIn("global_id", demo["participant"])
@@ -1328,7 +1334,7 @@ class ResponseDataDownloadTestCase(TestCase):
         response = self.client.get(
             f"{reverse('exp:study-responses-list', kwargs={'pk': self.study.pk})}"
         )
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         matches = re.finditer('data-response-uuid="(.*)"', content)
         for m in matches:
             n_matches += 1
@@ -1359,7 +1365,7 @@ class ResponseDataDownloadTestCase(TestCase):
         response = self.client.get(
             reverse("exp:study-responses-list", kwargs={"pk": self.study.pk})
         )
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
 
         matches = re.finditer('data-response-uuid="(.*)"', content)
         n_matches = 0

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -370,29 +370,30 @@ def make_chunk(paginator, page_num, header_options):
     return chunk
 
 
-"""Takes session_data dict list and converts it to csv formatted string
+"""Writes session data to a temp CSV file and returns the path.
 
     Args:
-        session_list(list of strings): list of strings representing rows of the csv
-        header_list(list of strings): list of headers to include at top of csv string
+        session_list(list of dicts): list of dicts representing rows of the csv
+        header_list(list of strings): list of headers to include at top of csv
 
     Returns:
-        (string): csv-formattted string for response data file.
+        (string): path to the temp file (caller is responsible for deletion)
     """
 
 
-def build_overview_str(session_list, header_list):
-    session_strings = [
-        ",".join(
-            [
-                (f'"{str(session_row[key])}"' if key in session_row else "")
+def write_overview_to_temp_file(session_list, header_list):
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".csv", mode="w")
+    tmp.write(",".join(header_list))
+    for session_row in session_list:
+        tmp.write(
+            "\n"
+            + ",".join(
+                f'"{str(session_row[key])}"' if key in session_row else ""
                 for key in header_list
-            ]
+            )
         )
-        for session_row in session_list
-    ]
-    header_str = ",".join(header_list)
-    return "\n".join([header_str] + session_strings)
+    tmp.close()
+    return tmp.name
 
 
 """Aggregates child data over responses and returns list of dictionaries for each row of csv
@@ -438,8 +439,8 @@ def get_child_overview_csv(paginator, study, header_options):
         header_options(list of strings): list of selected headers from header_options
         study_uuid(string): uuid for study object, either truncated or untruncated
         truncate_uuids(boolean): Represents whether user has selected to truncate their uuids in filenames
-        overview_str(string): string representing response overview file
-        child_overview_str(string): string representing child overview file
+        overview_path(string): path to temp file containing response overview CSV
+        child_overview_path(string): path to temp file containing child overview CSV
         metadata_json(dict): JSON object for global metadata file (variableMeasured will be added)
         all_response_filename(string): filename for response overview file
         all_response_json_path(string): path to temp file containing all-responses JSON
@@ -457,8 +458,8 @@ def build_zip_for_psychds(
     header_options,
     study_uuid,
     truncate_uuids,
-    overview_str,
-    child_overview_str,
+    overview_path,
+    child_overview_path,
     metadata_json,
     all_response_filename,
     all_response_json_path,
@@ -501,14 +502,14 @@ def build_zip_for_psychds(
             all_children += "_identifiable-true"
 
         # save response overview
-        zipped.writestr(
+        zipped.write(
+            overview_path,
             f"data/overview/study-{study_uuid}_{all_responses}_data.csv",
-            overview_str,
         )
         # save children overview
-        zipped.writestr(
+        zipped.write(
+            child_overview_path,
             f"data/overview/study-{study_uuid}_{all_children}_data.csv",
-            child_overview_str,
         )
         if not study.use_generator:
             # save study protocol
@@ -1579,12 +1580,14 @@ class StudyResponsesFrameDataPsychDS(ResponseDownloadMixin, generic.list.ListVie
         session_list, header_options, header_list = get_study_responses_csv(
             self, paginator, study
         )
-        overview_str = build_overview_str(session_list, header_list)
+        tmp_overview = write_overview_to_temp_file(session_list, header_list)
         # gets data necessary for building child overview file
         child_session_list, child_header_list = get_child_overview_csv(
             paginator, study, header_options
         )
-        child_overview_str = build_overview_str(child_session_list, child_header_list)
+        tmp_child_overview = write_overview_to_temp_file(
+            child_session_list, child_header_list
+        )
         # builds "all response" json download
         all_response_filename = "all_responses{}.json".format(
             ("_identifiable" if IDENTIFIABLE_DATA_HEADERS & header_options else ""),
@@ -1602,8 +1605,8 @@ class StudyResponsesFrameDataPsychDS(ResponseDownloadMixin, generic.list.ListVie
                 header_options,
                 study_uuid,
                 truncate_uuids,
-                overview_str,
-                child_overview_str,
+                tmp_overview,
+                tmp_child_overview,
                 metadata_json,
                 all_response_filename,
                 all_response_json_path=tmp_all_response.name,
@@ -1612,6 +1615,8 @@ class StudyResponsesFrameDataPsychDS(ResponseDownloadMixin, generic.list.ListVie
             )
         finally:
             os.unlink(tmp_all_response.name)
+            os.unlink(tmp_overview)
+            os.unlink(tmp_child_overview)
 
         return response
 

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1,5 +1,4 @@
 import datetime
-import io
 import json
 import logging
 import os
@@ -1637,7 +1636,7 @@ class StudyResponsesFrameDataCSV(ResponseDownloadMixin, generic.list.ListView):
 
             return study_responses_all(study)
 
-        zipped_file = io.BytesIO()
+        zipped_file = tempfile.NamedTemporaryFile(suffix=".zip")
         with zipfile.ZipFile(zipped_file, "w", zipfile.ZIP_DEFLATED) as zipped:
             for page_num in paginator.page_range:
                 page_of_responses = paginator.page(page_num)

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1,4 +1,6 @@
+import csv
 import datetime
+import io
 import json
 import logging
 import os
@@ -1449,18 +1451,29 @@ class StudyResponsesCSV(ResponseDownloadMixin, generic.list.ListView):
         session_list, header_options, header_list = get_study_responses_csv(
             self, paginator, study
         )
-        output, writer = csv_dict_output_and_writer(header_list)
+        tmp = tempfile.NamedTemporaryFile(suffix=".csv")
+        text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
+        writer = csv.DictWriter(
+            text_wrapper,
+            quoting=csv.QUOTE_NONNUMERIC,
+            fieldnames=header_list,
+            restval="",
+            extrasaction="ignore",
+        )
+        writer.writeheader()
         writer.writerows(session_list)
-        cleaned_data = output.getvalue()
+        text_wrapper.flush()
+        text_wrapper.detach()
+        tmp.seek(0)
 
         all_responses = "all-responses"
         if IDENTIFIABLE_DATA_HEADERS & header_options:
             all_responses += "-identifiable"
 
         filename = csv_filename(study, all_responses)
-        response = HttpResponse(cleaned_data, content_type=CONTENT_TYPE)
-        set_content_disposition(response, filename)
-        return response
+        return FileResponse(
+            tmp, as_attachment=True, filename=filename, content_type=CONTENT_TYPE
+        )
 
 
 class StudyResponsesDictCSV(CanViewStudyResponsesMixin, View):

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -469,17 +469,17 @@ def build_zip_for_psychds(
     zipped_file = tempfile.NamedTemporaryFile(suffix=".zip")
     with zipfile.ZipFile(zipped_file, "w", zipfile.ZIP_DEFLATED) as zipped:
         # write frame data for each response directly into the zip, one at a time
-        variables_measured = []
+        variables_measured = set()
         for page_num in paginator.page_range:
             page_of_responses = paginator.page(page_num)
             for resp in page_of_responses:
                 response_uuid = resp.uuid.hex[:8] if truncate_uuids else resp.uuid.hex
                 data = build_single_response_framedata_csv(resp)
                 # collect column headers for variableMeasured metadata
-                variables_measured += [
+                variables_measured |= {
                     column.strip('"')
                     for column in data.split("\n")[0].strip().split(",")
-                ]
+                }
                 keywords = {"study": study_uuid, "response": response_uuid}
                 filename = keyword_filename(keywords, "csv")
                 sidecar_metadata = {
@@ -573,14 +573,14 @@ def build_zip_for_psychds(
             "materials/study_ad_info.json", f"{json.dumps(study_ad, indent=4)}"
         )
         # build variableMeasured from frame data headers + overview headers, then finalise metadata
-        variables_measured += header_list + CHILD_CSV_HEADERS
+        variables_measured |= set(header_list + CHILD_CSV_HEADERS)
         variables_measured_objects = [
             {
                 "@type": "PropertyValue",
                 "name": column,
                 "description": descriptions[column.split(".")[0]],
             }
-            for column in list(set(variables_measured))
+            for column in variables_measured
         ]
         metadata_json["variableMeasured"] = variables_measured_objects
         # save global metadata file

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1785,21 +1785,30 @@ class StudyDemographicsCSV(DemographicDownloadMixin, generic.list.ListView):
         paginator = context["paginator"]
         header_options = set(self.request.GET.getlist("demo_options"))
 
-        participant_list = []
         headers_for_download = get_demographic_headers(header_options)
+        tmp = tempfile.NamedTemporaryFile(suffix=".csv")
+        text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
+        writer = csv.DictWriter(
+            text_wrapper,
+            quoting=csv.QUOTE_NONNUMERIC,
+            fieldnames=headers_for_download,
+            restval="",
+            extrasaction="ignore",
+        )
+        writer.writeheader()
         for page_num in paginator.page_range:
-            page_of_responses = paginator.page(page_num)
-            for resp in page_of_responses:
-                row_data = {col.id: col.extractor(resp) for col in DEMOGRAPHIC_COLUMNS}
-                participant_list.append(row_data)
-        output, writer = csv_dict_output_and_writer(headers_for_download)
-        writer.writerows(participant_list)
-        cleaned_data = output.getvalue()
+            for resp in paginator.page(page_num):
+                writer.writerow(
+                    {col.id: col.extractor(resp) for col in DEMOGRAPHIC_COLUMNS}
+                )
+        text_wrapper.flush()
+        text_wrapper.detach()
+        tmp.seek(0)
 
         filename = csv_filename(study, "all-demographic-snapshots")
-        response = HttpResponse(cleaned_data, content_type=CONTENT_TYPE)
-        set_content_disposition(response, filename)
-        return response
+        return FileResponse(
+            tmp, as_attachment=True, filename=filename, content_type=CONTENT_TYPE
+        )
 
 
 class StudyDemographicsDictCSV(DemographicDownloadMixin, generic.list.ListView):

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -505,7 +505,7 @@ def build_zip_for_psychds(
     all_response_filename,
     all_response_json_path,
 ):
-    zipped_file = io.BytesIO()
+    zipped_file = tempfile.NamedTemporaryFile(suffix=".zip")
     with zipfile.ZipFile(zipped_file, "w", zipfile.ZIP_DEFLATED) as zipped:
         for data, filename, sidecar_metadata, sidecar_filename in response_data:
             # write data file for response

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -430,64 +430,21 @@ def get_child_overview_csv(paginator, study, header_options):
     return session_list, header_list
 
 
-"""Grab all relevant frame data for framedata responses for psychds download
+"""Writes psych-ds formatted zip file based on all response data aggregated
 
     Args:
         paginator(Paginator): Serialized set of entries from the studies_responses table
         study(Study): Query object for the given study
-        truncate_uuids(boolean): Represents whether user has selected to truncate their uuids in filenames
-
-    Returns:
-        response_data(list of lists): contains necessary objects for building and writing files related to frame data for each response
-        variables_measured(list of strings): global record of which columns appeared in various response files
-    """
-
-
-# Helper function to grab all relevant data for framedata responses for psychds download
-def get_framedata_for_psychds(paginator, study, truncate_uuids):
-    study_uuid = study.uuid.hex[:8] if truncate_uuids else study.uuid.hex
-    response_data = []
-    variables_measured = []
-    for page_num in paginator.page_range:
-        page_of_responses = paginator.page(page_num)
-        for resp in page_of_responses:
-            response_uuid = resp.uuid.hex[:8] if truncate_uuids else study.uuid.hex
-            # get framedata for response
-            data = build_single_response_framedata_csv(resp)
-            # get column headers from first row
-            variables_measured += [
-                column.strip('"') for column in data.split("\n")[0].strip().split(",")
-            ]
-            # psych-DS files use "keyword" formatting
-            keywords = {"study": study_uuid, "response": response_uuid}
-            filename = keyword_filename(keywords, "csv")
-            # make a response-specific metadata file
-            sidecar_metadata = {
-                "response_uuid": resp.uuid.hex,
-                "eligibility": resp.eligibility,
-                "study_completed": resp.completed,
-            }
-            sidecar_filename = keyword_filename(keywords, "json")
-            response_data.append([data, filename, sidecar_metadata, sidecar_filename])
-    return response_data, variables_measured
-
-
-"""Writes psych-ds formatted zip file based on all response data aggregated
-
-    Args:
-        response_data(list of lists): list of the following objects for each response object:
-            data(string): framedata-per-response csv string
-            filename(string): formatted name for csv file
-            sidecar_metadata(dict): JSON object for sidecar metadata file
-            sidecar_filename(string): formatted name for sidecar file
-        study(Study): Query object for the given study
         header_options(list of strings): list of selected headers from header_options
         study_uuid(string): uuid for study object, either truncated or untruncated
-        overview_str(string): string representing reponse overview file 
+        truncate_uuids(boolean): Represents whether user has selected to truncate their uuids in filenames
+        overview_str(string): string representing response overview file
         child_overview_str(string): string representing child overview file
-        metadata_json(dict): JSON object for global metadata file
+        metadata_json(dict): JSON object for global metadata file (variableMeasured will be added)
         all_response_filename(string): filename for response overview file
-        all_response_json_str(string): string representing json for all response overview file
+        all_response_json_path(string): path to temp file containing all-responses JSON
+        descriptions(dict): mapping of column ids to column descriptions
+        header_list(list of strings): list of response overview column headers
 
     Returns:
         response(FileResponse): Formatted response object with constructed zipfile
@@ -495,26 +452,46 @@ def get_framedata_for_psychds(paginator, study, truncate_uuids):
 
 
 def build_zip_for_psychds(
-    response_data,
+    paginator,
     study,
     header_options,
     study_uuid,
+    truncate_uuids,
     overview_str,
     child_overview_str,
     metadata_json,
     all_response_filename,
     all_response_json_path,
+    descriptions,
+    header_list,
 ):
     zipped_file = tempfile.NamedTemporaryFile(suffix=".zip")
     with zipfile.ZipFile(zipped_file, "w", zipfile.ZIP_DEFLATED) as zipped:
-        for data, filename, sidecar_metadata, sidecar_filename in response_data:
-            # write data file for response
-            zipped.writestr(f"data/framedata-per-response/{filename}", data)
-            # write metadata sidecar for response
-            zipped.writestr(
-                f"data/framedata-per-response/{sidecar_filename}",
-                json.dumps(sidecar_metadata, indent=4),
-            )
+        # write frame data for each response directly into the zip, one at a time
+        variables_measured = []
+        for page_num in paginator.page_range:
+            page_of_responses = paginator.page(page_num)
+            for resp in page_of_responses:
+                response_uuid = resp.uuid.hex[:8] if truncate_uuids else resp.uuid.hex
+                data = build_single_response_framedata_csv(resp)
+                # collect column headers for variableMeasured metadata
+                variables_measured += [
+                    column.strip('"')
+                    for column in data.split("\n")[0].strip().split(",")
+                ]
+                keywords = {"study": study_uuid, "response": response_uuid}
+                filename = keyword_filename(keywords, "csv")
+                sidecar_metadata = {
+                    "response_uuid": resp.uuid.hex,
+                    "eligibility": resp.eligibility,
+                    "study_completed": resp.completed,
+                }
+                sidecar_filename = keyword_filename(keywords, "json")
+                zipped.writestr(f"data/framedata-per-response/{filename}", data)
+                zipped.writestr(
+                    f"data/framedata-per-response/{sidecar_filename}",
+                    json.dumps(sidecar_metadata, indent=4),
+                )
 
         # mark response overview with identifiable keyword if identifiable columns were selected
         all_responses = "all-responses"
@@ -594,6 +571,17 @@ def build_zip_for_psychds(
         zipped.writestr(
             "materials/study_ad_info.json", f"{json.dumps(study_ad, indent=4)}"
         )
+        # build variableMeasured from frame data headers + overview headers, then finalise metadata
+        variables_measured += header_list + CHILD_CSV_HEADERS
+        variables_measured_objects = [
+            {
+                "@type": "PropertyValue",
+                "name": column,
+                "description": descriptions[column.split(".")[0]],
+            }
+            for column in list(set(variables_measured))
+        ]
+        metadata_json["variableMeasured"] = variables_measured_objects
         # save global metadata file
         zipped.writestr(
             "dataset_description.json", f"{json.dumps(metadata_json, indent=4)}"
@@ -1597,11 +1585,6 @@ class StudyResponsesFrameDataPsychDS(ResponseDownloadMixin, generic.list.ListVie
             paginator, study, header_options
         )
         child_overview_str = build_overview_str(child_session_list, child_header_list)
-        # gets data necessary for building psychds framedata files
-        response_data, variables_measured = get_framedata_for_psychds(
-            paginator, study, truncate_uuids
-        )
-        variables_measured += header_list + CHILD_CSV_HEADERS
         # builds "all response" json download
         all_response_filename = "all_responses{}.json".format(
             ("_identifiable" if IDENTIFIABLE_DATA_HEADERS & header_options else ""),
@@ -1613,28 +1596,19 @@ class StudyResponsesFrameDataPsychDS(ResponseDownloadMixin, generic.list.ListVie
                 for page_num in paginator.page_range:
                     f.write(make_chunk(paginator, page_num, header_options))
 
-            # construct more informative variablesMeasured object
-            variables_measured_objects = [
-                {
-                    "@type": "PropertyValue",
-                    "name": column,
-                    "description": descriptions[column.split(".")[0]],
-                }
-                for column in list(set(variables_measured))
-            ]
-            # add final variables list to metadata
-            metadata_json["variableMeasured"] = variables_measured_objects
-
             response = build_zip_for_psychds(
-                response_data,
+                paginator,
                 study,
                 header_options,
                 study_uuid,
+                truncate_uuids,
                 overview_str,
                 child_overview_str,
                 metadata_json,
                 all_response_filename,
                 all_response_json_path=tmp_all_response.name,
+                descriptions=descriptions,
+                header_list=header_list,
             )
         finally:
             os.unlink(tmp_all_response.name)

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1524,17 +1524,28 @@ class StudyChildrenCSV(ResponseDownloadMixin, generic.list.ListView):
             paginator, study, header_options
         )
 
-        output, writer = csv_dict_output_and_writer(header_list)
+        tmp = tempfile.NamedTemporaryFile(suffix=".csv")
+        text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
+        writer = csv.DictWriter(
+            text_wrapper,
+            quoting=csv.QUOTE_NONNUMERIC,
+            fieldnames=header_list,
+            restval="",
+            extrasaction="ignore",
+        )
+        writer.writeheader()
         writer.writerows(session_list)
-        cleaned_data = output.getvalue()
+        text_wrapper.flush()
+        text_wrapper.detach()
+        tmp.seek(0)
 
         filename = "all-children{}".format(
             ("-identifiable" if IDENTIFIABLE_DATA_HEADERS & header_options else ""),
         )
         filename = csv_filename(study, filename)
-        response = HttpResponse(cleaned_data, content_type=CONTENT_TYPE)
-        set_content_disposition(response, filename)
-        return response
+        return FileResponse(
+            tmp, as_attachment=True, filename=filename, content_type=CONTENT_TYPE
+        )
 
 
 class StudyChildrenDictCSV(CanViewStudyResponsesMixin, View):

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1745,13 +1745,16 @@ class StudyDemographicsJSON(DemographicDownloadMixin, generic.list.ListView):
         study = self.study
         header_options = self.request.GET.getlist("demo_options")
 
-        json_responses = []
         paginator = context["paginator"]
-        for page_num in paginator.page_range:
-            page_of_responses = paginator.page(page_num)
-            for resp in page_of_responses:
-                json_responses.append(
-                    json.dumps(
+
+        def json_generator():
+            yield "[\n"
+            first = True
+            for page_num in paginator.page_range:
+                for resp in paginator.page(page_num):
+                    if not first:
+                        yield ",\n"
+                    yield json.dumps(
                         construct_response_dictionary(
                             resp,
                             DEMOGRAPHIC_COLUMNS,
@@ -1761,12 +1764,13 @@ class StudyDemographicsJSON(DemographicDownloadMixin, generic.list.ListView):
                         indent="\t",
                         default=str,
                     )
-                )
-        cleaned_data = f"[ {', '.join(json_responses)} ]"
+                    first = False
+            yield "\n]"
+
         filename = "{}_{}.json".format(
             study_name_for_files(study.name), "all-demographic-snapshots"
         )
-        response = HttpResponse(cleaned_data, content_type="text/json")
+        response = StreamingHttpResponse(json_generator(), content_type="text/json")
         set_content_disposition(response, filename)
         return response
 

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -2,6 +2,8 @@ import datetime
 import io
 import json
 import logging
+import os
+import tempfile
 import zipfile
 from functools import cached_property
 from typing import Dict, KeysView, List, NamedTuple, Set, Text, Union
@@ -501,7 +503,7 @@ def build_zip_for_psychds(
     child_overview_str,
     metadata_json,
     all_response_filename,
-    all_response_json_str,
+    all_response_json_path,
 ):
     zipped_file = io.BytesIO()
     with zipfile.ZipFile(zipped_file, "w", zipfile.ZIP_DEFLATED) as zipped:
@@ -564,10 +566,7 @@ def build_zip_for_psychds(
             VIDEOS_README_STR,
         )
         # save all responses json
-        zipped.writestr(
-            f"data/raw/{all_response_filename}",
-            all_response_json_str,
-        )
+        zipped.write(all_response_json_path, f"data/raw/{all_response_filename}")
         # save psychds-ignore file to avoid NOT_INCLUDED warnings
         zipped.writestr(
             ".psychds-ignore",
@@ -1607,35 +1606,38 @@ class StudyResponsesFrameDataPsychDS(ResponseDownloadMixin, generic.list.ListVie
         all_response_filename = "all_responses{}.json".format(
             ("_identifiable" if IDENTIFIABLE_DATA_HEADERS & header_options else ""),
         )
-        all_response_json_str = "".join(
-            [
-                make_chunk(paginator, page_num, header_options)
-                for page_num in paginator.page_range
-            ]
-        )
-        # construct more informative variablesMeasured object
-        variables_measured_objects = [
-            {
-                "@type": "PropertyValue",
-                "name": column,
-                "description": descriptions[column.split(".")[0]],
-            }
-            for column in list(set(variables_measured))
-        ]
-        # add final variables list to metadata
-        metadata_json["variableMeasured"] = variables_measured_objects
+        tmp_all_response = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
 
-        response = build_zip_for_psychds(
-            response_data,
-            study,
-            header_options,
-            study_uuid,
-            overview_str,
-            child_overview_str,
-            metadata_json,
-            all_response_filename,
-            all_response_json_str,
-        )
+        try:
+            with open(tmp_all_response.name, "w") as f:
+                for page_num in paginator.page_range:
+                    f.write(make_chunk(paginator, page_num, header_options))
+
+            # construct more informative variablesMeasured object
+            variables_measured_objects = [
+                {
+                    "@type": "PropertyValue",
+                    "name": column,
+                    "description": descriptions[column.split(".")[0]],
+                }
+                for column in list(set(variables_measured))
+            ]
+            # add final variables list to metadata
+            metadata_json["variableMeasured"] = variables_measured_objects
+
+            response = build_zip_for_psychds(
+                response_data,
+                study,
+                header_options,
+                study_uuid,
+                overview_str,
+                child_overview_str,
+                metadata_json,
+                all_response_filename,
+                all_response_json_path=tmp_all_response.name,
+            )
+        finally:
+            os.unlink(tmp_all_response.name)
 
         return response
 


### PR DESCRIPTION
Fixes #1599

We've had a number of problems with data downloads timing out recently. This PR attempts to fix those issues by streaming to/from temp files, rather than concatenating very large strings that are fully stored in memory. 

The temp files created with `tempfile.NamedTemporaryFile` will be deleted automatically. There a few places that use the `delete=False` argument because the data needs to be read back in later - these are cleaned up via a `try`/`finally` block, but we may need to check periodically to make sure that they do not persist if/when a download request fails.

Also, these changes reduce the peak memory usage, but there might still be issues with the response taking too long and hitting the response timeout. So if the problems continue, then we may need to turn some of the large/slow downloads into async tasks.

This PR also adds tests for the PsychDS zip file contents.