### PR TITLE
Domain migration dynamic URLs

### DIFF
--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -43,6 +43,7 @@ from exp.views.mixins import (
     StudyLookupMixin,
 )
 from exp.views.responses_data import DEMOGRAPHIC_COLUMNS, RESPONSE_COLUMNS
+from studies.helpers import get_absolute_url
 from studies.models import Feedback, Response, Study, Video
 from studies.permissions import StudyPermission
 from studies.queries import (
@@ -543,7 +544,7 @@ def build_zip_for_psychds(
             "README.md",
             PSYCHDS_README_STR.format(
                 study_title=study.name,
-                study_url=f'"https://childrenhelpingscience.com/exp/studies/{study.id}/responses/all/"',
+                study_url=f'"{get_absolute_url(reverse("exp:study-responses-all", kwargs={"pk": study.id}))}"',
                 download_date=str(
                     datetime.datetime.now().strftime("%A, %B %d, %Y at %I:%M %p")
                 ),

--- a/studies/templates/studies/study_participant_analytics.html
+++ b/studies/templates/studies/study_participant_analytics.html
@@ -81,7 +81,7 @@
                 </p>
                 <p class="help-block">
                     Please note that demographic survey data may never be published such that it could be linked to an individual
-                    participant's video (see <a href="https://lookit.mit.edu/termsofuse/">Terms of Use</a>). Before sharing any demographic data, consider whether it
+                    participant's video (see <a href="{% url 'web:termsofuse' %}">Terms of Use</a>). Before sharing any demographic data, consider whether it
                     might be possible to link to individual participants: e.g., because a child's name is mentioned
                     in a comment or because only one family speaks a particular language and that language is
                     used in their video.

--- a/web/templates/web/faq.html
+++ b/web/templates/web/faq.html
@@ -564,9 +564,10 @@
                  aria-labelledby="heading-21"
                  data-bs-parent="#faq-accordion-participation">
                 <div class="accordion-body">
+                    {% url 'web:publications' as publications_url %}
                     {% blocktranslate %} <p>You should expect to get an explanation about the purpose of every study you participate in when you consent to the study. At the end of the study, especially when it is a video chat, you should have a chance to ask any questions you like.</p> <p>In general though, the goal of research studies is to learn about children in general, not any particular child. Thus, the information we get is usually not appropriate for making diagnoses or assessing the performance of individuals. For instance, while it might be interesting to learn that your child looked 70% of the time at videos where things fell up versus falling down today, we won't be able to tell you whether this means your child is going to be especially good at physics.</p>
                 <p>If you're interested in getting individual results right away, please see our <a href='resources'>Resources</a> section for fun at-home activities you can try with your child.</p>
-                <p>Researchers usually aim to share the general results of studies in scientific journals (e.g., “The majority of three-year-olds chose option A; the majority of five-year-olds chose option B."). You can click <a href = "https://childrenhelpingscience.com/publications">here</a> to see some examples of scientific research published with data collected online with children.</p>
+                <p>Researchers usually aim to share the general results of studies in scientific journals (e.g., “The majority of three-year-olds chose option A; the majority of five-year-olds chose option B."). You can click <a href = "{{ publications_url }}">here</a> to see some examples of scientific research published with data collected online with children.</p>
                 <p>There can be a long lag between conducting a study and publication -- your five-year-olds might be eight-year-olds before the results are in press! So in addition to scientific publications, many of the labs that post studies on this website have ways for parents to sign up to receive updates. You can also set your communication preferences to be notified by Children Helping Science when we have results from studies you participated in.</p>
                 {% endblocktranslate %}
                 </div>
@@ -746,8 +747,9 @@
                         <a href="https://lookit.readthedocs.io/en/develop/researchers-start-here.html">{% trans "documentation" %}</a>
                         {% trans "for a complete guide to posting your studies on Children Helping Science!" %}
                     </p>
+                    {% url 'web:termsofuse' as termsofuse_url %}
                     {% blocktranslate %}
-                <p>In order to list your study on this website, you first will need to have your institution sign a contract with MIT where they agree to the <a href="https://lookit.mit.edu/termsofuse">Terms of Use</a> and certify that their studies will be reviewed and approved by an institutional review board. You will also need to edit your IRB protocol to include online testing, or submit a new protocol for your proposed online study.</p>
+                <p>In order to list your study on this website, you first will need to have your institution sign a contract with MIT where they agree to the <a href="{{ termsofuse_url }}">Terms of Use</a> and certify that their studies will be reviewed and approved by an institutional review board. You will also need to edit your IRB protocol to include online testing, or submit a new protocol for your proposed online study.</p>
                 <p>As of April 2023, we have agreements with over 90 universities, including institutions in the United States, Canada, the United Kingdom, and European Union. Please email <a href="mailto:lookit@mit.edu">lookit@mit.edu</a> if you are not sure whether your institution already has an agreement, or if you need any help at all getting your paperwork in order.</p>
                 <p>While you are completing these steps, you can get started on Children Helping Science by creating a lab account, creating your first study, and getting it peer reviewed by our researcher community. A step-by-step guide to getting started is available <a href="https://lookit.readthedocs.io/en/develop/researchers-start-here.html">here</a>.</p>
                 {% endblocktranslate %}

--- a/web/templates/web/studies-list.html
+++ b/web/templates/web/studies-list.html
@@ -66,7 +66,7 @@
     <div class="row px-2">
         <p>
             {% trans "Want to learn more about research with babies & children? Check out the " %}
-            <a href="https://lookit.mit.edu/resources"
+            <a href="{% url 'web:resources' %}"
                target="_blank"
                rel="noreferrer noopener">{% trans "Resources" %}</a>
             {% trans "page for activities to try at home and developmental labs near you!" %}


### PR DESCRIPTION
This PR just cleans up some hard-coded URLs (which currently use the CHS .com or lookit.mit.edu domains). They are now dynamic URLs that are created based on whatever the current domain is.