### PR TITLE
Add lab page license info and response stats

### DIFF
--- a/exp/views/lab.py
+++ b/exp/views/lab.py
@@ -73,6 +73,7 @@ class LabDetailView(
         context["custom_url"] = self.request.build_absolute_uri(
             reverse("web:lab-studies-list", args=[lab.slug])
         )
+        context["lab_stats"] = lab.get_response_stats()
         return context
 
 

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -120,6 +120,15 @@ class LabForm(ModelForm):
             "badge": "This image will be shown at the top of your custom URL page when it is viewed on a mobile device/narrow browser window, and as a badge/avatar image for your lab. This image should be square. Please keep your file size less than 1 MB.",
         }
 
+    def clean_description(self):
+        """Lazy, on-demand fix for malformed lab description values in the database that contain literal \r\n strings."""
+        description = self.cleaned_data.get("description", "")
+        return (
+            description.replace("\\r\\n", "\n")
+            .replace("\\r", "\n")
+            .replace("\\n", "\n")
+        )
+
     def clean_banner(self):
         cleaned_banner = self.cleaned_data["banner"]
         ratio = 2

--- a/studies/migrations/0107_add_lab_created_at.py
+++ b/studies/migrations/0107_add_lab_created_at.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("studies", "0106_add_researcher_valid_response"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="lab",
+            name="created_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/studies/models.py
+++ b/studies/models.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 
 import boto3
@@ -169,6 +169,37 @@ class Lab(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.principal_investigator_name}, {self.institution})"
+
+    def save(self, *args, **kwargs):
+        if self._state.adding and self.created_at is None:
+            self.created_at = dutimezone.now()
+        super().save(*args, **kwargs)
+
+    def get_response_stats(self) -> dict:
+        """Return tallied response counts for this lab, broken down by study type and time range.
+
+        Uses effective_is_tallied logic: researcher override takes precedence over is_tallied.
+        """
+        one_year_ago = dutimezone.now() - timedelta(days=365)
+
+        # StudyType id=2 is external (consistent with StudyType.is_external)
+        base_qs = Response.objects.filter(study__lab=self).filter(EFFECTIVELY_TALLIED_Q)
+        internal_qs = base_qs.exclude(study__study_type__id=2)
+        external_qs = base_qs.filter(study__study_type__id=2)
+
+        internal_all = internal_qs.count()
+        internal_year = internal_qs.filter(date_created__gte=one_year_ago).count()
+        external_all = external_qs.count()
+        external_year = external_qs.filter(date_created__gte=one_year_ago).count()
+
+        return {
+            "internal_all_time": internal_all,
+            "internal_last_year": internal_year,
+            "external_all_time": external_all,
+            "external_last_year": external_year,
+            "total_all_time": internal_all + external_all,
+            "total_last_year": internal_year + external_year,
+        }
 
 
 # Using Direct foreign keys for guardian, see:

--- a/studies/models.py
+++ b/studies/models.py
@@ -161,6 +161,7 @@ class Lab(models.Model):
     )
     banner = models.ImageField(null=True, blank=True, upload_to="lab_images/")
     badge = models.ImageField(null=True, blank=True, upload_to="lab_images/")
+    created_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         permissions = LabPermission

--- a/studies/models.py
+++ b/studies/models.py
@@ -54,6 +54,12 @@ ACCEPTED = "accepted"
 REJECTED = "rejected"
 CONSENT_RULINGS = (ACCEPTED, REJECTED, PENDING)
 
+# It would've made more sense to put this in queries.py and import it here, but queries.py imports from this file, so doing it the other way around avoids a circular import.
+EFFECTIVELY_TALLIED_Q = models.Q(
+    is_tallied_researcher_override__isnull=False,
+    is_tallied_researcher_override=True,
+) | models.Q(is_tallied_researcher_override__isnull=True, is_tallied=True)
+
 S3_RESOURCE = boto3.resource("s3")
 S3_BUCKET = S3_RESOURCE.Bucket(settings.BUCKET_NAME)
 
@@ -566,11 +572,7 @@ class Study(models.Model):
         Returns:
             int: Count of tallied responses
         """
-        is_effectively_tallied = models.Q(
-            is_tallied_researcher_override__isnull=False,
-            is_tallied_researcher_override=True,
-        ) | models.Q(is_tallied_researcher_override__isnull=True, is_tallied=True)
-        return self.responses.filter(is_effectively_tallied).count()
+        return self.responses.filter(EFFECTIVELY_TALLIED_Q).count()
 
     @property
     def has_reached_max_responses(self) -> bool:

--- a/studies/queries.py
+++ b/studies/queries.py
@@ -24,6 +24,7 @@ from guardian.shortcuts import get_objects_for_user
 from attachment_helpers import get_url
 from studies.models import (
     ACCEPTED,
+    EFFECTIVELY_TALLIED_Q,
     PENDING,
     REJECTED,
     ConsentRuling,
@@ -290,10 +291,6 @@ def get_response_type_counts_external(study) -> Dict:
     - tallied: all effectively tallied non-preview responses
     - total: all responses (preview/tallied/untallied)
     """
-    is_effectively_tallied = Q(
-        is_tallied_researcher_override__isnull=False,
-        is_tallied_researcher_override=True,
-    ) | Q(is_tallied_researcher_override__isnull=True, is_tallied=True)
     is_effectively_untallied = Q(
         is_tallied_researcher_override__isnull=False,
         is_tallied_researcher_override=False,
@@ -301,7 +298,7 @@ def get_response_type_counts_external(study) -> Dict:
 
     counts = study.responses.aggregate(
         preview=Count("id", filter=Q(is_preview=True)),
-        tallied=Count("id", filter=Q(is_preview=False) & is_effectively_tallied),
+        tallied=Count("id", filter=Q(is_preview=False) & EFFECTIVELY_TALLIED_Q),
         untallied=Count("id", filter=Q(is_preview=False) & is_effectively_untallied),
     )
     counts["total"] = counts["preview"] + counts["tallied"] + counts["untallied"]
@@ -330,10 +327,6 @@ def get_response_type_counts(study) -> Dict:
     - total_rejected: all responses with rejected consent (preview_rejected + nonpreview_rejected)
     - total: total_available + total_pending + total_rejected
     """
-    is_effectively_tallied = Q(
-        is_tallied_researcher_override__isnull=False,
-        is_tallied_researcher_override=True,
-    ) | Q(is_tallied_researcher_override__isnull=True, is_tallied=True)
     is_effectively_untallied = Q(
         is_tallied_researcher_override__isnull=False,
         is_tallied_researcher_override=False,
@@ -355,12 +348,12 @@ def get_response_type_counts(study) -> Dict:
         tallied_approved=Count(
             "id",
             filter=Q(is_preview=False)
-            & is_effectively_tallied
+            & EFFECTIVELY_TALLIED_Q
             & Q(current_ruling="accepted"),
         ),
         tallied_pending=Count(
             "id",
-            filter=Q(is_preview=False) & is_effectively_tallied & is_pending_ruling,
+            filter=Q(is_preview=False) & EFFECTIVELY_TALLIED_Q & is_pending_ruling,
         ),
         untallied_approved=Count(
             "id",

--- a/studies/templates/studies/lab_detail.html
+++ b/studies/templates/studies/lab_detail.html
@@ -28,66 +28,92 @@
     {% endif %}
     {% set_variable link_edit_lab|add:link_lab_members|add:lab_join_message as page_title_right_content %}
     {% page_title lab.name right_side_elements=page_title_right_content %}
-    <div class="row">
-        <div class="col-12">
-            <strong>Institution</strong>
-            <p>{{ lab.institution }}</p>
+    <div class="row my-4">
+        <div class="col-12 {% if in_this_lab %}col-lg-6 mb-4 mb-lg-0 gx-5{% endif %}" style="min-width: 320px;">
+            <div class="mb-3">
+                <strong>Institution</strong>
+                <p class="mb-0">{{ lab.institution }}</p>
+            </div>
+            <div class="mb-3">
+                <strong>Principal investigator</strong>
+                <p class="mb-0">{{ lab.principal_investigator_name }}</p>
+            </div>
+            <div class="mb-3">
+                <strong>Contact email</strong>
+                <p class="mb-0">{{ lab.contact_email }}</p>
+            </div>
+            <div class="mb-3">
+                <strong>Contact phone</strong>
+                <p class="mb-0">{{ lab.contact_phone }}</p>
+            </div>
+            <div class="mb-3">
+                <strong>Lab website</strong>
+                <p class="mb-0">
+                    <a href="{{ lab.lab_website }}"
+                       target="_blank"
+                       rel="noopener noreferrer">{{ lab.lab_website }}</a>
+                </p>
+            </div>
+            <div class="mb-3">
+                <strong>Custom URL</strong>
+                <p class="mb-0">
+                    <a href="{% url 'web:lab-studies-list' lab.slug %}"
+                       target="_blank"
+                       rel="noopener noreferrer">{{ custom_url }}</a>
+                </p>
+            </div>
+            <div class="mb-3">
+                <strong>Lab description</strong>
+                <p class="mb-0">{{ lab.description|linebreaks }}</p>
+            </div>
+            <div class="mb-3">
+                <strong>IRB contact info</strong>
+                <p class="mb-0">{{ lab.irb_contact_info }}</p>
+            </div>
+            <div class="mb-3">
+                <strong>Approved to test:</strong>
+                {{ lab.approved_to_test|yesno:"Yes,No" }}
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <strong>Principal investigator</strong>
-            <p>{{ lab.principal_investigator_name }}</p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <strong>Contact email</strong>
-            <p>{{ lab.contact_email }}</p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <strong>Contact phone</strong>
-            <p>{{ lab.contact_phone }}</p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <strong>Lab website</strong>
-            <p>
-                <a href="{{ lab.lab_website }}"
-                   target="_blank"
-                   rel="noopener noreferrer">{{ lab.lab_website }}</a>
-            </p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <strong>Custom URL</strong>
-            <p>
-                <a href="{% url 'web:lab-studies-list' lab.slug %}"
-                   target="_blank"
-                   rel="noopener noreferrer">{{ custom_url }}</a>
-            </p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <strong>Lab description</strong>
-            {{ lab.description|linebreaks }}
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <strong>IRB contact info</strong>
-            <p>{{ lab.irb_contact_info }}</p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <strong>Approved to test:</strong>
-            {{ lab.approved_to_test|yesno:"Yes,No" }}
-        </div>
+        {% if in_this_lab %}
+            <div class="col-12 col-lg-6 gx-5" style="min-width: 320px;">
+                <div>
+                    <strong>CHS License and Usage</strong>
+                    <div class="border border-3 border-primary mt-2 mb-4 p-3">The {{ lab.name }} is using Children Helping Science under a free license (through 2026-12-31).</div>
+                    <div>Response sessions collected through the CHS platform:</div>
+                    <table class="table mb-2">
+                        <caption class="visually-hidden">Response sessions collected through the CHS platform by study type and time range.</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col"></th>
+                                <th scope="col" class="text-center">Internal</th>
+                                <th scope="col" class="text-center">External</th>
+                                <th scope="col" class="text-center">Total</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <th scope="row">Last 12 months</th>
+                                <td class="text-center">{{ lab_stats.internal_last_year }}</td>
+                                <td class="text-center">{{ lab_stats.external_last_year }}</td>
+                                <td class="text-center">{{ lab_stats.total_last_year }}</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">
+                                    {% if lab.created_at %}
+                                        Since {{ lab.created_at|date:"N j, Y" }}
+                                    {% else %}
+                                        All time
+                                    {% endif %}</th>
+                                <td class="text-center">{{ lab_stats.internal_all_time }}</td>
+                                <td class="text-center">{{ lab_stats.external_all_time }}</td>
+                                <td class="text-center">{{ lab_stats.total_all_time }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p class="text-muted small mb-0">Note: Session counts reflect the number of “tallied” sessions across all of your studies, including only non-preview responses from eligible children. For internal studies only, tallied sessions are also limited to those which are marked complete and have a consent status of approved or pending. See <a href="https://lookit.readthedocs.io/en/master/researchers-set-study-fields.html#set-a-response-limit" target="_blank" rel="noopener">documentation</a> for additional detail on session tallies and how to submit individual session updates.</p>
+                </div>
+            </div>
+        {% endif %}
     </div>
 {% endblock content %}

--- a/studies/templates/studies/lab_detail.html
+++ b/studies/templates/studies/lab_detail.html
@@ -64,7 +64,7 @@
             </div>
             <div class="mb-3">
                 <strong>Lab description</strong>
-                <p class="mb-0">{{ lab.description|linebreaks }}</p>
+                <p class="mb-0">{{ lab.description|squash_spaces|linebreaks }}</p>
             </div>
             <div class="mb-3">
                 <strong>IRB contact info</strong>

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -2846,3 +2846,177 @@ class CheckModificationOfApprovedStudyTestCase(TestCase):
         self.study.save()
         self.study.refresh_from_db()
         self.assertEqual(self.study.state, "rejected")
+
+
+class LabCreatedAtTestCase(TestCase):
+    """Tests for Lab.created_at auto-population on save."""
+
+    def _make_lab(self, name, email):
+        return Lab.objects.create(name=name, institution="Test", contact_email=email)
+
+    def test_created_at_set_on_new_lab(self):
+        lab = self._make_lab("New Lab", "new@lab.com")
+        lab.refresh_from_db()
+        self.assertIsNotNone(lab.created_at)
+
+    def test_created_at_not_overwritten_on_resave(self):
+        lab = self._make_lab("Resave Lab", "resave@lab.com")
+        original_created_at = lab.created_at
+        lab.institution = "Changed"
+        lab.save()
+        lab.refresh_from_db()
+        self.assertEqual(lab.created_at, original_created_at)
+
+    def test_null_created_at_stays_null_on_resave(self):
+        """Labs with null created_at (simulating pre-migration rows) keep null after a subsequent save."""
+        lab = self._make_lab("Null Lab", "null@lab.com")
+        Lab.objects.filter(pk=lab.pk).update(created_at=None)
+        lab.refresh_from_db()
+        self.assertIsNone(lab.created_at)
+        lab.institution = "Updated"
+        lab.save()
+        lab.refresh_from_db()
+        self.assertIsNone(lab.created_at)
+
+
+class LabGetResponseStatsTestCase(TestCase):
+    """Tests for Lab.get_response_stats() using the effective-is-tallied logic."""
+
+    def setUp(self):
+        self.lab = Lab.objects.create(
+            name="Stats Lab", institution="Test", contact_email="stats@lab.com"
+        )
+        self.other_lab = Lab.objects.create(
+            name="Other Lab", institution="Test", contact_email="other@lab.com"
+        )
+        self.internal_study = Study.objects.create(
+            name="Internal Study",
+            lab=self.lab,
+            study_type=StudyType.get_ember_frame_player(),
+        )
+        self.external_study = Study.objects.create(
+            name="External Study",
+            lab=self.lab,
+            study_type=StudyType.get_external(),
+        )
+        self.other_study = Study.objects.create(
+            name="Other Lab Study",
+            lab=self.other_lab,
+            study_type=StudyType.get_ember_frame_player(),
+        )
+        self.user = User.objects.create(is_active=True)
+        self.child = Child.objects.create(
+            user=self.user, birthday=date.today() - timedelta(days=365)
+        )
+
+    def _make_response(self, study, tallied=True, override=None):
+        """Create a response whose is_tallied matches `tallied`, optionally with a researcher override."""
+        eligibility = (
+            [ResponseEligibility.ELIGIBLE]
+            if tallied
+            else [ResponseEligibility.INELIGIBLE_OLD]
+        )
+        r = Response.objects.create(
+            study=study,
+            child=self.child,
+            study_type=study.study_type,
+            completed=True,
+            completed_consent_frame=True,
+            is_preview=False,
+        )
+        # Second save sets eligibility (first save auto-computed it from child/study age range)
+        r.eligibility = eligibility
+        r.save()
+        r.refresh_from_db()  # ensure is_tallied reflects the signal-computed DB value
+        if override is not None:
+            r.is_tallied_researcher_override = override
+            r.save()
+        return r
+
+    def test_empty_lab_returns_zeros(self):
+        stats = self.lab.get_response_stats()
+        for key in (
+            "internal_all_time",
+            "external_all_time",
+            "total_all_time",
+            "internal_last_year",
+            "external_last_year",
+            "total_last_year",
+        ):
+            self.assertEqual(stats[key], 0, f"Expected 0 for {key}")
+
+    def test_counts_tallied_internal_responses(self):
+        self._make_response(self.internal_study, tallied=True)
+        self._make_response(self.internal_study, tallied=True)
+        self._make_response(
+            self.internal_study, tallied=False
+        )  # untallied, should not count
+        stats = self.lab.get_response_stats()
+        self.assertEqual(stats["internal_all_time"], 2)
+        self.assertEqual(stats["external_all_time"], 0)
+        self.assertEqual(stats["total_all_time"], 2)
+
+    def test_counts_tallied_external_responses(self):
+        self._make_response(self.external_study, tallied=True)
+        self._make_response(
+            self.external_study, tallied=False
+        )  # untallied, should not count
+        stats = self.lab.get_response_stats()
+        self.assertEqual(stats["internal_all_time"], 0)
+        self.assertEqual(stats["external_all_time"], 1)
+        self.assertEqual(stats["total_all_time"], 1)
+
+    def test_mixed_study_types_breakdown(self):
+        self._make_response(self.internal_study, tallied=True)
+        self._make_response(self.internal_study, tallied=True)
+        self._make_response(self.external_study, tallied=True)
+        stats = self.lab.get_response_stats()
+        self.assertEqual(stats["internal_all_time"], 2)
+        self.assertEqual(stats["external_all_time"], 1)
+        self.assertEqual(stats["total_all_time"], 3)
+
+    def test_researcher_override_true_counts_untallied_response(self):
+        """Override=True on an untallied response makes it effectively tallied."""
+        r = self._make_response(self.internal_study, tallied=False)
+        self.assertFalse(r.is_tallied)
+        r.is_tallied_researcher_override = True
+        r.save()
+        stats = self.lab.get_response_stats()
+        self.assertEqual(stats["internal_all_time"], 1)
+
+    def test_researcher_override_false_excludes_tallied_response(self):
+        """Override=False on a tallied response makes it effectively untallied."""
+        r = self._make_response(self.internal_study, tallied=True)
+        self.assertTrue(r.is_tallied)
+        r.is_tallied_researcher_override = False
+        r.save()
+        stats = self.lab.get_response_stats()
+        self.assertEqual(stats["internal_all_time"], 0)
+
+    def test_last_year_excludes_responses_older_than_365_days(self):
+        recent = self._make_response(self.internal_study, tallied=True)  # noqa: F841
+        old = self._make_response(self.internal_study, tallied=True)
+        two_years_ago = datetime.now(timezone.utc) - timedelta(days=730)
+        Response.objects.filter(pk=old.pk).update(date_created=two_years_ago)
+
+        stats = self.lab.get_response_stats()
+        self.assertEqual(stats["internal_all_time"], 2)
+        self.assertEqual(stats["internal_last_year"], 1)
+
+    def test_last_year_totals_sum_correctly(self):
+        self._make_response(self.internal_study, tallied=True)
+        self._make_response(self.external_study, tallied=True)
+        old_ext = self._make_response(self.external_study, tallied=True)
+        two_years_ago = datetime.now(timezone.utc) - timedelta(days=730)
+        Response.objects.filter(pk=old_ext.pk).update(date_created=two_years_ago)
+
+        stats = self.lab.get_response_stats()
+        self.assertEqual(stats["total_all_time"], 3)
+        self.assertEqual(stats["total_last_year"], 2)
+
+    def test_does_not_count_other_lab_responses(self):
+        self._make_response(self.other_study, tallied=True)
+        self._make_response(self.other_study, tallied=True)
+        stats = self.lab.get_response_stats()
+        self.assertEqual(stats["total_all_time"], 0)
+        self.assertEqual(stats["total_last_year"], 0)

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -2994,7 +2994,7 @@ class LabGetResponseStatsTestCase(TestCase):
         self.assertEqual(stats["internal_all_time"], 0)
 
     def test_last_year_excludes_responses_older_than_365_days(self):
-        recent = self._make_response(self.internal_study, tallied=True)  # noqa: F841
+        self._make_response(self.internal_study, tallied=True)
         old = self._make_response(self.internal_study, tallied=True)
         two_years_ago = datetime.now(timezone.utc) - timedelta(days=730)
         Response.objects.filter(pk=old.pk).update(date_created=two_years_ago)

--- a/web/templatetags/web_extras.py
+++ b/web/templatetags/web_extras.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 from typing import Text
 
@@ -356,3 +357,13 @@ def response_page_transform(request, study_pk, page_number):
     else:
         updated[key] = str(page_number)
     return updated.urlencode()
+
+
+@register.filter(name="squash_spaces")
+def squash_spaces(value):
+    """Collapses runs of spaces/tabs to a single space, preserving newlines.
+    Also normalizes literal backslash-r-backslash-n escape sequences to actual newlines."""
+    if isinstance(value, str):
+        value = value.replace("\\r\\n", "\n").replace("\\r", "\n").replace("\\n", "\n")
+        return re.sub(r"[^\S\r\n]+", " ", value)
+    return value


### PR DESCRIPTION
Fixes #1888 

This PR adds the subscription license and platform use history to lab pages. It shows the number of tallied responses by study type (internal, external) and time range (last 12 months, all time). This information is only visible to users who are members of that lab.

## Screenshots

<img width="1277" height="793" alt="Screenshot 2026-06-04 at 4 57 52 PM" src="https://github.com/user-attachments/assets/c18f138e-fb47-4247-9b6a-782ca244ec09" />

Longer lab description:

<img width="1378" height="897" alt="Screenshot 2026-06-04 at 4 55 59 PM" src="https://github.com/user-attachments/assets/1cb0dff4-8ad4-4f6e-8f2b-8fbc2289e282" />

The columns will stack on narrow screens:

<img width="804" height="849" alt="Screenshot 2026-06-04 at 4 56 45 PM" src="https://github.com/user-attachments/assets/9a14a724-8c64-43e8-84d4-618ff5516f90" />
