### PR TITLE
Production release

### DIFF
--- a/accounts/management/commands/get_user_data.py
+++ b/accounts/management/commands/get_user_data.py
@@ -1,0 +1,130 @@
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+# This query generates the following:
+# User
+#  ├ Child
+#  │  └ Response
+#  │      ├ Feedback
+#  │      ├ Video
+#  │      └ ConsentRuling
+#  │  └ MessageChildrenOfInterest
+#  │      └ Message
+#  ├ MessageRecipients
+#  │   └ Message
+#  └ DemographicData
+
+SQL_QUERY = """
+WITH target_user AS (
+    SELECT * FROM accounts_user WHERE id = %(user_id)s
+),
+
+children AS (
+    SELECT * FROM accounts_child WHERE user_id = %(user_id)s
+),
+
+responses AS (
+    SELECT * FROM studies_response
+    WHERE child_id IN (SELECT id FROM children)
+),
+
+feedback AS (
+    SELECT * FROM studies_feedback
+    WHERE response_id IN (SELECT id FROM responses)
+),
+
+videos AS (
+    SELECT * FROM studies_video
+    WHERE response_id IN (SELECT id FROM responses)
+),
+
+consent_rulings AS (
+    SELECT * FROM studies_consentruling
+    WHERE response_id IN (SELECT id FROM responses)
+),
+
+demographics AS (
+    SELECT * FROM accounts_demographicdata
+    WHERE user_id = %(user_id)s
+),
+
+messages_to_user AS (
+    SELECT m.*
+    FROM accounts_message m
+    JOIN accounts_message_recipients r
+      ON m.id = r.message_id
+    WHERE r.user_id = %(user_id)s
+),
+
+messages_about_children AS (
+    SELECT m.*
+    FROM accounts_message m
+    JOIN accounts_message_children_of_interest c
+      ON m.id = c.message_id
+    WHERE c.child_id IN (SELECT id FROM children)
+),
+
+messages AS (
+    SELECT * FROM messages_to_user
+    UNION
+    SELECT * FROM messages_about_children
+)
+
+SELECT json_build_object(
+    'User', (SELECT json_agg(t) FROM target_user t),
+    'Child', (SELECT json_agg(c) FROM children c),
+    'DemographicData', (SELECT json_agg(d) FROM demographics d),
+    'Response', (SELECT json_agg(r) FROM responses r),
+    'Feedback', (SELECT json_agg(f) FROM feedback f),
+    'Video', (SELECT json_agg(v) FROM videos v),
+    'ConsentRuling', (SELECT json_agg(c) FROM consent_rulings c),
+    'Message', (SELECT json_agg(m) FROM messages m)
+);
+"""
+
+
+class Command(BaseCommand):
+    help = "Export objects related to a User and their Children"
+
+    def add_arguments(self, parser):
+        parser.add_argument("user_id", type=int)
+        parser.add_argument(
+            "--summary",
+            action="store_true",
+            help="Print counts of related objects instead of full export",
+        )
+        parser.add_argument(
+            "--output",
+            type=str,
+            help="Write export JSON to a file",
+        )
+
+    def handle(self, *args, **options):
+        user_id = options["user_id"]
+        summary = options["summary"]
+        output_file = options.get("output")
+
+        with connection.cursor() as cursor:
+            cursor.execute(SQL_QUERY, {"user_id": user_id})
+            result = cursor.fetchone()[0]
+
+        # normalize nulls
+        result = {k: (v or []) for k, v in result.items()}
+
+        if summary:
+            self.stdout.write("\nObject counts:\n")
+            for table, rows in result.items():
+                self.stdout.write(f"{table}: {len(rows)}")
+            return
+
+        json_output = json.dumps(result, indent=2, default=str)
+
+        if output_file:
+            path = Path(output_file)
+            path.write_text(json_output)
+            self.stdout.write(f"\nExport written to {path.resolve()}")
+        else:
+            print(json_output)

--- a/exp/templatetags/exp_extras.py
+++ b/exp/templatetags/exp_extras.py
@@ -70,3 +70,9 @@ def get_bit_label(bit_handler, bit_number):
 @register.filter
 def pretty_json(value):
     return json.dumps(value, indent=4, default=str)
+
+
+@register.filter
+def before_paren(value):
+    """Return the portion of a string before the first '(', stripped of whitespace."""
+    return value.partition("(")[0].strip()

--- a/exp/tests/test_response_postsave.py
+++ b/exp/tests/test_response_postsave.py
@@ -165,6 +165,42 @@ class ResponseSaveHandlingTestCase(TestCase):
         self.withdrawn_response_after_exit_frame.save()  # to run post-save hook
         self.assertEqual(len(self.withdrawn_response_after_exit_frame.videos.all()), 0)
 
+    def test_exit_frame_properties_with_non_dict_value_does_not_raise(self):
+        """Accessing exit-frame-derived response properties (withdrawn, privacy, databrary)
+        should not raise when exp_data contains non-dict values."""
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study,
+            completed=False,
+            completed_consent_frame=True,
+            sequence=["0-video-config", "1-exit-frame"],
+            exp_data={
+                "0-video-config": {"frameType": "DEFAULT"},
+                "1-exit-frame": "unexpected string",
+            },
+        )
+        _ = response.withdrawn
+        _ = response.privacy
+        _ = response.databrary
+
+    def test_non_dict_exp_data_value_does_not_raise(self):
+        """Saving an EFP response where the current frame's exp_data value is not a dict
+        should not raise an error."""
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study,
+            completed=False,
+            completed_consent_frame=True,
+            sequence=["0-video-config", "1-non-dict-frame"],
+            exp_data={
+                "0-video-config": {"frameType": "DEFAULT"},
+                "1-non-dict-frame": "unexpected string",
+            },
+        )
+        response.save()
+
     def test_responses_per_study_type(self):
         user = G(User)
         researcher = G(User, is_active=True, is_researcher=True, username="Researcher")
@@ -263,3 +299,28 @@ class JspsychResponseSaveHandlingTestCase(TestCase):
         self.assertFalse(self.response.videos.first().is_consent_footage)
         self.response.save()
         self.assertTrue(self.response.videos.first().is_consent_footage)
+
+    def test_non_dict_element_does_not_raise(self):
+        """Saving a jsPsych response where an exp_data element is not a dict
+        should not raise an error."""
+        self.response.exp_data = [{"chs_type": "consent", "response": {}}, "not-a-dict"]
+        self.response.sequence = ["0-consent", "1-bad"]
+        self.response.save()
+
+    def test_non_dict_only_element_does_not_raise(self):
+        """Saving a jsPsych response where the sole exp_data element is not a dict
+        should not raise an error."""
+        self.response.exp_data = ["not-a-dict"]
+        self.response.sequence = ["0-bad"]
+        self.response.save()
+
+    def test_exit_frame_properties_with_non_dict_element_does_not_raise(self):
+        """Accessing exit-frame-derived response properties (withdrawn, privacy, databrary)
+        should not raise when exp_data contains non-dict elements."""
+        self.response.exp_data = [
+            {"chs_type": "exit", "response": {"withdrawal": True}},
+            "not-a-dict",
+        ]
+        _ = self.response.withdrawn
+        _ = self.response.privacy
+        _ = self.response.databrary

--- a/exp/tests/test_response_views.py
+++ b/exp/tests/test_response_views.py
@@ -3,6 +3,7 @@ import datetime
 import io
 import json
 import re
+import zipfile
 
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
@@ -399,6 +400,12 @@ class ResponseViewsTestCase(TestCase):
 
 
 class ResponseDataDownloadTestCase(TestCase):
+    def _decode_response(self, response):
+        """Read content from either a streaming or regular response."""
+        if hasattr(response, "streaming_content"):
+            return b"".join(response.streaming_content).decode("utf-8")
+        return response.content.decode("utf-8")
+
     def setUp(self):
         self.client = Force2FAClient()
 
@@ -688,7 +695,7 @@ class ResponseDataDownloadTestCase(TestCase):
         self.client.force_login(self.study_reader)
         query_string = urlencode({"data_options": self.optionset_1}, doseq=True)
         response = self.client.get(f"{self.response_summary_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -799,7 +806,7 @@ class ResponseDataDownloadTestCase(TestCase):
         self.client.force_login(self.study_reader)
         query_string = urlencode({"data_options": self.optionset_2}, doseq=True)
         response = self.client.get(f"{self.response_summary_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -932,7 +939,7 @@ class ResponseDataDownloadTestCase(TestCase):
         ]
 
         csv_response = self.client.get(self.response_summary_url)
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1106,7 +1113,7 @@ class ResponseDataDownloadTestCase(TestCase):
         self.client.force_login(self.study_reader)
         query_string = urlencode({"data_options": self.optionset_1}, doseq=True)
         response = self.client.get(f"{self.response_summary_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1137,7 +1144,7 @@ class ResponseDataDownloadTestCase(TestCase):
                 "exp:study-responses-children-summary-csv", kwargs={"pk": self.study.pk}
             )
         )
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_body.pop(0)
@@ -1160,7 +1167,7 @@ class ResponseDataDownloadTestCase(TestCase):
                 "exp:study-responses-children-summary-csv", kwargs={"pk": self.study.pk}
             )
         )
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_body.pop(0)
@@ -1177,7 +1184,7 @@ class ResponseDataDownloadTestCase(TestCase):
         response = self.client.get(
             reverse("exp:study-demographics", kwargs={"pk": self.study.pk})
         )
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         self.assertIn(
             f"{self.n_previews + self.n_responses} snapshot",
             content,
@@ -1190,7 +1197,7 @@ class ResponseDataDownloadTestCase(TestCase):
         response = self.client.get(
             reverse("exp:study-demographics", kwargs={"pk": self.study.pk})
         )
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         self.assertIn(
             f"{self.n_previews} snapshot",
             content,
@@ -1207,7 +1214,7 @@ class ResponseDataDownloadTestCase(TestCase):
         csv_response = self.client.get(
             reverse("exp:study-demographics-download-csv", kwargs={"pk": self.study.pk})
         )
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1234,7 +1241,7 @@ class ResponseDataDownloadTestCase(TestCase):
         csv_response = self.client.get(
             reverse("exp:study-demographics-download-csv", kwargs={"pk": self.study.pk})
         )
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1267,7 +1274,7 @@ class ResponseDataDownloadTestCase(TestCase):
             {"demo_options": ["participant__global_id"]}, doseq=True
         )
         csv_response = self.client.get(f"{demographic_csv_url}?{query_string}")
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1277,7 +1284,7 @@ class ResponseDataDownloadTestCase(TestCase):
         # Without participant__global_id selected, should not be in header and data should not be included
         query_string = urlencode({"demo_options": []}, doseq=True)
         csv_response = self.client.get(f"{demographic_csv_url}?{query_string}")
-        content = csv_response.content.decode("utf-8")
+        content = self._decode_response(csv_response)
         csv_reader = csv.reader(io.StringIO(content), quoting=csv.QUOTE_ALL)
         csv_body = list(csv_reader)
         csv_headers = csv_body.pop(0)
@@ -1295,7 +1302,7 @@ class ResponseDataDownloadTestCase(TestCase):
             {"demo_options": ["participant__global_id"]}, doseq=True
         )
         response = self.client.get(f"{demographic_json_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         data = json.loads(content)
         for demo in data:
             self.assertIn("global_id", demo["participant"])
@@ -1309,7 +1316,7 @@ class ResponseDataDownloadTestCase(TestCase):
         # Without participant__global_id selected, this info is absent
         query_string = urlencode({"demo_options": []}, doseq=True)
         response = self.client.get(f"{demographic_json_url}?{query_string}")
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         data = json.loads(content)
         for demo in data:
             self.assertNotIn("global_id", demo["participant"])
@@ -1327,7 +1334,7 @@ class ResponseDataDownloadTestCase(TestCase):
         response = self.client.get(
             f"{reverse('exp:study-responses-list', kwargs={'pk': self.study.pk})}"
         )
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
         matches = re.finditer('data-response-uuid="(.*)"', content)
         for m in matches:
             n_matches += 1
@@ -1358,7 +1365,7 @@ class ResponseDataDownloadTestCase(TestCase):
         response = self.client.get(
             reverse("exp:study-responses-list", kwargs={"pk": self.study.pk})
         )
-        content = response.content.decode("utf-8")
+        content = self._decode_response(response)
 
         matches = re.finditer('data-response-uuid="(.*)"', content)
         n_matches = 0
@@ -1372,6 +1379,95 @@ class ResponseDataDownloadTestCase(TestCase):
 
         # Assumes n_previews fit on one page
         self.assertEqual(n_matches, self.n_previews)
+
+    def _get_psychds_zip(self, query_string=""):
+        url = reverse(
+            "exp:study-responses-download-frame-data-zip-psychds",
+            kwargs={"pk": self.study.pk},
+        )
+        response = self.client.get(f"{url}?{query_string}" if query_string else url)
+        zip_bytes = b"".join(response.streaming_content)
+        return response, zip_bytes
+
+    def test_psychds_download_returns_zip(self):
+        self.client.force_login(self.study_reader)
+        response, zip_bytes = self._get_psychds_zip()
+        self.assertEqual(response.status_code, 200)
+        self.assertRegex(
+            response.get("Content-Disposition"),
+            r'^attachment; filename=".*--psychds\.zip"',
+        )
+        # Verify content is a valid zip file
+        zipfile.ZipFile(io.BytesIO(zip_bytes))
+
+    def test_psychds_download_zip_structure(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+        self.assertIn("dataset_description.json", names)
+        self.assertIn("README.md", names)
+        self.assertIn(".psychds-ignore", names)
+        self.assertTrue(
+            any(n.startswith("data/framedata-per-response/") for n in names)
+        )
+        self.assertTrue(any(n.startswith("data/overview/") for n in names))
+        self.assertTrue(
+            any(n.startswith("data/raw/") and n.endswith(".json") for n in names)
+        )
+
+    def test_psychds_download_dataset_description_has_variables_measured(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            metadata = json.loads(zf.read("dataset_description.json"))
+        self.assertIn("variableMeasured", metadata)
+        self.assertIsInstance(metadata["variableMeasured"], list)
+        self.assertGreater(len(metadata["variableMeasured"]), 0)
+
+    def test_psychds_download_frame_data_file_per_response(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            framedata_csv_files = [
+                n
+                for n in zf.namelist()
+                if n.startswith("data/framedata-per-response/") and n.endswith(".csv")
+            ]
+        self.assertEqual(
+            len(framedata_csv_files),
+            self.n_responses + self.n_previews,
+            "Expected one frame data CSV file per consented response",
+        )
+
+    def test_psychds_download_all_responses_json_count(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            all_responses_json = [
+                n
+                for n in zf.namelist()
+                if n.startswith("data/raw/") and n.endswith(".json")
+            ]
+            self.assertEqual(len(all_responses_json), 1)
+            all_responses = json.loads(zf.read(all_responses_json[0]))
+        self.assertEqual(
+            len(all_responses),
+            self.n_responses + self.n_previews,
+            "Unexpected number of responses in all_responses JSON",
+        )
+
+    def test_psychds_download_excludes_unconsented_responses(self):
+        self.client.force_login(self.study_reader)
+        _, zip_bytes = self._get_psychds_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            for name in zf.namelist():
+                content = zf.read(name).decode("utf-8", errors="replace")
+                self.assertNotIn(
+                    self.poison_string,
+                    content,
+                    f"Data from unconsented response found in {name}",
+                )
 
 
 class ResponseViewResearcherUpdateFieldsTestCase(TestCase):

--- a/exp/tests/test_response_views.py
+++ b/exp/tests/test_response_views.py
@@ -3,6 +3,7 @@ import datetime
 import io
 import json
 import re
+import uuid
 import zipfile
 
 from django.test import Client, TestCase, override_settings
@@ -13,7 +14,10 @@ from django_dynamic_fixture import G
 from accounts.backends import TWO_FACTOR_AUTH_SESSION_KEY
 from accounts.models import Child, DemographicData, User
 from accounts.utils import hash_id
-from exp.views.responses import StudyResponseSetResearcherFields
+from exp.views.responses import (
+    StudyResponseSetResearcherFields,
+    get_frame_data,
+)
 from studies.models import ConsentRuling, Lab, Response, Study, StudyType, Video
 
 
@@ -1750,6 +1754,86 @@ class ResponseViewResearcherUpdateFieldsTestCase(TestCase):
         )
         success_str = f"Response {self.response.id} field {self.editable_fields[2]} updated to {False}"
         self.assertIn(success_str, post_response.json().get("success"))
+
+
+class GetFrameDataTestCase(TestCase):
+    """Unit tests for the get_frame_data helper function."""
+
+    BASE_RESP = {
+        "child__uuid": uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        "study__uuid": uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        "study__salt": uuid.UUID("00000000-0000-0000-0000-000000000003"),
+        "study__hash_digits": 6,
+        "uuid": uuid.UUID("00000000-0000-0000-0000-000000000004"),
+        "global_event_timings": [],
+    }
+
+    def _make_resp(self, exp_data):
+        return {**self.BASE_RESP, "exp_data": exp_data}
+
+    def test_non_dict_frame_value_produces_row(self):
+        """A top-level exp_data value that is a string or int should produce a
+        FrameDataRow with that frame_id, a blank key, and the raw value — rather
+        than raising an error."""
+        resp = self._make_resp(
+            {
+                "0-intro": {"frameType": "DEFAULT", "someKey": "someValue"},
+                "top-level-string": "unexpected string",
+                "top-level-int": 42,
+            }
+        )
+        rows = get_frame_data(resp)
+
+        frame_ids = [row.frame_id for row in rows]
+        self.assertIn("top-level-string", frame_ids)
+        self.assertIn("top-level-int", frame_ids)
+
+        string_row = next(r for r in rows if r.frame_id == "top-level-string")
+        self.assertEqual(string_row.key, "")
+        self.assertEqual(string_row.value, "unexpected string")
+
+        int_row = next(r for r in rows if r.frame_id == "top-level-int")
+        self.assertEqual(int_row.key, "")
+        self.assertEqual(int_row.value, 42)
+
+    def test_jspsych_non_dict_list_element_produces_row(self):
+        """For jsPsych responses, normalized_exp_data zips sequence with exp_data into a
+        dict. A non-dict element in the list becomes a non-dict value in that dict. It
+        should produce a row with a blank key and the raw value rather than raising."""
+        # Simulate what normalized_exp_data returns for a jsPsych response where one
+        # trial's data is a bare string.
+        resp = self._make_resp(
+            {
+                "0-survey-likert": {
+                    "trial_type": "survey-likert",
+                    "response": {"q0": 3},
+                },
+                "1-bad-trial": "unexpected string",
+            }
+        )
+        rows = get_frame_data(resp)
+
+        frame_ids = [row.frame_id for row in rows]
+        self.assertIn("1-bad-trial", frame_ids)
+
+        bad_row = next(r for r in rows if r.frame_id == "1-bad-trial")
+        self.assertEqual(bad_row.key, "")
+        self.assertEqual(bad_row.value, "unexpected string")
+
+    def test_normal_dict_frame_values_still_included(self):
+        """Normal dict-valued frames should still produce rows as expected."""
+        resp = self._make_resp(
+            {"0-intro": {"frameType": "DEFAULT", "someKey": "someValue"}}
+        )
+        rows = get_frame_data(resp)
+
+        frame_ids = [row.frame_id for row in rows]
+        self.assertIn("0-intro", frame_ids)
+
+        key_row = next(
+            r for r in rows if r.frame_id == "0-intro" and r.key == "someKey"
+        )
+        self.assertEqual(key_row.value, "someValue")
 
     # TODO: test individual file downloads from response-list
     #       * cannot get response from another study,

--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -10,7 +10,9 @@ from unittest.mock import (
     patch,
     sentinel,
 )
+from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms.models import model_to_dict
@@ -31,7 +33,7 @@ from exp.views.study import (
     StudyDetailView,
     StudyPreviewDetailView,
 )
-from studies.models import Lab, Study, StudyType
+from studies.models import Lab, Study, StudyLog, StudyType
 from studies.permissions import LabPermission, StudyPermission
 
 
@@ -1321,6 +1323,210 @@ class StudyParticipatedViewTestCase(TestCase):
         self.assertSetEqual(set(study.must_not_have_participated.all()), set())
 
 
+class StudyListViewTestCase(TestCase):
+    """Tests for StudyListView (Manage Studies page), including admin-only search/filter inputs and queries."""
+
+    def setUp(self):
+        self.client = Force2FAClient()
+        self.url = reverse("exp:study-list")
+
+        self.lab1 = G(Lab, name="Alpha Lab", approved_to_test=True)
+        self.lab2 = G(Lab, name="Beta Lab", approved_to_test=True)
+
+        self.study_type_efp = StudyType.objects.get(id=1)
+        self.study_type_jspsych = StudyType.objects.get(id=3)
+
+        self.creator1 = G(
+            User,
+            is_active=True,
+            is_researcher=True,
+            given_name="Alice",
+            family_name="Anderson",
+        )
+        self.creator2 = G(
+            User,
+            is_active=True,
+            is_researcher=True,
+            given_name="Bob",
+            family_name="Brown",
+        )
+        self.superuser = G(
+            User,
+            is_active=True,
+            is_researcher=True,
+            is_superuser=True,
+        )
+
+        self.study1 = G(
+            Study,
+            name="Apples Study",
+            lab=self.lab1,
+            public=True,
+            creator=self.creator1,
+            study_type=self.study_type_efp,
+        )
+        self.study2 = G(
+            Study,
+            name="Bananas Study",
+            lab=self.lab2,
+            public=False,
+            creator=self.creator2,
+            study_type=self.study_type_jspsych,
+        )
+
+        # Give creator1 READ_STUDY_DETAILS on study1 only
+        assign_perm(
+            StudyPermission.READ_STUDY_DETAILS.prefixed_codename,
+            self.creator1,
+            self.study1,
+        )
+
+    def test_superuser_sees_admin_filter_section(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Admin filters")
+        self.assertContains(response, 'name="uuid"')
+        self.assertContains(response, 'name="study_type"')
+        self.assertContains(response, 'name="lab"')
+        self.assertContains(response, 'name="public"')
+        self.assertContains(response, 'name="creator"')
+
+    def test_non_superuser_does_not_see_admin_filter_section(self):
+        self.client.force_login(self.creator1)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'name="match"')
+        self.assertNotContains(response, "Admin filters")
+        self.assertNotContains(response, 'name="uuid"')
+        self.assertNotContains(response, 'name="creator"')
+
+    def test_superuser_filter_by_uuid(self):
+        self.client.force_login(self.superuser)
+        partial_uuid = str(self.study1.uuid)[:8]
+        response = self.client.get(self.url, {"uuid": partial_uuid})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_study_type(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"study_type": self.study_type_efp.id})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_lab_name(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"lab": "Beta"})
+        self.assertContains(response, self.study2.name)
+        self.assertNotContains(response, self.study1.name)
+
+    def test_superuser_filter_by_public_true(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"public": "true"})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_public_false(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"public": "false"})
+        self.assertNotContains(response, self.study1.name)
+        self.assertContains(response, self.study2.name)
+
+    def test_superuser_filter_by_creator_given_name(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"creator": "Alice"})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_creator_family_name(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"creator": "Brown"})
+        self.assertNotContains(response, self.study1.name)
+        self.assertContains(response, self.study2.name)
+
+    def test_superuser_filter_by_creator_email(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"creator": self.creator1.username})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_filter_by_creator_full_name(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url, {"creator": "Alice Anderson"})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_combined_name_and_lab_filter(self):
+        self.client.force_login(self.superuser)
+        # Both studies match "Study" but only study1 is in Alpha Lab
+        response = self.client.get(self.url, {"match": "Study", "lab": "Alpha"})
+        self.assertContains(response, self.study1.name)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_superuser_invalid_public_value_ignored(self):
+        self.client.force_login(self.superuser)
+        # Values other than "true"/"false" should be ignored
+        response = self.client.get(self.url, {"public": "maybe"})
+        self.assertContains(response, self.study1.name)
+        self.assertContains(response, self.study2.name)
+
+    def test_non_superuser_admin_filter_params_are_ignored(self):
+        self.client.force_login(self.creator1)
+        # creator1 only has permission on study1; filtering by lab2 should be ignored
+        response = self.client.get(self.url, {"lab": self.lab2.name})
+        self.assertContains(response, self.study1.name)
+
+    def test_non_superuser_cannot_see_study_outside_permissions(self):
+        self.client.force_login(self.creator1)
+        # study2 is not in creator1's permissions — should never appear
+        response = self.client.get(self.url)
+        self.assertNotContains(response, self.study2.name)
+
+    def test_non_superuser_uuid_param_does_not_expand_visible_studies(self):
+        self.client.force_login(self.creator1)
+        # Sending study2's UUID should not make it visible to creator1
+        response = self.client.get(self.url, {"uuid": str(self.study2.uuid)})
+        self.assertNotContains(response, self.study2.name)
+
+    def test_status_change_date_display_shows_status_change_date(self):
+        """Study with non-null status_change_date shows it formatted in the list."""
+        known_date = datetime.datetime(2020, 6, 15, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        self.study1.status_change_date = known_date
+        self.study1.save()
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, "Jun 15, 2020")
+
+    def test_status_change_date_display_falls_back_to_studylog(self):
+        """Study with null status_change_date shows date from matching StudyLog entry."""
+        known_date = datetime.datetime(2021, 3, 15, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        # Explicitly set state to "created" so we know the matching StudyLog action.
+        # The post_save signal always creates a StudyLog(action="created") on study creation.
+        self.study1.state = "created"
+        self.study1.status_change_date = None
+        self.study1.save()
+        StudyLog.objects.filter(study=self.study1, action="created").update(
+            created_at=known_date
+        )
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, "Mar 15, 2021")
+
+    def test_status_change_date_display_is_na_without_date_or_log(self):
+        """Study with null status_change_date and no matching StudyLog shows N/A."""
+        # Set state to "submitted" so the fallback looks for action="submitted" logs,
+        # but no such log exists (only the action="created" log from the post_save signal).
+        self.study1.state = "submitted"
+        self.study1.status_change_date = None
+        self.study1.save()
+        # Use the submitted-state tab so only study1 is visible.
+        submitted_url = reverse("exp:study-list-submitted")
+        self.client.force_login(self.superuser)
+        response = self.client.get(submitted_url)
+        self.assertContains(response, self.study1.name)
+        self.assertContains(response, "N/A")
+
+
 # TODO: StudyCreateView
 # - check user has to be in a lab with perms to create study to get
 # TODO: StudyUpdateView
@@ -1328,9 +1534,6 @@ class StudyParticipatedViewTestCase(TestCase):
 # - check posting change works
 # - check invalid metadata not saved
 # - check can't change lab to one you're not in, or at all w/o perms to change lab
-# TODO: StudyListView
-# - check can get as researcher only
-# - check you see exactly studies you have view details perms for
 # TODO: StudyPreviewProxyView
 # - add checks analogous to preview detail view
 # - check for correct redirect

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1,7 +1,10 @@
+import csv
 import datetime
 import io
 import json
 import logging
+import os
+import tempfile
 import zipfile
 from functools import cached_property
 from typing import Dict, KeysView, List, NamedTuple, Set, Text, Union
@@ -368,29 +371,30 @@ def make_chunk(paginator, page_num, header_options):
     return chunk
 
 
-"""Takes session_data dict list and converts it to csv formatted string
+"""Writes session data to a temp CSV file and returns the path.
 
     Args:
-        session_list(list of strings): list of strings representing rows of the csv
-        header_list(list of strings): list of headers to include at top of csv string
+        session_list(list of dicts): list of dicts representing rows of the csv
+        header_list(list of strings): list of headers to include at top of csv
 
     Returns:
-        (string): csv-formattted string for response data file.
+        (string): path to the temp file (caller is responsible for deletion)
     """
 
 
-def build_overview_str(session_list, header_list):
-    session_strings = [
-        ",".join(
-            [
-                (f'"{str(session_row[key])}"' if key in session_row else "")
+def write_overview_to_temp_file(session_list, header_list):
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".csv", mode="w")
+    tmp.write(",".join(header_list))
+    for session_row in session_list:
+        tmp.write(
+            "\n"
+            + ",".join(
+                f'"{str(session_row[key])}"' if key in session_row else ""
                 for key in header_list
-            ]
+            )
         )
-        for session_row in session_list
-    ]
-    header_str = ",".join(header_list)
-    return "\n".join([header_str] + session_strings)
+    tmp.close()
+    return tmp.name
 
 
 """Aggregates child data over responses and returns list of dictionaries for each row of csv
@@ -428,64 +432,21 @@ def get_child_overview_csv(paginator, study, header_options):
     return session_list, header_list
 
 
-"""Grab all relevant frame data for framedata responses for psychds download
+"""Writes psych-ds formatted zip file based on all response data aggregated
 
     Args:
         paginator(Paginator): Serialized set of entries from the studies_responses table
         study(Study): Query object for the given study
-        truncate_uuids(boolean): Represents whether user has selected to truncate their uuids in filenames
-
-    Returns:
-        response_data(list of lists): contains necessary objects for building and writing files related to frame data for each response
-        variables_measured(list of strings): global record of which columns appeared in various response files
-    """
-
-
-# Helper function to grab all relevant data for framedata responses for psychds download
-def get_framedata_for_psychds(paginator, study, truncate_uuids):
-    study_uuid = study.uuid.hex[:8] if truncate_uuids else study.uuid.hex
-    response_data = []
-    variables_measured = []
-    for page_num in paginator.page_range:
-        page_of_responses = paginator.page(page_num)
-        for resp in page_of_responses:
-            response_uuid = resp.uuid.hex[:8] if truncate_uuids else study.uuid.hex
-            # get framedata for response
-            data = build_single_response_framedata_csv(resp)
-            # get column headers from first row
-            variables_measured += [
-                column.strip('"') for column in data.split("\n")[0].strip().split(",")
-            ]
-            # psych-DS files use "keyword" formatting
-            keywords = {"study": study_uuid, "response": response_uuid}
-            filename = keyword_filename(keywords, "csv")
-            # make a response-specific metadata file
-            sidecar_metadata = {
-                "response_uuid": resp.uuid.hex,
-                "eligibility": resp.eligibility,
-                "study_completed": resp.completed,
-            }
-            sidecar_filename = keyword_filename(keywords, "json")
-            response_data.append([data, filename, sidecar_metadata, sidecar_filename])
-    return response_data, variables_measured
-
-
-"""Writes psych-ds formatted zip file based on all response data aggregated
-
-    Args:
-        response_data(list of lists): list of the following objects for each response object:
-            data(string): framedata-per-response csv string
-            filename(string): formatted name for csv file
-            sidecar_metadata(dict): JSON object for sidecar metadata file
-            sidecar_filename(string): formatted name for sidecar file
-        study(Study): Query object for the given study
         header_options(list of strings): list of selected headers from header_options
         study_uuid(string): uuid for study object, either truncated or untruncated
-        overview_str(string): string representing reponse overview file 
-        child_overview_str(string): string representing child overview file
-        metadata_json(dict): JSON object for global metadata file
+        truncate_uuids(boolean): Represents whether user has selected to truncate their uuids in filenames
+        overview_path(string): path to temp file containing response overview CSV
+        child_overview_path(string): path to temp file containing child overview CSV
+        metadata_json(dict): JSON object for global metadata file (variableMeasured will be added)
         all_response_filename(string): filename for response overview file
-        all_response_json_str(string): string representing json for all response overview file
+        all_response_json_path(string): path to temp file containing all-responses JSON
+        descriptions(dict): mapping of column ids to column descriptions
+        header_list(list of strings): list of response overview column headers
 
     Returns:
         response(FileResponse): Formatted response object with constructed zipfile
@@ -493,26 +454,46 @@ def get_framedata_for_psychds(paginator, study, truncate_uuids):
 
 
 def build_zip_for_psychds(
-    response_data,
+    paginator,
     study,
     header_options,
     study_uuid,
-    overview_str,
-    child_overview_str,
+    truncate_uuids,
+    overview_path,
+    child_overview_path,
     metadata_json,
     all_response_filename,
-    all_response_json_str,
+    all_response_json_path,
+    descriptions,
+    header_list,
 ):
-    zipped_file = io.BytesIO()
+    zipped_file = tempfile.NamedTemporaryFile(suffix=".zip")
     with zipfile.ZipFile(zipped_file, "w", zipfile.ZIP_DEFLATED) as zipped:
-        for data, filename, sidecar_metadata, sidecar_filename in response_data:
-            # write data file for response
-            zipped.writestr(f"data/framedata-per-response/{filename}", data)
-            # write metadata sidecar for response
-            zipped.writestr(
-                f"data/framedata-per-response/{sidecar_filename}",
-                json.dumps(sidecar_metadata, indent=4),
-            )
+        # write frame data for each response directly into the zip, one at a time
+        variables_measured = set()
+        for page_num in paginator.page_range:
+            page_of_responses = paginator.page(page_num)
+            for resp in page_of_responses:
+                response_uuid = resp.uuid.hex[:8] if truncate_uuids else resp.uuid.hex
+                data = build_single_response_framedata_csv(resp)
+                # collect column headers for variableMeasured metadata
+                variables_measured |= {
+                    column.strip('"')
+                    for column in data.split("\n")[0].strip().split(",")
+                }
+                keywords = {"study": study_uuid, "response": response_uuid}
+                filename = keyword_filename(keywords, "csv")
+                sidecar_metadata = {
+                    "response_uuid": resp.uuid.hex,
+                    "eligibility": resp.eligibility,
+                    "study_completed": resp.completed,
+                }
+                sidecar_filename = keyword_filename(keywords, "json")
+                zipped.writestr(f"data/framedata-per-response/{filename}", data)
+                zipped.writestr(
+                    f"data/framedata-per-response/{sidecar_filename}",
+                    json.dumps(sidecar_metadata, indent=4),
+                )
 
         # mark response overview with identifiable keyword if identifiable columns were selected
         all_responses = "all-responses"
@@ -522,14 +503,14 @@ def build_zip_for_psychds(
             all_children += "_identifiable-true"
 
         # save response overview
-        zipped.writestr(
+        zipped.write(
+            overview_path,
             f"data/overview/study-{study_uuid}_{all_responses}_data.csv",
-            overview_str,
         )
         # save children overview
-        zipped.writestr(
+        zipped.write(
+            child_overview_path,
             f"data/overview/study-{study_uuid}_{all_children}_data.csv",
-            child_overview_str,
         )
         if not study.use_generator:
             # save study protocol
@@ -564,10 +545,7 @@ def build_zip_for_psychds(
             VIDEOS_README_STR,
         )
         # save all responses json
-        zipped.writestr(
-            f"data/raw/{all_response_filename}",
-            all_response_json_str,
-        )
+        zipped.write(all_response_json_path, f"data/raw/{all_response_filename}")
         # save psychds-ignore file to avoid NOT_INCLUDED warnings
         zipped.writestr(
             ".psychds-ignore",
@@ -595,6 +573,17 @@ def build_zip_for_psychds(
         zipped.writestr(
             "materials/study_ad_info.json", f"{json.dumps(study_ad, indent=4)}"
         )
+        # build variableMeasured from frame data headers + overview headers, then finalise metadata
+        variables_measured |= set(header_list + CHILD_CSV_HEADERS)
+        variables_measured_objects = [
+            {
+                "@type": "PropertyValue",
+                "name": column,
+                "description": descriptions[column.split(".")[0]],
+            }
+            for column in variables_measured
+        ]
+        metadata_json["variableMeasured"] = variables_measured_objects
         # save global metadata file
         zipped.writestr(
             "dataset_description.json", f"{json.dumps(metadata_json, indent=4)}"
@@ -1462,18 +1451,29 @@ class StudyResponsesCSV(ResponseDownloadMixin, generic.list.ListView):
         session_list, header_options, header_list = get_study_responses_csv(
             self, paginator, study
         )
-        output, writer = csv_dict_output_and_writer(header_list)
+        tmp = tempfile.NamedTemporaryFile(suffix=".csv")
+        text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
+        writer = csv.DictWriter(
+            text_wrapper,
+            quoting=csv.QUOTE_NONNUMERIC,
+            fieldnames=header_list,
+            restval="",
+            extrasaction="ignore",
+        )
+        writer.writeheader()
         writer.writerows(session_list)
-        cleaned_data = output.getvalue()
+        text_wrapper.flush()
+        text_wrapper.detach()
+        tmp.seek(0)
 
         all_responses = "all-responses"
         if IDENTIFIABLE_DATA_HEADERS & header_options:
             all_responses += "-identifiable"
 
         filename = csv_filename(study, all_responses)
-        response = HttpResponse(cleaned_data, content_type=CONTENT_TYPE)
-        set_content_disposition(response, filename)
-        return response
+        return FileResponse(
+            tmp, as_attachment=True, filename=filename, content_type=CONTENT_TYPE
+        )
 
 
 class StudyResponsesDictCSV(CanViewStudyResponsesMixin, View):
@@ -1524,17 +1524,28 @@ class StudyChildrenCSV(ResponseDownloadMixin, generic.list.ListView):
             paginator, study, header_options
         )
 
-        output, writer = csv_dict_output_and_writer(header_list)
+        tmp = tempfile.NamedTemporaryFile(suffix=".csv")
+        text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
+        writer = csv.DictWriter(
+            text_wrapper,
+            quoting=csv.QUOTE_NONNUMERIC,
+            fieldnames=header_list,
+            restval="",
+            extrasaction="ignore",
+        )
+        writer.writeheader()
         writer.writerows(session_list)
-        cleaned_data = output.getvalue()
+        text_wrapper.flush()
+        text_wrapper.detach()
+        tmp.seek(0)
 
         filename = "all-children{}".format(
             ("-identifiable" if IDENTIFIABLE_DATA_HEADERS & header_options else ""),
         )
         filename = csv_filename(study, filename)
-        response = HttpResponse(cleaned_data, content_type=CONTENT_TYPE)
-        set_content_disposition(response, filename)
-        return response
+        return FileResponse(
+            tmp, as_attachment=True, filename=filename, content_type=CONTENT_TYPE
+        )
 
 
 class StudyChildrenDictCSV(CanViewStudyResponsesMixin, View):
@@ -1592,50 +1603,43 @@ class StudyResponsesFrameDataPsychDS(ResponseDownloadMixin, generic.list.ListVie
         session_list, header_options, header_list = get_study_responses_csv(
             self, paginator, study
         )
-        overview_str = build_overview_str(session_list, header_list)
+        tmp_overview = write_overview_to_temp_file(session_list, header_list)
         # gets data necessary for building child overview file
         child_session_list, child_header_list = get_child_overview_csv(
             paginator, study, header_options
         )
-        child_overview_str = build_overview_str(child_session_list, child_header_list)
-        # gets data necessary for building psychds framedata files
-        response_data, variables_measured = get_framedata_for_psychds(
-            paginator, study, truncate_uuids
+        tmp_child_overview = write_overview_to_temp_file(
+            child_session_list, child_header_list
         )
-        variables_measured += header_list + CHILD_CSV_HEADERS
         # builds "all response" json download
         all_response_filename = "all_responses{}.json".format(
             ("_identifiable" if IDENTIFIABLE_DATA_HEADERS & header_options else ""),
         )
-        all_response_json_str = "".join(
-            [
-                make_chunk(paginator, page_num, header_options)
-                for page_num in paginator.page_range
-            ]
-        )
-        # construct more informative variablesMeasured object
-        variables_measured_objects = [
-            {
-                "@type": "PropertyValue",
-                "name": column,
-                "description": descriptions[column.split(".")[0]],
-            }
-            for column in list(set(variables_measured))
-        ]
-        # add final variables list to metadata
-        metadata_json["variableMeasured"] = variables_measured_objects
+        tmp_all_response = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
 
-        response = build_zip_for_psychds(
-            response_data,
-            study,
-            header_options,
-            study_uuid,
-            overview_str,
-            child_overview_str,
-            metadata_json,
-            all_response_filename,
-            all_response_json_str,
-        )
+        try:
+            with open(tmp_all_response.name, "w") as f:
+                for page_num in paginator.page_range:
+                    f.write(make_chunk(paginator, page_num, header_options))
+
+            response = build_zip_for_psychds(
+                paginator,
+                study,
+                header_options,
+                study_uuid,
+                truncate_uuids,
+                tmp_overview,
+                tmp_child_overview,
+                metadata_json,
+                all_response_filename,
+                all_response_json_path=tmp_all_response.name,
+                descriptions=descriptions,
+                header_list=header_list,
+            )
+        finally:
+            os.unlink(tmp_all_response.name)
+            os.unlink(tmp_overview)
+            os.unlink(tmp_child_overview)
 
         return response
 
@@ -1656,7 +1660,7 @@ class StudyResponsesFrameDataCSV(ResponseDownloadMixin, generic.list.ListView):
 
             return study_responses_all(study)
 
-        zipped_file = io.BytesIO()
+        zipped_file = tempfile.NamedTemporaryFile(suffix=".zip")
         with zipfile.ZipFile(zipped_file, "w", zipfile.ZIP_DEFLATED) as zipped:
             for page_num in paginator.page_range:
                 page_of_responses = paginator.page(page_num)
@@ -1741,13 +1745,16 @@ class StudyDemographicsJSON(DemographicDownloadMixin, generic.list.ListView):
         study = self.study
         header_options = self.request.GET.getlist("demo_options")
 
-        json_responses = []
         paginator = context["paginator"]
-        for page_num in paginator.page_range:
-            page_of_responses = paginator.page(page_num)
-            for resp in page_of_responses:
-                json_responses.append(
-                    json.dumps(
+
+        def json_generator():
+            yield "[\n"
+            first = True
+            for page_num in paginator.page_range:
+                for resp in paginator.page(page_num):
+                    if not first:
+                        yield ",\n"
+                    yield json.dumps(
                         construct_response_dictionary(
                             resp,
                             DEMOGRAPHIC_COLUMNS,
@@ -1757,12 +1764,13 @@ class StudyDemographicsJSON(DemographicDownloadMixin, generic.list.ListView):
                         indent="\t",
                         default=str,
                     )
-                )
-        cleaned_data = f"[ {', '.join(json_responses)} ]"
+                    first = False
+            yield "\n]"
+
         filename = "{}_{}.json".format(
             study_name_for_files(study.name), "all-demographic-snapshots"
         )
-        response = HttpResponse(cleaned_data, content_type="text/json")
+        response = StreamingHttpResponse(json_generator(), content_type="text/json")
         set_content_disposition(response, filename)
         return response
 
@@ -1777,21 +1785,30 @@ class StudyDemographicsCSV(DemographicDownloadMixin, generic.list.ListView):
         paginator = context["paginator"]
         header_options = set(self.request.GET.getlist("demo_options"))
 
-        participant_list = []
         headers_for_download = get_demographic_headers(header_options)
+        tmp = tempfile.NamedTemporaryFile(suffix=".csv")
+        text_wrapper = io.TextIOWrapper(tmp, encoding="utf-8", newline="")
+        writer = csv.DictWriter(
+            text_wrapper,
+            quoting=csv.QUOTE_NONNUMERIC,
+            fieldnames=headers_for_download,
+            restval="",
+            extrasaction="ignore",
+        )
+        writer.writeheader()
         for page_num in paginator.page_range:
-            page_of_responses = paginator.page(page_num)
-            for resp in page_of_responses:
-                row_data = {col.id: col.extractor(resp) for col in DEMOGRAPHIC_COLUMNS}
-                participant_list.append(row_data)
-        output, writer = csv_dict_output_and_writer(headers_for_download)
-        writer.writerows(participant_list)
-        cleaned_data = output.getvalue()
+            for resp in paginator.page(page_num):
+                writer.writerow(
+                    {col.id: col.extractor(resp) for col in DEMOGRAPHIC_COLUMNS}
+                )
+        text_wrapper.flush()
+        text_wrapper.detach()
+        tmp.seek(0)
 
         filename = csv_filename(study, "all-demographic-snapshots")
-        response = HttpResponse(cleaned_data, content_type=CONTENT_TYPE)
-        set_content_disposition(response, filename)
-        return response
+        return FileResponse(
+            tmp, as_attachment=True, filename=filename, content_type=CONTENT_TYPE
+        )
 
 
 class StudyDemographicsDictCSV(DemographicDownloadMixin, generic.list.ListView):

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -269,6 +269,18 @@ def get_frame_data(resp: Union[Response, Dict]) -> List[FrameDataRow]:
     # Next add all data in exp_data
     event_prefix = "eventTimings."
     for frame_id, frame_data in resp["exp_data"].items():
+        if not isinstance(frame_data, dict):
+            frame_data_tuples.append(
+                FrameDataRow(
+                    child_hashed_id=child_hashed_id,
+                    response_uuid=str(resp["uuid"]),
+                    frame_id=frame_id,
+                    key="",
+                    event_number="",
+                    value=frame_data,
+                )
+            )
+            continue
         for key, value in flatten_dict(frame_data).items():
             # Process event data separately and include event_number within frame
             if key.startswith(event_prefix):

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -291,6 +291,17 @@ class StudyListView(
         context["sort"] = self.request.GET.get("sort", "name")
         context["page"] = self.request.GET.get("page", "1")
         context["can_create_study"] = self.request.user.can_create_study()
+        if self.request.user.is_superuser:
+            context["study_types"] = StudyType.objects.all()
+            context["admin_uuid"] = self.request.GET.get("uuid", "")
+            context["admin_study_type"] = self.request.GET.get("study_type", "")
+            context["admin_lab"] = self.request.GET.get("lab", "")
+            context["admin_public"] = self.request.GET.get("public", "")
+            context["admin_creator"] = self.request.GET.get("creator", "")
+            if self.state == "submitted":
+                context["admin_submission_history"] = self.request.GET.get(
+                    "submission_history", ""
+                )
         return context
 
 

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -178,10 +178,14 @@ class FrameActionDispatcher(object):
 
         if response.study_type.is_jspsych:
             exp_data = response.exp_data[-1]
+            if not isinstance(exp_data, dict):
+                return
             frame_data = exp_data.get("response")
             frame_type = exp_data.get("chs_type")
         elif response.study_type.is_ember_frame_player:
             frame_data = response.exp_data[current_frame_id]
+            if not isinstance(frame_data, dict):
+                return
             frame_type = frame_data.get("frameType")
 
         if not frame_type:

--- a/studies/management/commands/delete_video.py
+++ b/studies/management/commands/delete_video.py
@@ -1,0 +1,128 @@
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models.deletion import Collector
+from django.db.models.signals import pre_delete
+
+from studies.models import Video, delete_video_on_s3
+from studies.tasks import delete_video_from_cloud
+
+
+class Command(BaseCommand):
+    help = "Safely delete a Video from the database, and optionally trigger immediate S3 deletion rather than waiting 7 days."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--uuid", type=str, help="UUID of the Video.")
+        parser.add_argument("--full-name", type=str, help="Full name of the Video.")
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview deletion without deleting.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Actually perform deletion.",
+        )
+        parser.add_argument(
+            "--immediate-s3",
+            action="store_true",
+            help="Delete from S3 immediately instead of waiting 7 days.",
+        )
+
+    def handle(self, *args, **options):
+        uuid = options.get("uuid")
+        full_name = options.get("full_name")
+        dry_run = options.get("dry_run")
+        force = options.get("force")
+        immediate_s3 = options.get("immediate_s3")
+
+        if not uuid and not full_name:
+            raise CommandError("Provide either --uuid or --full-name.")
+
+        if not dry_run and not force:
+            raise CommandError(
+                "Refusing to delete without --force. Use --dry-run to preview."
+            )
+
+        # Find the video
+        try:
+            if uuid:
+                video = Video.objects.get(uuid=uuid)
+            else:
+                video = Video.objects.get(full_name=full_name)
+        except Video.DoesNotExist:
+            raise CommandError("Video not found.")
+        except Video.MultipleObjectsReturned:
+            raise CommandError("Multiple matches found. Use UUID.")
+
+        self.stdout.write(self.style.WARNING("\nVideo found:"))
+        self.stdout.write(f"  ID: {video.id}")
+        self.stdout.write(f"  UUID: {video.uuid}")
+        self.stdout.write(f"  Full name: {video.full_name}")
+
+        # Check for cascading deletions due to related objects
+        collector = Collector(using="default")
+        collector.collect([video])
+
+        related_counts = defaultdict(int)
+        for model, objs in collector.data.items():
+            related_counts[model._meta.label] += len(objs)
+
+        self.stdout.write(self.style.WARNING("\nObjects that will be deleted:"))
+        total = 0
+        for model_label, count in sorted(related_counts.items()):
+            self.stdout.write(f"  {model_label}: {count}")
+            total += count
+
+        self.stdout.write(f"\n  TOTAL objects deleted: {total}")
+
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS("\nDry run complete. No deletion performed.")
+            )
+            return
+
+        # Perform deletion
+        with transaction.atomic():
+            if immediate_s3:
+                self.stdout.write(
+                    self.style.WARNING("\nTriggering immediate S3 deletion...")
+                )
+                # Disconnect pre_delete signal temporarily to avoid scheduling delayed S3 deletion task
+                pre_delete.disconnect(
+                    receiver=delete_video_on_s3,
+                    sender=Video,
+                )
+                try:
+                    # Trigger immediate S3 deletion
+                    delete_video_from_cloud.apply_async(
+                        args=(
+                            video.full_name,
+                            video.recording_method_is_pipe,
+                            video.study_type_is_jspsych,
+                        ),
+                        queue="cleanup",
+                    )
+                    # Delete without triggering delayed signal
+                    video.delete()
+                finally:
+                    # Reconnect the signal
+                    pre_delete.connect(
+                        receiver=delete_video_on_s3,
+                        sender=Video,
+                    )
+            else:
+                video.delete()
+
+        self.stdout.write(self.style.SUCCESS("\nVideo deleted successfully."))
+
+        if immediate_s3:
+            self.stdout.write(self.style.SUCCESS("S3 deletion triggered immediately."))
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "S3 deletion scheduled via pre_delete signal (7-day delay)."
+                )
+            )

--- a/studies/models.py
+++ b/studies/models.py
@@ -1166,7 +1166,7 @@ class Response(models.Model):
         exit_frame_values = [
             f.get(property, None)
             for f in self.exp_data.values()
-            if f.get("frameType", None) == "EXIT"
+            if isinstance(f, dict) and f.get("frameType", None) == "EXIT"
         ]
         if exit_frame_values and exit_frame_values != [None]:
             return exit_frame_values[-1]
@@ -1174,7 +1174,9 @@ class Response(models.Model):
             return None
 
     def exit_frame_properties_jspsych(self, property):
-        exit_frame_filter_fn = lambda x: x.get("chs_type") == "exit"
+        exit_frame_filter_fn = (
+            lambda x: isinstance(x, dict) and x.get("chs_type") == "exit"
+        )
         exit_frame_filter = filter(exit_frame_filter_fn, self.exp_data)
         exit_frame_list = list(exit_frame_filter)
 
@@ -1479,7 +1481,8 @@ class Video(models.Model):
         # >95% of the time.
         is_consent_footage = (
             marked_as_consent
-            or response.exp_data.get(frame_id, {}).get("frameType", "") == "CONSENT"
+            or isinstance(response.exp_data.get(frame_id), dict)
+            and response.exp_data[frame_id].get("frameType", "") == "CONSENT"
         )
 
         # Once we've completed the renaming, create our db object referencing it

--- a/studies/models.py
+++ b/studies/models.py
@@ -607,8 +607,23 @@ class Study(models.Model):
 
     @property
     def days_submitted(self):
-        if self.status_change_date:
-            return (dutimezone.now() - self.status_change_date).days
+        if self.state != "submitted":
+            return None
+        # status_change_date is set on every workflow state transition, so for a submitted study it is the submission date.
+        # It was added in a migration without a backfill, so it may be null for older studies.
+        date = self.status_change_date
+        if not date:
+            log = (
+                StudyLog.objects.filter(study=self, action="submitted")
+                .order_by("-created_at")
+                .first()
+            )
+            if log:
+                date = log.created_at
+        if date:
+            return (dutimezone.now() - date).days
+        else:
+            return None
 
     @property
     def approved_by(self):

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -5,7 +5,16 @@ from functools import reduce
 
 from django.core.exceptions import FieldError
 from django.db import models
-from django.db.models import Count, F, IntegerField, OuterRef, Q, Subquery, Value
+from django.db.models import (
+    Count,
+    Exists,
+    F,
+    IntegerField,
+    OuterRef,
+    Q,
+    Subquery,
+    Value,
+)
 from django.db.models.fields import CharField
 from django.db.models.functions import Coalesce, Concat
 from django.utils.timezone import now
@@ -264,19 +273,8 @@ def get_pending_responses_qs():
     )
 
 
-def get_study_list_qs(user, query_dict):
-    """Gets a study list query set annotated with response counts.
-
-    TODO: Factor in all the query mutation from the (view) caller.
-    TODO: Upgrade to Django 2.x and use the improved query mechanisms to clean this up.
-
-    Args:
-        user: django.utils.functional.SimpleLazyObject masquerading as a user.
-        query_dict: django.http.QueryDict from the self.request.GET property.
-
-    Returns:
-        A heavily annotated queryset for the list of studies.
-    """
+def _build_study_list_base_qs(user):
+    """Build the base annotated queryset for the study list."""
     annotated_responses_qs = get_annotated_responses_qs().only(
         "id",
         "completed",
@@ -286,7 +284,7 @@ def get_study_list_qs(user, query_dict):
         "is_preview",
     )
 
-    queryset = (
+    return (
         studies_for_which_user_has_perm(user, StudyPermission.READ_STUDY_DETAILS)
         # .select_related("lab")
         # .select_related("creator")
@@ -348,19 +346,31 @@ def get_study_list_qs(user, query_dict):
                 .filter(action="deactivated")
                 .values("created_at")[:1]
             ),
+            status_change_date_display=Coalesce(
+                F("status_change_date"),
+                Subquery(
+                    StudyLog.objects.filter(
+                        study=OuterRef("pk"), action=OuterRef("state")
+                    )
+                    .order_by("-created_at")
+                    .values("created_at")[:1]
+                ),
+            ),
         )
     )
 
-    # Request filtering
 
-    state = query_dict.get("state")
+def _apply_state_filter(queryset, user, state):
+    """Filter queryset by state or restrict to the current user's studies."""
     if state and state != "all":
         if state == "myStudies":
-            queryset = queryset.filter(creator=user)
-        else:
-            queryset = queryset.filter(state=state)
+            return queryset.filter(creator=user)
+        return queryset.filter(state=state)
+    return queryset
 
-    match = query_dict.get("match")
+
+def _apply_match_filter(queryset, match):
+    """Filter queryset to studies whose name or description contain all search terms."""
     if match:
         queryset = queryset.filter(
             reduce(
@@ -371,14 +381,95 @@ def get_study_list_qs(user, query_dict):
                 ),
             )
         )
+    return queryset
 
-    # Sort value is in a list
-    sort = "".join(query_dict.get("sort", []))
+
+def _apply_submission_history_filter(queryset, submission_history):
+    """Filter submitted studies by their approval/rejection history."""
+    ever_approved = Exists(
+        StudyLog.objects.filter(study=OuterRef("pk"), action="approved")
+    )
+    ever_rejected = Exists(
+        StudyLog.objects.filter(study=OuterRef("pk"), action="rejected")
+    )
+    if submission_history == "first_submission":
+        return queryset.filter(~ever_approved, ~ever_rejected)
+    elif submission_history == "previously_rejected":
+        return queryset.filter(~ever_approved, ever_rejected)
+    elif submission_history == "previously_approved":
+        return queryset.filter(ever_approved)
+    elif submission_history == "other":
+        # Complement of the three exhaustive categories above — always empty
+        # in practice, but kept as a filter option for data anomalies
+        return queryset.exclude(
+            Q(~ever_approved, ~ever_rejected)
+            | Q(~ever_approved, ever_rejected)
+            | Q(ever_approved)
+        )
+    return queryset
+
+
+def _apply_superuser_filters(queryset, state, query_dict):
+    """Apply admin-only search filters from the query string."""
+    uuid_filter = "".join(query_dict.get("uuid", []))
+    if uuid_filter:
+        queryset = queryset.filter(uuid__icontains=uuid_filter)
+
+    study_type_filter = "".join(query_dict.get("study_type", []))
+    if study_type_filter:
+        queryset = queryset.filter(study_type_id=study_type_filter)
+
+    lab_filter = "".join(query_dict.get("lab", []))
+    if lab_filter:
+        queryset = queryset.filter(lab__name__icontains=lab_filter)
+
+    public_filter = "".join(query_dict.get("public", []))
+    if public_filter in ("true", "false"):
+        queryset = queryset.filter(public=(public_filter == "true"))
+
+    creator_filter = "".join(query_dict.get("creator", []))
+    if creator_filter:
+        queryset = queryset.filter(
+            Q(creator__given_name__icontains=creator_filter)
+            | Q(creator__family_name__icontains=creator_filter)
+            | Q(creator__username__icontains=creator_filter)
+            | Q(creator_name__icontains=creator_filter)
+        )
+
+    if state == "submitted":
+        submission_history = "".join(query_dict.get("submission_history", []))
+        if submission_history:
+            queryset = _apply_submission_history_filter(queryset, submission_history)
+
+    return queryset
+
+
+def _apply_sort(queryset, sort):
+    """Sort queryset by the given field name, ignoring invalid field names."""
     if sort:
         try:
             queryset = queryset.order_by(sort)
         except FieldError:
             # if someone attempts to manually enter a field that doesn't exist
             pass
+    return queryset
 
+
+def get_study_list_qs(user, query_dict):
+    """Gets a study list query set annotated with response counts.
+
+    Args:
+        user: django.utils.functional.SimpleLazyObject masquerading as a user.
+        query_dict: django.http.QueryDict from the self.request.GET property.
+
+    Returns:
+        A heavily annotated queryset for the list of studies.
+    """
+    state = query_dict.get("state")
+    queryset = _build_study_list_base_qs(user)
+    queryset = _apply_state_filter(queryset, user, state)
+    queryset = _apply_match_filter(queryset, query_dict.get("match"))
+    if user.is_superuser:
+        queryset = _apply_superuser_filters(queryset, state, query_dict)
+    queryset = _apply_sort(queryset, "".join(query_dict.get("sort", [])))
     return queryset

--- a/studies/templates/studies/study_detail/_manage_researchers.html
+++ b/studies/templates/studies/study_detail/_manage_researchers.html
@@ -49,14 +49,14 @@
                     Researchers belonging to this study's access groups. {{ study.lab.name }} Admins will automatically be able to edit this study, regardless of study group.
                 </div>
                 <div class="row mb-1">
-                    <div class="col-4 fw-bold">Name</div>
-                    <div class="col-6 fw-bold">Permissions</div>
+                    <div class="col-5 fw-bold">Name</div>
+                    <div class="col-5 fw-bold">Permissions</div>
                 </div>
                 {% for researcher in current_researchers %}
                     <div class="row mb-1">
-                        <div class="col-4">{{ researcher.user.identicon_small_html }} {{ researcher.user.get_short_name }}</div>
+                        <div class="col-5">{{ researcher.user.identicon_small_html }} {{ researcher.user.get_short_name }} ({{ researcher.user.username }})</div>
                         {% if can_manage_researchers %}
-                            <div class="col-6">
+                            <div class="col-5">
                                 <div class="permissionDisplay">
                                     <a href="#"
                                        data-name="update_user"
@@ -69,7 +69,7 @@
                                        data-title="Select researcher permissions">{{ researcher.current_group }}</a>
                                 </div>
                             </div>
-                            <div class="col-2">
+                            <div class="col-2 text-center">
                                 <form method="post"
                                       action="{% url 'exp:manage-researcher-permissions' study.id %}">
                                     {% csrf_token %}

--- a/studies/templates/studies/study_list.html
+++ b/studies/templates/studies/study_list.html
@@ -10,24 +10,87 @@
     {% bs_icon "plus" as bs_icon_plus %}
     {% url 'exp:study-create' as url_study_create %}
     {% button_primary_classes as btn_primary_classes %}
+    {% button_primary_light_classes as btn_primary_lgt_classes %}
     {% bootstrap_button bs_icon_plus|add:"Create Study" href=url_study_create button_class=btn_primary_classes as btn_create_study %}
     {% if can_create_study %}
         {% page_title "Manage Studies" right_side_elements=btn_create_study %}
     {% else %}
         {% page_title "Manage Studies" %}
     {% endif %}
-    <form method="get" class="search-bar">
-        <input id="search-studies"
-               class="form-control"
-               name="match"
-               placeholder="Filter name or description"
-               size="50"
-               type="text"
-               value="{{ match }}" />
-        <input type="hidden" name="sort" value="{{ sort }}" />
-        <input type="hidden" name="state" value="{{ state }}" />
-        <input type="hidden" name="page" value="1" />
-    </form>
+    <div class="mt-2 p-2 pb-4 border rounded bg-white">
+        <form method="get" class="search-bar">
+            <div class="row g-2">
+                <div class="col-lg-10">
+                    <input id="search-studies"
+                        class="form-control"
+                        name="match"
+                        placeholder="Filter name or description"
+                        size="50"
+                        type="text"
+                        value="{{ match }}" />
+                </div>
+                <div class="col-lg-2 text-center text-lg-end">
+                    {% bootstrap_button "Search" button_type="submit" button_class=btn_primary_lgt_classes %}
+                </div>
+            </div>
+            <input type="hidden" name="sort" value="{{ sort }}" />
+            <input type="hidden" name="state" value="{{ state }}" />
+            <input type="hidden" name="page" value="1" />
+            {% if request.user.is_superuser %}
+                <div class="text-muted d-block mb-1 mt-3">Admin filters</div>
+                <div class="row g-2">
+                    <div class="col-lg-6">
+                        <input class="form-control"
+                               name="uuid"
+                               placeholder="Study UUID"
+                               size="35"
+                               type="text"
+                               value="{{ admin_uuid }}" />
+                    </div>
+                    <div class="col-lg-3">
+                        <select class="form-select" name="study_type">
+                            <option value="">All study types</option>
+                            {% for st in study_types %}
+                                <option value="{{ st.id }}" {% if admin_study_type == st.id|stringformat:"s" %}selected{% endif %}>{{ st.name|before_paren }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-lg-3">
+                        <select class="form-select" name="public">
+                            <option value="">Public: any</option>
+                            <option value="true" {% if admin_public == "true" %}selected{% endif %}>Public: yes</option>
+                            <option value="false" {% if admin_public == "false" %}selected{% endif %}>Public: no</option>
+                        </select>
+                    </div>
+                    <div class="col-lg-6">
+                        <input class="form-control"
+                               name="lab"
+                               placeholder="Lab name"
+                               type="text"
+                               value="{{ admin_lab }}" />
+                    </div>
+                    <div class="col-lg-6">
+                        <input class="form-control"
+                               name="creator"
+                               placeholder="Study creator name or email"
+                               type="text"
+                               value="{{ admin_creator }}" />
+                    </div>
+                    {% if state == "submitted" %}
+                        <div class="col-lg-6">
+                            <select class="form-select" name="submission_history">
+                                <option value="">Submission history: all</option>
+                                <option value="first_submission" {% if admin_submission_history == "first_submission" %}selected{% endif %}>First submission</option>
+                                <option value="previously_rejected" {% if admin_submission_history == "previously_rejected" %}selected{% endif %}>Previously rejected</option>
+                                <option value="previously_approved" {% if admin_submission_history == "previously_approved" %}selected{% endif %}>Previously approved</option>
+                                <option value="other" {% if admin_submission_history == "other" %}selected{% endif %}>Other</option>
+                            </select>
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
+        </form>
+    </div>
     <div class="row text-center mb-5 mt-2">
         <ul class="nav nav-pills justify-content-center">
             {% nav_link request 'exp:study-list-active' 'Active' %}
@@ -67,10 +130,10 @@
             <strong>Last Status Change</strong>
             <a class="text-decoration-none"
                aria-label="Sort studies by end date"
-               href="?{% query_transform request page='1' sort='status_change_date' %}">{% bs_icon "chevron-up" %}</a>
+               href="?{% query_transform request page='1' sort='status_change_date_display' %}">{% bs_icon "chevron-up" %}</a>
             <a class="text-decoration-none"
                aria-label="Reverse sort studies by end date"
-               href="?{% query_transform request page='1' sort='-status_change_date' %}">{% bs_icon "chevron-down" %}</a>
+               href="?{% query_transform request page='1' sort='-status_change_date_display' %}">{% bs_icon "chevron-down" %}</a>
         </div>
     </div>
     {% for study in object_list %}
@@ -92,7 +155,7 @@
                             {% endblock status_change_label %}
                         </strong>
                         {% block status_change_date %}
-                            {{ study.status_change_date|date:"M d, Y"|default:"N/A" }}
+                            {{ study.status_change_date_display|date:"M d, Y"|default:"N/A" }}
                         {% endblock status_change_date %}
                     </div>
                 </div>

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -22,7 +22,15 @@ from studies.helpers import (
     get_experiment_absolute_url,
     send_mail,
 )
-from studies.models import Lab, Response, Study, StudyType, StudyTypeEnum, Video
+from studies.models import (
+    Lab,
+    Response,
+    Study,
+    StudyLog,
+    StudyType,
+    StudyTypeEnum,
+    Video,
+)
 from studies.permissions import StudyPermission
 from studies.tasks import (
     MessageTarget,
@@ -860,6 +868,48 @@ class StudyModelTestCase(TestCase):
         assign_perm(StudyPermission.READ_STUDY_RESPONSE_DATA.codename, user, study)
 
         self.assertIn(response, study.responses_for_researcher(user))
+
+
+class DaysSubmittedTestCase(TestCase):
+    def setUp(self):
+        self.study = G(
+            Study,
+            study_type=StudyType.get_ember_frame_player(),
+            state="created",
+            status_change_date=None,
+        )
+
+    def test_non_submitted_state_returns_none(self):
+        self.study.state = "active"
+        self.assertIsNone(self.study.days_submitted)
+
+    def test_submitted_with_status_change_date(self):
+        ten_days_ago = datetime.now(timezone.utc) - timedelta(days=10)
+        self.study.state = "submitted"
+        self.study.status_change_date = ten_days_ago
+        self.study.save()
+        self.assertEqual(self.study.days_submitted, 10)
+
+    def test_submitted_null_status_change_date_falls_back_to_studylog(self):
+        five_days_ago = datetime.now(timezone.utc) - timedelta(days=5)
+        self.study.state = "submitted"
+        self.study.status_change_date = None
+        self.study.save()
+        log = StudyLog.objects.create(study=self.study, action="submitted")
+        StudyLog.objects.filter(pk=log.pk).update(created_at=five_days_ago)
+        self.assertEqual(self.study.days_submitted, 5)
+
+    def test_submitted_multiple_studylogs_uses_most_recent(self):
+        ten_days_ago = datetime.now(timezone.utc) - timedelta(days=10)
+        three_days_ago = datetime.now(timezone.utc) - timedelta(days=3)
+        self.study.state = "submitted"
+        self.study.status_change_date = None
+        self.study.save()
+        log_old = StudyLog.objects.create(study=self.study, action="submitted")
+        StudyLog.objects.filter(pk=log_old.pk).update(created_at=ten_days_ago)
+        log_recent = StudyLog.objects.create(study=self.study, action="submitted")
+        StudyLog.objects.filter(pk=log_recent.pk).update(created_at=three_days_ago)
+        self.assertEqual(self.study.days_submitted, 3)
 
 
 class VideoModelTestCase(TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -1129,11 +1129,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
 ]
 
 [[package]]

--- a/web/templates/web/studies-history.html
+++ b/web/templates/web/studies-history.html
@@ -76,7 +76,7 @@
                     </div>
                 </div>
                 <h4 class="card-title">{% trans "Study Responses" %}</h4>
-                {% for response in study.responses.all %}
+                {% for response in study.response_page %}
                     <div class="row mb-3">
                         {% if form.past_studies_tabs|studies_tab_selected == "0" %}
                             <div class="col-3 d-flex flex-column">
@@ -140,6 +140,26 @@
                         </div>
                     </div>
                 {% endfor %}
+                {% if study.response_page.paginator.num_pages > 1 %}
+                    <div class="text-end px-5">{% trans "Study responses" %}</div>
+                    <div class="text-end px-5">
+                        {% if study.response_page.has_previous %}
+                            <a class="text-decoration-none"
+                               aria-label="{% trans "Go to previous page of responses" %}"
+                               href="?{% response_page_transform request study.pk study.response_page.previous_page_number %}">
+                                {% bs_icon "chevron-left" %}
+                            </a>
+                        {% endif %}
+                        {% trans "Page" %} {{ study.response_page.number }} {% trans "of" %} {{ study.response_page.paginator.num_pages }}
+                        {% if study.response_page.has_next %}
+                            <a class="text-decoration-none"
+                               aria-label="{% trans "Go to next page of responses" %}"
+                               href="?{% response_page_transform request study.pk study.response_page.next_page_number %}">
+                                {% bs_icon "chevron-right" %}
+                            </a>
+                        {% endif %}
+                    </div>
+                {% endif %}
             </div>
         </div>
     {% empty %}
@@ -151,4 +171,8 @@
             {% endif %}
         </div>
     {% endfor %}
+    {% if object_list.paginator.num_pages > 1 %}
+        <div class="text-end px-5">{% trans "Previous studies" %}</div>
+        {% include "studies/_paginator.html" with page=object_list %}
+    {% endif %}
 {% endblock content %}

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -264,6 +264,15 @@ def button_secondary_classes(extra_classes=None):
 
 
 @register.simple_tag
+def button_primary_light_classes(extra_classes=None):
+    classes = ["btn", "btn-light", "link-primary", "border-primary"]
+    if extra_classes:
+        classes.extend([extra_classes])
+
+    return " ".join(classes)
+
+
+@register.simple_tag
 def page_title(title, right_side_elements=None):
     if right_side_elements:
         html = f"""<div class="d-flex flex-row bd-highlight mb-4 align-items-center">

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -331,3 +331,19 @@ def staff_profile(name, img, blurb, type="large"):
 @register.simple_tag
 def absolute_url(name, *args, **kwargs):
     return get_absolute_url(reverse(name, args=args, kwargs=kwargs))
+
+
+@register.simple_tag
+def response_page_transform(request, study_pk, page_number):
+    """Build a query string for per-study response pagination.
+
+    Updates response_page_<study_pk> while preserving all other GET params
+    (e.g. the study-level page number and tab selection).
+    """
+    updated = request.GET.copy()
+    key = f"response_page_{study_pk}"
+    if page_number == 1:
+        updated.pop(key, None)
+    else:
+        updated[key] = str(page_number)
+    return updated.urlencode()

--- a/web/tests/test_views.py
+++ b/web/tests/test_views.py
@@ -839,11 +839,121 @@ class OneClickUnsubcribeTestCase(TestCase):
         )
 
 
+class StudiesHistoryViewTestCase(TestCase):
+    def setUp(self):
+        self.participant = G(User, is_active=True, is_researcher=False)
+        self.child = G(Child, user=self.participant)
+        self.second_child = G(Child, user=self.participant)
+        self.other_participant = G(User, is_active=True, is_researcher=False)
+        self.other_child = G(Child, user=self.other_participant)
+        self.study_type = StudyType.get_ember_frame_player()
+        self.study = self._make_study("Test Study")
+        self.url = reverse("web:studies-history")
+
+    def _make_study(self, name="Study"):
+        small_gif = (
+            b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x00\x00\x00\x21\xf9\x04"
+            b"\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02"
+            b"\x02\x4c\x01\x00\x3b"
+        )
+        thumbnail = SimpleUploadedFile(
+            name="small.gif", content=small_gif, content_type="image/gif"
+        )
+        return G(Study, study_type=self.study_type, name=name, image=thumbnail)
+
+    def _make_response(self, child=None, study=None, completed_consent_frame=True):
+        return G(
+            Response,
+            child=child or self.child,
+            study=study or self.study,
+            study_type=self.study_type,
+            completed_consent_frame=completed_consent_frame,
+        )
+
+    def test_shows_study_with_completed_consent_frame(self):
+        """A response with completed_consent_frame=True appears even without a consent ruling (pending)."""
+        self.client.force_login(self.participant)
+        self._make_response()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        studies = list(response.context["object_list"])
+        self.assertEqual(len(studies), 1)
+        self.assertEqual(studies[0].pk, self.study.pk)
+        self.assertEqual(len(list(studies[0].response_page)), 1)
+
+    def test_shows_shows_responses_for_multiple_children(self):
+        """If a user has multiple child accounts, they can see the responses for all of their children."""
+        self.client.force_login(self.participant)
+        self._make_response(child=self.child)
+        self._make_response(child=self.second_child)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        studies = list(response.context["object_list"])
+        self.assertEqual(len(studies), 1)
+        self.assertEqual(studies[0].pk, self.study.pk)
+        self.assertEqual(len(list(studies[0].response_page)), 2)
+
+    def test_excludes_response_without_completed_consent_frame(self):
+        """A response where the consent frame was not completed should not appear."""
+        self.client.force_login(self.participant)
+        self._make_response(completed_consent_frame=False)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(list(response.context["object_list"])), 0)
+
+    def test_excludes_other_users_responses(self):
+        """Responses for another user's child should not be visible."""
+        self.client.force_login(self.participant)
+        self._make_response(child=self.other_child)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(list(response.context["object_list"])), 0)
+
+    def test_study_pagination(self):
+        """Studies are paginated at 10 per page."""
+        self.client.force_login(self.participant)
+        for i in range(11):
+            self._make_response(study=self._make_study(f"Study {i}"))
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        page = response.context["object_list"]
+        self.assertEqual(len(list(page)), 10)
+        self.assertEqual(page.paginator.num_pages, 2)
+
+        response_p2 = self.client.get(self.url, {"page": 2})
+        self.assertEqual(len(list(response_p2.context["object_list"])), 1)
+
+    def test_response_pagination(self):
+        """Responses within a study are paginated at 10 per response page."""
+        self.client.force_login(self.participant)
+        for _ in range(11):
+            self._make_response()
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        studies = list(response.context["object_list"])
+        self.assertEqual(len(studies), 1)
+        self.assertEqual(studies[0].response_page.paginator.num_pages, 2)
+        self.assertEqual(len(list(studies[0].response_page)), 10)
+
+        response_p2 = self.client.get(self.url, {f"response_page_{self.study.pk}": 2})
+        studies_p2 = list(response_p2.context["object_list"])
+        self.assertEqual(len(list(studies_p2[0].response_page)), 1)
+
+
 # TODO: StudyDetailView
 # - check can see for public or private active study, unauthenticated or authenticated
 # - check context[children] has own children
 # TODO: StudiesHistoryView
-# - check can see several sessions where consent frame was completed (but consent not marked), not for someone else's
-# child, not for consent frame incomplete.
+# - external studies
 # TODO: ExperimentAssetsProxyView
 # - check have to be authenticated, maybe that's it for now?

--- a/web/views.py
+++ b/web/views.py
@@ -38,6 +38,7 @@ from accounts.queries import (
     get_child_eligibility_for_study,
 )
 from accounts.utils import hash_id
+from exp.mixins.paginator_mixin import PaginatorMixin
 from project import settings
 from studies.helpers import get_experiment_absolute_url
 from studies.models import Lab, Response, Study, StudyType, StudyTypeEnum, Video
@@ -654,7 +655,9 @@ class LabStudiesListView(StudiesListView):
             )
 
 
-class StudiesHistoryView(LoginRequiredMixin, generic.ListView, FormView):
+class StudiesHistoryView(
+    LoginRequiredMixin, PaginatorMixin, generic.ListView, FormView
+):
     """
     List all active, public studies.
     """
@@ -662,6 +665,7 @@ class StudiesHistoryView(LoginRequiredMixin, generic.ListView, FormView):
     template_name = "web/studies-history.html"
     model = Study
     form_class = PastStudiesForm
+    responses_per_study = 10
 
     def post(self, request, *args, **kwargs):
         form = self.get_form()
@@ -677,39 +681,58 @@ class StudiesHistoryView(LoginRequiredMixin, generic.ListView, FormView):
     def get_queryset(self):
         tab_value = self.request.session.get("past_studies_tabs", "0")
 
-        response_query = Q()
+        self._response_query = Q()
         study_query = Q()
 
         if tab_value == PastStudiesFormTabChoices.lookit_studies.value[0]:
             study_query = Q(
                 study_type__name=StudyTypeEnum.ember_frame_player.value
             ) | Q(study_type__name=StudyTypeEnum.jspsych.value)
-            response_query = Q(completed_consent_frame=True)
+            self._response_query = Q(completed_consent_frame=True)
         elif tab_value == PastStudiesFormTabChoices.external_studies.value[0]:
             study_query = Q(study_type__name=StudyTypeEnum.external.value)
 
-        children_ids = Child.objects.filter(user__id=self.request.user.id).values_list(
-            "id", flat=True
-        )
-        responses = (
-            Response.objects.filter(Q(child__id__in=children_ids) & response_query)
-            .select_related("child")
-            .prefetch_related(
-                Prefetch(
-                    "videos",
-                    queryset=Video.objects.order_by("pipe_numeric_id", "s3_timestamp"),
-                ),
-                "consent_rulings",
-                "feedback",
+        self._children_ids = Child.objects.filter(
+            user__id=self.request.user.id
+        ).values_list("id", flat=True)
+
+        study_ids = Response.objects.filter(
+            Q(child__id__in=self._children_ids) & self._response_query
+        ).values_list("study_id", flat=True)
+
+        return Study.objects.filter(Q(id__in=study_ids) & study_query)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        page = self.request.GET.get("page", 1)
+        studies_page = self.paginated_queryset(context["object_list"], page, 10)
+
+        for study in studies_page:
+            response_page_num = self.request.GET.get(f"response_page_{study.pk}", 1)
+            study_responses = (
+                Response.objects.filter(
+                    Q(child__id__in=self._children_ids) & self._response_query,
+                    study=study,
+                )
+                .select_related("child")
+                .prefetch_related(
+                    Prefetch(
+                        "videos",
+                        queryset=Video.objects.order_by(
+                            "pipe_numeric_id", "s3_timestamp"
+                        ),
+                    ),
+                    "consent_rulings",
+                    "feedback",
+                )
+                .order_by("-date_created")
             )
-            .order_by("-date_created")
-        )
+            study.response_page = self.paginated_queryset(
+                study_responses, response_page_num, self.responses_per_study
+            )
 
-        study_ids = responses.values_list("study_id", flat=True)
-
-        return Study.objects.filter(Q(id__in=study_ids) & study_query).prefetch_related(
-            Prefetch("responses", queryset=responses)
-        )
+        context["object_list"] = studies_page
+        return context
 
     def get_success_url(self):
         return reverse("web:studies-history")


### PR DESCRIPTION
This PR moves the following changes from staging to production:

- Add the following management commands for staff/devs (#1851)
  - Retrieve all user data (for e.g. GDPR requests)
  - Delete video from the database and S3

- Add more search/filter options on the Manage Studies page for staff/admins (#1861 )
- Paginate the studies history page to improve loading speed and prevent 504 gateway timeout errors (#1859)
- Attempt to improve performance and prevent timeouts with large data downloads (#1863)
- Fix bug that causes errors on the Individual Responses page and in data download requests when the data contains unexpected values (EFP) or list elements (jsPsych) (#1869)