### PR TITLE
Fix email unsubscribe error

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,8 +1,11 @@
 import base64
 import hashlib
+import logging
 import uuid
 from io import BytesIO
 from typing import Union
+
+logger = logging.getLogger(__name__)
 
 import pydenticon
 import pyotp
@@ -681,6 +684,12 @@ class Message(models.Model):
         recipient_email_list = list(self.recipients.values_list("username", flat=True))
 
         for to_email in recipient_email_list:
+            if not to_email or "@" not in to_email:
+                logger.warning(
+                    "Skipping custom email recipient: username %s is not a valid email address.",
+                    to_email,
+                )
+                continue
             user = User.objects.get(username=to_email)
             context.update(token=user.generate_token(), username=to_email)
             send_mail.delay(

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -179,6 +179,14 @@ def _deserialized(user_grouped_targets, number_of_parents: int = 100):
 def _validated(deserialized_groups):
     """Yield only groups with targets that satisfy criteria for their respective studies."""
     for user, child_study_pairs in deserialized_groups:
+        if not user or not user.username or "@" not in user.username:
+            # Skip users that were deleted between the SQL query and ORM cache lookup,
+            # or who have no email address (which would break unsubscribe URL generation).
+            logger.warning(
+                "Skipping announcement email target: user %s has no valid username.",
+                getattr(user, "id", None),
+            )
+            continue
         valid_message_targets = []
         for pair in child_study_pairs:
             child, study = pair

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -37,6 +37,7 @@ from studies.models import (
 from studies.permissions import StudyPermission
 from studies.tasks import (
     MessageTarget,
+    _validated,
     acquire_potential_announcement_email_targets,
     cleanup_incomplete_video_uploads,
     complete_multipart_upload,
@@ -662,6 +663,22 @@ class TestAnnouncementEmailFunctionality(TestCase):
         # Check that the message target no longer has this child for this study
         self.assertNotIn(message_target, potential_message_targets())
 
+    def test_validated_skips_none_user(self):
+        result = list(_validated([(None, [])]))
+        self.assertEqual(result, [])
+
+    def test_validated_skips_user_with_empty_username(self):
+        mock_user = MagicMock()
+        mock_user.username = ""
+        result = list(_validated([(mock_user, [])]))
+        self.assertEqual(result, [])
+
+    def test_validated_skips_user_with_non_email_username(self):
+        mock_user = MagicMock()
+        mock_user.username = "debuguser"
+        result = list(_validated([(mock_user, [])]))
+        self.assertEqual(result, [])
+
 
 class TestSendMail(TestCase):
     def setUp(self):
@@ -816,6 +833,55 @@ class TestEmailHeaders(TestCase):
         context = {"token": self.context["token"]}
         headers = Message.email_headers(context)
         self.assertIsNone(headers)
+
+
+class TestSendAsEmail(TestCase):
+    def setUp(self):
+        self.fake_lab = G(Lab, contact_email="lab@example.com")
+        self.study = G(
+            Study,
+            lab=self.fake_lab,
+            image=SimpleUploadedFile(
+                "fake_image.png", b"fake-stuff", content_type="image/png"
+            ),
+            study_type=StudyType.get_ember_frame_player(),
+        )
+        self.message = G(
+            Message, related_study=self.study, subject="Test Subject", body="Test body"
+        )
+
+    @patch("accounts.models.send_mail")
+    def test_send_as_email_skips_recipient_with_non_email_username(
+        self, mock_send_mail
+    ):
+        invalid_user = G(User, username="notanemail")
+        self.message.recipients.add(invalid_user)
+
+        self.message.send_as_email()
+
+        mock_send_mail.delay.assert_not_called()
+
+    @patch("accounts.models.send_mail")
+    def test_send_as_email_skips_recipient_with_empty_username(self, mock_send_mail):
+        invalid_user = User(username="")
+        invalid_user.save()
+        self.message.recipients.add(invalid_user)
+
+        self.message.send_as_email()
+
+        mock_send_mail.delay.assert_not_called()
+
+    @patch("accounts.models.send_mail")
+    def test_send_as_email_sends_to_valid_recipients_only(self, mock_send_mail):
+        valid_user = G(User, username="valid@example.com")
+        invalid_user = G(User, username="notanemail")
+        self.message.recipients.add(valid_user, invalid_user)
+
+        self.message.send_as_email()
+
+        mock_send_mail.delay.assert_called_once()
+        call_args = mock_send_mail.delay.call_args
+        self.assertEqual(call_args[0][2], "valid@example.com")
 
 
 class StudyTypeModelTestCase(TestCase):


### PR DESCRIPTION
This PR fixes an error that occurs when the site attempts to send an email to a user that (1) doesn't exist, because it was loaded in cache but then deleted, (2) username is an empty string, or (3) username does not contain an @ symbol. These cases were throwing uncaught errors, and now they are skipped with a log warning. These edge cases mostly affect dev environments but it doesn't hurt to handle them in staging/production.

This PR also adds tests to cover these cases.