### PR TITLE
add survey likert plugin to jspsych study template

### DIFF
--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -82,6 +82,9 @@
         <script src="https://unpkg.com/@jspsych/plugin-survey-multi-choice@2.1.0"
                 integrity="sha384-NDx/PP6brJOK2yI3xA9yYbsgRe6I7BUZ3jcBD9aiVRWNYiei88wLmzsMEdWGJXOr"
                 crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/@jspsych/plugin-survey-likert@2.2.0"
+                integrity="sha384-88dibDOm9kxaXAwTWWQWZa1+0RBPA6WNU0lrWYLfeMEIQgovura7DxPG9kPXrBRc"
+                crossorigin="anonymous"></script>
         <script src="https://unpkg.com/@jspsych/plugin-fullscreen@2.1.0" 
                 integrity="sha384-JQEV9wMXFDbTpp1eYJSU9G7uQeyZcLGabno5ZHQJGytUBG19mTZ+ZBV5dsm7m6Mf"
                 crossorigin="anonymous"></script>


### PR DESCRIPTION
This PR adds the [jsPsych survey likert plugin](https://www.jspsych.org/latest/plugins/survey-likert/) to the jsPsych study template, so that researchers can use it.