### PR TITLE
Fix exp data parsing with non-dict values

### DIFF
--- a/exp/tests/test_response_postsave.py
+++ b/exp/tests/test_response_postsave.py
@@ -165,6 +165,42 @@ class ResponseSaveHandlingTestCase(TestCase):
         self.withdrawn_response_after_exit_frame.save()  # to run post-save hook
         self.assertEqual(len(self.withdrawn_response_after_exit_frame.videos.all()), 0)
 
+    def test_exit_frame_properties_with_non_dict_value_does_not_raise(self):
+        """Accessing exit-frame-derived response properties (withdrawn, privacy, databrary)
+        should not raise when exp_data contains non-dict values."""
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study,
+            completed=False,
+            completed_consent_frame=True,
+            sequence=["0-video-config", "1-exit-frame"],
+            exp_data={
+                "0-video-config": {"frameType": "DEFAULT"},
+                "1-exit-frame": "unexpected string",
+            },
+        )
+        _ = response.withdrawn
+        _ = response.privacy
+        _ = response.databrary
+
+    def test_non_dict_exp_data_value_does_not_raise(self):
+        """Saving an EFP response where the current frame's exp_data value is not a dict
+        should not raise an error."""
+        response = G(
+            Response,
+            child=self.child,
+            study=self.study,
+            completed=False,
+            completed_consent_frame=True,
+            sequence=["0-video-config", "1-non-dict-frame"],
+            exp_data={
+                "0-video-config": {"frameType": "DEFAULT"},
+                "1-non-dict-frame": "unexpected string",
+            },
+        )
+        response.save()
+
     def test_responses_per_study_type(self):
         user = G(User)
         researcher = G(User, is_active=True, is_researcher=True, username="Researcher")
@@ -263,3 +299,28 @@ class JspsychResponseSaveHandlingTestCase(TestCase):
         self.assertFalse(self.response.videos.first().is_consent_footage)
         self.response.save()
         self.assertTrue(self.response.videos.first().is_consent_footage)
+
+    def test_non_dict_element_does_not_raise(self):
+        """Saving a jsPsych response where an exp_data element is not a dict
+        should not raise an error."""
+        self.response.exp_data = [{"chs_type": "consent", "response": {}}, "not-a-dict"]
+        self.response.sequence = ["0-consent", "1-bad"]
+        self.response.save()
+
+    def test_non_dict_only_element_does_not_raise(self):
+        """Saving a jsPsych response where the sole exp_data element is not a dict
+        should not raise an error."""
+        self.response.exp_data = ["not-a-dict"]
+        self.response.sequence = ["0-bad"]
+        self.response.save()
+
+    def test_exit_frame_properties_with_non_dict_element_does_not_raise(self):
+        """Accessing exit-frame-derived response properties (withdrawn, privacy, databrary)
+        should not raise when exp_data contains non-dict elements."""
+        self.response.exp_data = [
+            {"chs_type": "exit", "response": {"withdrawal": True}},
+            "not-a-dict",
+        ]
+        _ = self.response.withdrawn
+        _ = self.response.privacy
+        _ = self.response.databrary

--- a/exp/tests/test_response_views.py
+++ b/exp/tests/test_response_views.py
@@ -3,6 +3,7 @@ import datetime
 import io
 import json
 import re
+import uuid
 
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
@@ -12,7 +13,10 @@ from django_dynamic_fixture import G
 from accounts.backends import TWO_FACTOR_AUTH_SESSION_KEY
 from accounts.models import Child, DemographicData, User
 from accounts.utils import hash_id
-from exp.views.responses import StudyResponseSetResearcherFields
+from exp.views.responses import (
+    StudyResponseSetResearcherFields,
+    get_frame_data,
+)
 from studies.models import ConsentRuling, Lab, Response, Study, StudyType, Video
 
 
@@ -1654,6 +1658,86 @@ class ResponseViewResearcherUpdateFieldsTestCase(TestCase):
         )
         success_str = f"Response {self.response.id} field {self.editable_fields[2]} updated to {False}"
         self.assertIn(success_str, post_response.json().get("success"))
+
+
+class GetFrameDataTestCase(TestCase):
+    """Unit tests for the get_frame_data helper function."""
+
+    BASE_RESP = {
+        "child__uuid": uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        "study__uuid": uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        "study__salt": uuid.UUID("00000000-0000-0000-0000-000000000003"),
+        "study__hash_digits": 6,
+        "uuid": uuid.UUID("00000000-0000-0000-0000-000000000004"),
+        "global_event_timings": [],
+    }
+
+    def _make_resp(self, exp_data):
+        return {**self.BASE_RESP, "exp_data": exp_data}
+
+    def test_non_dict_frame_value_produces_row(self):
+        """A top-level exp_data value that is a string or int should produce a
+        FrameDataRow with that frame_id, a blank key, and the raw value — rather
+        than raising an error."""
+        resp = self._make_resp(
+            {
+                "0-intro": {"frameType": "DEFAULT", "someKey": "someValue"},
+                "top-level-string": "unexpected string",
+                "top-level-int": 42,
+            }
+        )
+        rows = get_frame_data(resp)
+
+        frame_ids = [row.frame_id for row in rows]
+        self.assertIn("top-level-string", frame_ids)
+        self.assertIn("top-level-int", frame_ids)
+
+        string_row = next(r for r in rows if r.frame_id == "top-level-string")
+        self.assertEqual(string_row.key, "")
+        self.assertEqual(string_row.value, "unexpected string")
+
+        int_row = next(r for r in rows if r.frame_id == "top-level-int")
+        self.assertEqual(int_row.key, "")
+        self.assertEqual(int_row.value, 42)
+
+    def test_jspsych_non_dict_list_element_produces_row(self):
+        """For jsPsych responses, normalized_exp_data zips sequence with exp_data into a
+        dict. A non-dict element in the list becomes a non-dict value in that dict. It
+        should produce a row with a blank key and the raw value rather than raising."""
+        # Simulate what normalized_exp_data returns for a jsPsych response where one
+        # trial's data is a bare string.
+        resp = self._make_resp(
+            {
+                "0-survey-likert": {
+                    "trial_type": "survey-likert",
+                    "response": {"q0": 3},
+                },
+                "1-bad-trial": "unexpected string",
+            }
+        )
+        rows = get_frame_data(resp)
+
+        frame_ids = [row.frame_id for row in rows]
+        self.assertIn("1-bad-trial", frame_ids)
+
+        bad_row = next(r for r in rows if r.frame_id == "1-bad-trial")
+        self.assertEqual(bad_row.key, "")
+        self.assertEqual(bad_row.value, "unexpected string")
+
+    def test_normal_dict_frame_values_still_included(self):
+        """Normal dict-valued frames should still produce rows as expected."""
+        resp = self._make_resp(
+            {"0-intro": {"frameType": "DEFAULT", "someKey": "someValue"}}
+        )
+        rows = get_frame_data(resp)
+
+        frame_ids = [row.frame_id for row in rows]
+        self.assertIn("0-intro", frame_ids)
+
+        key_row = next(
+            r for r in rows if r.frame_id == "0-intro" and r.key == "someKey"
+        )
+        self.assertEqual(key_row.value, "someValue")
 
     # TODO: test individual file downloads from response-list
     #       * cannot get response from another study,

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -266,6 +266,18 @@ def get_frame_data(resp: Union[Response, Dict]) -> List[FrameDataRow]:
     # Next add all data in exp_data
     event_prefix = "eventTimings."
     for frame_id, frame_data in resp["exp_data"].items():
+        if not isinstance(frame_data, dict):
+            frame_data_tuples.append(
+                FrameDataRow(
+                    child_hashed_id=child_hashed_id,
+                    response_uuid=str(resp["uuid"]),
+                    frame_id=frame_id,
+                    key="",
+                    event_number="",
+                    value=frame_data,
+                )
+            )
+            continue
         for key, value in flatten_dict(frame_data).items():
             # Process event data separately and include event_number within frame
             if key.startswith(event_prefix):

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -178,10 +178,14 @@ class FrameActionDispatcher(object):
 
         if response.study_type.is_jspsych:
             exp_data = response.exp_data[-1]
+            if not isinstance(exp_data, dict):
+                return
             frame_data = exp_data.get("response")
             frame_type = exp_data.get("chs_type")
         elif response.study_type.is_ember_frame_player:
             frame_data = response.exp_data[current_frame_id]
+            if not isinstance(frame_data, dict):
+                return
             frame_type = frame_data.get("frameType")
 
         if not frame_type:

--- a/studies/models.py
+++ b/studies/models.py
@@ -1166,7 +1166,7 @@ class Response(models.Model):
         exit_frame_values = [
             f.get(property, None)
             for f in self.exp_data.values()
-            if f.get("frameType", None) == "EXIT"
+            if isinstance(f, dict) and f.get("frameType", None) == "EXIT"
         ]
         if exit_frame_values and exit_frame_values != [None]:
             return exit_frame_values[-1]
@@ -1174,7 +1174,9 @@ class Response(models.Model):
             return None
 
     def exit_frame_properties_jspsych(self, property):
-        exit_frame_filter_fn = lambda x: x.get("chs_type") == "exit"
+        exit_frame_filter_fn = (
+            lambda x: isinstance(x, dict) and x.get("chs_type") == "exit"
+        )
         exit_frame_filter = filter(exit_frame_filter_fn, self.exp_data)
         exit_frame_list = list(exit_frame_filter)
 
@@ -1479,7 +1481,8 @@ class Video(models.Model):
         # >95% of the time.
         is_consent_footage = (
             marked_as_consent
-            or response.exp_data.get(frame_id, {}).get("frameType", "") == "CONSENT"
+            or isinstance(response.exp_data.get(frame_id), dict)
+            and response.exp_data[frame_id].get("frameType", "") == "CONSENT"
         )
 
         # Once we've completed the renaming, create our db object referencing it


### PR DESCRIPTION
Fixes https://github.com/lookit/lookit-api/issues/1868

This PR adds some defensive guards against unexpected non-dict values associated with frame ID keys (EFP) and non-dict elements in the exp data array (jsPsych). It prevents errors that are thrown when trying to access attributes/keys on non-dict elements. It also attempts to retain the unexpected values when converting the exp data to rows ("frame data").

This also adds unit tests to cover unexpected strings/ints in the data.

Note: this PR does not cover all possible cases of malformed data structures, and all unexpected value/element types when converting data to rows (e.g. lists). In the future we may need to add more guards and parsing cases, and/or prevent researchers from arbitrarily modifying the experiment data.