### PR TITLE
Deprecate old efp versions

### DIFF
--- a/exp/tests/test_runner_forms.py
+++ b/exp/tests/test_runner_forms.py
@@ -1,10 +1,31 @@
 import json
+from datetime import timedelta
+from http import HTTPStatus
 from unittest.mock import Mock, patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from studies.forms import EFPForm, ExternalForm, JSPsychForm, ScheduledChoice
+from studies.helpers import (
+    EFP_LATEST_VERSION_NOT_ON_GITHUB,
+    EFP_LATEST_VERSION_UNRESOLVABLE,
+    EFP_MINIMUM_COMMIT_DATE,
+    EFP_VERSION_UNVERIFIABLE,
+)
 from studies.models import default_study_structure
+
+DEFAULT_REPO = "https://github.com/lookit/ember-lookit-frameplayer"
+DEFAULT_BRANCH = "master"
+CUSTOM_REPO = "https://github.com/someone/my-fork"
+NON_GITHUB_REPO = "https://gitlab.com/someone/my-fork"
+
+# Derived from the cutoff so these stay valid whenever the cutoff moves.
+DEPRECATED_COMMIT_DATE = EFP_MINIMUM_COMMIT_DATE - timedelta(days=1)
+SUPPORTED_COMMIT_DATE = EFP_MINIMUM_COMMIT_DATE + timedelta(days=1)
+
+DEPRECATED_SHA = "0" * 40
+SUPPORTED_SHA = "1" * 40
+HEAD_SHA = "2" * 40
 
 
 class EFPFormTestCase(TestCase):
@@ -103,6 +124,198 @@ class EFPFormTestCase(TestCase):
                 ]
             },
         )
+        self.assertFalse(form.is_valid())
+
+
+@override_settings(
+    EMBER_EXP_PLAYER_REPO=DEFAULT_REPO, EMBER_EXP_PLAYER_BRANCH=DEFAULT_BRANCH
+)
+class EFPFormRunnerVersionTestCase(TestCase):
+    """Version deprecation and blank-means-latest handling in EFPForm."""
+
+    def form_data(self, sha, repo_url=DEFAULT_REPO):
+        return {
+            "last_known_player_sha": sha,
+            "player_repo_url": repo_url,
+            "use_generator": False,
+            "structure": json.dumps(default_study_structure()),
+        }
+
+    def mock_get_side_effect(
+        self,
+        commit_date=SUPPORTED_COMMIT_DATE,
+        commit_status=HTTPStatus.OK,
+        head_status=HTTPStatus.OK,
+        repo_status=HTTPStatus.OK,
+    ):
+        """URL-keyed stand-in for requests.get, covering every call the form makes.
+
+        Note that studies.forms and studies.helpers share the one requests module, so
+        patching studies.forms.requests.get covers the helpers' API calls too.
+        """
+
+        def side_effect(url, *args, **kwargs):
+            if "/git/refs/heads/" in url:
+                return Mock(
+                    ok=head_status == HTTPStatus.OK,
+                    status_code=head_status,
+                    json=Mock(return_value={"object": {"sha": HEAD_SHA}}),
+                )
+            if url.startswith("https://api.github.com/"):
+                return Mock(
+                    ok=commit_status == HTTPStatus.OK,
+                    status_code=commit_status,
+                    json=Mock(
+                        return_value={
+                            "commit": {"committer": {"date": commit_date.isoformat()}}
+                        }
+                    ),
+                )
+            # Whatever's left is the form probing the repo URL, or a custom repo's
+            # <url>/commit/<sha> existence check.
+            return Mock(ok=repo_status == HTTPStatus.OK, status_code=repo_status)
+
+        return side_effect
+
+    @patch("studies.forms.requests.get")
+    def test_supported_version_saves(self, mock_get):
+        mock_get.side_effect = self.mock_get_side_effect()
+
+        form = EFPForm(data=self.form_data(SUPPORTED_SHA))
+
+        self.assertDictEqual(form.errors, {})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["last_known_player_sha"], SUPPORTED_SHA)
+
+    @patch("studies.forms.requests.get")
+    def test_deprecated_version_is_rejected(self, mock_get):
+        mock_get.side_effect = self.mock_get_side_effect(
+            commit_date=DEPRECATED_COMMIT_DATE
+        )
+
+        form = EFPForm(data=self.form_data(DEPRECATED_SHA))
+
+        self.assertIn("no longer supported", form.errors["last_known_player_sha"][0])
+        self.assertFalse(form.is_valid())
+
+    @patch("studies.forms.requests.get")
+    def test_unknown_commit_is_rejected(self, mock_get):
+        mock_get.side_effect = self.mock_get_side_effect(
+            commit_status=HTTPStatus.NOT_FOUND
+        )
+
+        form = EFPForm(data=self.form_data(SUPPORTED_SHA))
+
+        self.assertEqual(
+            form.errors["last_known_player_sha"],
+            [f"Frameplayer commit {SUPPORTED_SHA} does not exist."],
+        )
+        self.assertFalse(form.is_valid())
+
+    @patch("studies.forms.requests.get")
+    def test_unverifiable_version_fails_closed(self, mock_get):
+        """A rate-limited or unreachable GitHub blocks the save rather than waving it through."""
+        mock_get.side_effect = self.mock_get_side_effect(
+            commit_status=HTTPStatus.FORBIDDEN
+        )
+
+        form = EFPForm(data=self.form_data(SUPPORTED_SHA))
+
+        self.assertEqual(
+            form.errors["last_known_player_sha"], [EFP_VERSION_UNVERIFIABLE]
+        )
+        self.assertFalse(form.is_valid())
+
+    @patch("studies.forms.requests.get")
+    def test_custom_repo_keeps_its_old_version(self, mock_get):
+        """Forks are exempt from the cutoff, and are checked without the GitHub API."""
+        mock_get.side_effect = self.mock_get_side_effect(
+            commit_date=DEPRECATED_COMMIT_DATE
+        )
+
+        form = EFPForm(data=self.form_data(DEPRECATED_SHA, repo_url=CUSTOM_REPO))
+
+        self.assertDictEqual(form.errors, {})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["last_known_player_sha"], DEPRECATED_SHA)
+        for call in mock_get.call_args_list:
+            self.assertNotIn("api.github.com", call.args[0])
+
+    @patch("studies.forms.requests.get")
+    def test_custom_repo_commit_must_still_exist(self, mock_get):
+        mock_get.side_effect = self.mock_get_side_effect(
+            repo_status=HTTPStatus.NOT_FOUND
+        )
+
+        form = EFPForm(data=self.form_data(DEPRECATED_SHA, repo_url=CUSTOM_REPO))
+
+        # The repo URL check fails first here, which short-circuits the SHA check.
+        self.assertIn("player_repo_url", form.errors)
+        self.assertFalse(form.is_valid())
+
+    @patch("studies.forms.requests.get")
+    def test_blank_sha_pins_to_branch_head(self, mock_get):
+        """Blank means "use the latest", and the resolved SHA is stored, not the blank."""
+        mock_get.side_effect = self.mock_get_side_effect()
+
+        form = EFPForm(data=self.form_data(""))
+
+        self.assertDictEqual(form.errors, {})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["last_known_player_sha"], HEAD_SHA)
+
+    @patch("studies.forms.requests.get")
+    def test_blank_sha_does_not_date_check_the_head_commit(self, mock_get):
+        """Whatever HEAD is today is current by definition, so no commits API call."""
+        mock_get.side_effect = self.mock_get_side_effect()
+
+        form = EFPForm(data=self.form_data(""))
+
+        self.assertDictEqual(form.errors, {})
+        self.assertTrue(form.is_valid())
+        for call in mock_get.call_args_list:
+            self.assertNotIn("/commits/", call.args[0])
+
+    @patch("studies.forms.requests.get")
+    def test_blank_sha_fails_closed_when_head_cannot_be_resolved(self, mock_get):
+        mock_get.side_effect = self.mock_get_side_effect(
+            head_status=HTTPStatus.FORBIDDEN
+        )
+
+        form = EFPForm(data=self.form_data(""))
+
+        self.assertEqual(
+            form.errors["last_known_player_sha"], [EFP_LATEST_VERSION_UNRESOLVABLE]
+        )
+        self.assertFalse(form.is_valid())
+
+    @patch("studies.forms.requests.get")
+    def test_blank_sha_on_a_non_github_repo_asks_for_an_explicit_sha(self, mock_get):
+        """There's no portable way to ask a non-GitHub host what a branch points at."""
+        mock_get.side_effect = self.mock_get_side_effect()
+
+        form = EFPForm(data=self.form_data("", repo_url=NON_GITHUB_REPO))
+
+        self.assertEqual(
+            form.errors["last_known_player_sha"], [EFP_LATEST_VERSION_NOT_ON_GITHUB]
+        )
+        self.assertFalse(form.is_valid())
+
+    @patch("studies.forms.requests.get")
+    def test_bad_repo_url_does_not_also_report_a_sha_error(self, mock_get):
+        """clean_last_known_player_sha bails when the URL it depends on didn't clean.
+
+        Otherwise a single typo in the URL field produces a second, misleading error
+        against the SHA field.
+        """
+        mock_get.side_effect = self.mock_get_side_effect(
+            repo_status=HTTPStatus.NOT_FOUND
+        )
+
+        form = EFPForm(data=self.form_data(SUPPORTED_SHA))
+
+        self.assertIn("player_repo_url", form.errors)
+        self.assertNotIn("last_known_player_sha", form.errors)
         self.assertFalse(form.is_valid())
 
 

--- a/exp/tests/test_runner_views.py
+++ b/exp/tests/test_runner_views.py
@@ -1,5 +1,8 @@
+from datetime import timedelta
 from http import HTTPStatus
+from unittest.mock import Mock, patch
 
+import requests
 from django.test import Client, TestCase
 from django.urls import reverse
 from django_dynamic_fixture import G
@@ -9,8 +12,40 @@ from accounts.backends import TWO_FACTOR_AUTH_SESSION_KEY
 from accounts.models import User
 from project import settings
 from studies.forms import ScheduledChoice
+from studies.helpers import EFP_MINIMUM_COMMIT_DATE
 from studies.models import Lab, Study, StudyType
 from studies.permissions import StudyPermission
+
+# Derived from the cutoff so these stay valid whatever date the cutoff is set to.
+SUPPORTED_COMMIT_DATE = (EFP_MINIMUM_COMMIT_DATE + timedelta(days=1)).isoformat()
+
+# Captured before any patching, so the passthrough below can't recurse into a mock.
+REAL_REQUESTS_GET = requests.get
+
+
+def mock_github_get(commit_date=SUPPORTED_COMMIT_DATE):
+    """URL-keyed stand-in for requests.get, so EFP form validation stays offline.
+
+    Covers the repo existence check and the commits API that dates the pinned
+    version. Anything else - notably the SVG icons django_bootstrap_icons fetches
+    while rendering - is delegated to the real requests.get, since patching
+    studies.forms.requests.get patches the shared requests module for everyone.
+    """
+
+    def side_effect(url, *args, **kwargs):
+        if url == settings.EMBER_EXP_PLAYER_REPO:
+            return Mock(ok=True, status_code=HTTPStatus.OK)
+        if url.startswith("https://api.github.com/"):
+            return Mock(
+                ok=True,
+                status_code=HTTPStatus.OK,
+                json=Mock(
+                    return_value={"commit": {"committer": {"date": commit_date}}}
+                ),
+            )
+        return REAL_REQUESTS_GET(url, *args, **kwargs)
+
+    return side_effect
 
 
 class Force2FAClient(Client):
@@ -55,7 +90,10 @@ class RunnerDetailsViewsTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(Study.objects.get(id=study.id).metadata, metadata)
 
-    def test_efp_details_view(self):
+    @patch("studies.forms.requests.get")
+    def test_efp_details_view(self, mock_get):
+        mock_get.side_effect = mock_github_get()
+
         user = G(User, is_active=True, is_researcher=True)
         lab = G(Lab)
         study = G(Study, creator=user, lab=lab, study_type=1)
@@ -155,7 +193,10 @@ class RunnerDetailsViewsTestCase(TestCase):
             ],
         )
 
-    def test_efp_study_set_not_built(self):
+    @patch("studies.forms.requests.get")
+    def test_efp_study_set_not_built(self, mock_get):
+        mock_get.side_effect = mock_github_get()
+
         user = G(User, is_active=True, is_researcher=True)
         lab = G(Lab)
         study = G(

--- a/exp/tests/test_runner_views.py
+++ b/exp/tests/test_runner_views.py
@@ -121,6 +121,42 @@ class RunnerDetailsViewsTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(Study.objects.get(id=study.id).metadata, metadata)
 
+    def test_efp_design_page_hands_the_cutoff_to_the_javascript(self):
+        """efp-runner.js warns about old versions, but only the server knows the cutoff.
+
+        The attribute names are the contract between the template and the script, so
+        renaming one without the other silently drops the warning.
+        """
+        user = G(User, is_active=True, is_researcher=True)
+        study = G(
+            Study,
+            creator=user,
+            lab=G(Lab),
+            study_type=StudyType.get_ember_frame_player(),
+        )
+
+        assign_perm(StudyPermission.WRITE_STUDY_DETAILS.codename, user, study)
+        assign_perm(StudyPermission.READ_STUDY_DETAILS.codename, user, study)
+
+        self.client.force_login(user)
+        response = self.client.get(
+            reverse(self.efp_study_details, kwargs={"pk": study.id})
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(
+            response, f'data-min-commit-date="{EFP_MINIMUM_COMMIT_DATE.isoformat()}"'
+        )
+        self.assertContains(
+            response, f'data-default-repo="{settings.EMBER_EXP_PLAYER_REPO}"'
+        )
+        # Hidden on load: the script only unhides it once GitHub says the pinned
+        # commit really is too old.
+        self.assertContains(
+            response,
+            '<div id="version-deprecated-warning" class="alert alert-warning d-none"',
+        )
+
     def test_study_details_redirect_efp(self):
         user = G(User, is_active=True, is_researcher=True)
         lab = G(Lab)

--- a/exp/tests/test_study_views.py
+++ b/exp/tests/test_study_views.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms.models import model_to_dict
 from django.test import Client, TestCase, override_settings
@@ -277,6 +278,82 @@ class StudyViewsTestCase(TestCase):
             403,
             "Study build allowed from lab researcher without specific perms",
         )
+
+    def _prepare_buildable_study(self):
+        """Put self.study in a state where the researcher is allowed to build it.
+
+        The researcher needs write access to build the study.
+        Read access is also needed because the build button lives
+        on the study detail page, which is also where the view redirects afterwards.
+        In practice, a researcher who can build a study can also see it.
+        """
+        self.client.force_login(self.lab_researcher)
+        for permission in (
+            StudyPermission.READ_STUDY_DETAILS,
+            StudyPermission.WRITE_STUDY_DETAILS,
+        ):
+            assign_perm(permission.prefixed_codename, self.lab_researcher, self.study)
+        self.study.built = False
+        self.study.is_building = False
+        self.study.save()
+
+    @patch("exp.views.study.ember_build_and_gcp_deploy")
+    @patch("studies.models.efp_runner_version_error")
+    def test_build_study_blocked_by_deprecated_runner_version(
+        self, mock_error, mock_build_task
+    ):
+        mock_error.return_value = "version too old"
+        self._prepare_buildable_study()
+
+        page = self.client.post(self.study_build_url, {})
+
+        # Read the messages before assertRedirects follows the redirect and renders them.
+        self.assertIn(
+            "version too old", [str(m) for m in get_messages(page.wsgi_request)]
+        )
+        self.assertRedirects(page, reverse("exp:study", kwargs={"pk": self.study.pk}))
+        mock_build_task.delay.assert_not_called()
+        self.study.refresh_from_db()
+        self.assertFalse(
+            self.study.is_building, "Study marked as building despite the blocked build"
+        )
+
+    @patch("exp.views.study.ember_build_and_gcp_deploy")
+    @patch("studies.models.efp_runner_version_error")
+    def test_build_study_allowed_with_supported_runner_version(
+        self, mock_error, mock_build_task
+    ):
+        mock_error.return_value = None
+        self._prepare_buildable_study()
+
+        page = self.client.post(self.study_build_url, {})
+
+        self.assertRedirects(page, reverse("exp:study", kwargs={"pk": self.study.pk}))
+        mock_build_task.delay.assert_called_once_with(
+            self.study.uuid, self.lab_researcher.uuid
+        )
+        self.study.refresh_from_db()
+        self.assertTrue(self.study.is_building)
+
+    @patch("exp.views.study.ember_build_and_gcp_deploy")
+    @patch("studies.models.efp_runner_version_error")
+    def test_build_study_permission_check_runs_before_version_check(
+        self, mock_error, mock_build_task
+    ):
+        """A researcher without build perms gets a 403, not a version error.
+
+        The version check is deliberately in post() rather than the test predicate, so
+        it must not run for requests that were going to be rejected anyway due to
+        permissions.
+        """
+        mock_error.return_value = "version too old"
+        self.client.force_login(self.other_researcher)
+
+        page = self.client.post(self.study_build_url, {})
+
+        self.assertEqual(page.status_code, 403)
+        mock_error.assert_not_called()
+        mock_build_task.delay.assert_not_called()
 
     @skip
     def test_build_study_with_correct_perms_and_current_exp_runner(self):

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -38,6 +38,8 @@ from studies.forms import (
     StudyEditForm,
 )
 from studies.helpers import (
+    EFP_MINIMUM_COMMIT_DATE,
+    EFP_MINIMUM_COMMIT_DATE_DISPLAY,
     get_absolute_url,
     get_experiment_absolute_url,
     send_mail,
@@ -1223,6 +1225,14 @@ class EFPEditView(ExperimentRunnerEditView):
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["branch"] = settings.EMBER_EXP_PLAYER_BRANCH
+        # Pass info into the view for EFP version date validation.
+        # The client-side version deprecation is just a warning to save the researcher a
+        # round trip to the server. EFPForm validation is what actually enforces the cutoff.
+        # The repo is passed along because the cutoff only applies to the default repo, and
+        # the researcher set the URL form field to a fork without reloading the page.
+        context["default_repo"] = settings.EMBER_EXP_PLAYER_REPO
+        context["min_commit_date"] = EFP_MINIMUM_COMMIT_DATE.isoformat()
+        context["min_commit_date_display"] = EFP_MINIMUM_COMMIT_DATE_DISPLAY
         return context
 
 

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -840,6 +840,17 @@ class StudyBuildView(
 
     def post(self, request, *args, **kwargs):
         study = self.object
+
+        # Check the EFP version here rather than in user_can_build_study
+        # (a False there will go through handle_no_permission(), which is the wrong
+        # response to "your runner version is too old"). Blocking here also keeps the
+        # deprecated version out of the build task itself, which retries on failure
+        # and would burn all 10 attempts on something no retry can fix.
+        error = study.get_efp_runner_version_error()
+        if error:
+            messages.error(request, error)
+            return HttpResponseRedirect(self.get_redirect_url())
+
         study.is_building = True
         study.save(update_fields=["is_building"])
         ember_build_and_gcp_deploy.delay(study.uuid, self.request.user.uuid)

--- a/studies/experiment_builder.py
+++ b/studies/experiment_builder.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.core.files import File
 
 from project import storages
-from studies.helpers import send_mail
+from studies.helpers import get_repo_path, send_mail
 
 logger = logging.getLogger(__name__)
 
@@ -279,10 +279,6 @@ class EmberFrameplayerBuilder(ExperimentBuilder):
         )
 
         StudyLog.objects.create(study=study, action=action, user=researcher, extra=logs)
-
-
-def get_repo_path(full_repo_path):
-    return re.search("https://github.com/(.*)", full_repo_path).group(1).rstrip("/")
 
 
 def get_branch_sha(repo_url, branch):

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -451,8 +451,11 @@ class EFPForm(ModelForm):
     )
     last_known_player_sha = forms.CharField(
         label="Experiment runner version (commit SHA)",
+        required=False,
         help_text=(
-            "If you're using the default Ember Frame Player, you can see <a "
+            "Leave this blank to use the latest version, which will be filled in "
+            "for you when you save. If you're using the default Ember Frame Player, "
+            "you can see <a "
             f'href="{settings.EMBER_EXP_PLAYER_REPO}/commits/{settings.EMBER_EXP_PLAYER_BRANCH}" target="_blank" rel="noopener noreferrer">'
             "the commits page</a> for other commit SHA options."
         ),
@@ -555,8 +558,20 @@ class EFPForm(ModelForm):
 
         # player_repo_url is cleaned first, so if it raises an error then it will be None here,
         # and we should not validate the SHA (otherwise it will throw a second, misleading error)
-        if not (last_known_player_sha and player_repo_url):
+        if not player_repo_url:
             return last_known_player_sha
+
+        if not last_known_player_sha:
+            # Blank means "use the latest version". Resolve it now and store the
+            # most recent commit (study will be pinned to that version going forward).
+            # Whatever HEAD is will be newer than the date cutoff, so no need to
+            # run the date check via efp_runner_version_error.
+            sha, error = helpers.get_branch_head_sha(
+                player_repo_url, settings.EMBER_EXP_PLAYER_BRANCH
+            )
+            if error:
+                raise forms.ValidationError(error)
+            return sha
 
         if helpers.is_default_player_repo(player_repo_url):
             # One API call covers both "does this commit exist" and "is it too old".

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from accounts.queries import compile_expression
 from project import settings
+from studies import helpers
 from studies.models import Lab, Response, Study
 from studies.permissions import LabPermission, StudyPermission
 
@@ -493,6 +494,8 @@ class EFPForm(ModelForm):
 
     class Meta:
         model = Study
+        # player_repo_url must come before player SHA in this list because it determines
+        # the validation order (clean_<field>), and we must validate URL before SHA.
         fields = (
             "use_generator",
             "structure",
@@ -539,9 +542,9 @@ class EFPForm(ModelForm):
         )
 
         try:
-            if not requests.get(player_repo_url).ok:
+            if not requests.get(player_repo_url, timeout=helpers.GITHUB_API_TIMEOUT).ok:
                 raise validation_error
-        except requests.exceptions.ConnectionError:
+        except requests.exceptions.RequestException:
             raise validation_error
 
         return player_repo_url
@@ -550,8 +553,31 @@ class EFPForm(ModelForm):
         last_known_player_sha = self.cleaned_data.get("last_known_player_sha")
         player_repo_url = self.cleaned_data.get("player_repo_url")
 
-        if last_known_player_sha and player_repo_url:
-            if not requests.get(f"{player_repo_url}/commit/{last_known_player_sha}").ok:
+        # player_repo_url is cleaned first, so if it raises an error then it will be None here,
+        # and we should not validate the SHA (otherwise it will throw a second, misleading error)
+        if not (last_known_player_sha and player_repo_url):
+            return last_known_player_sha
+
+        if helpers.is_default_player_repo(player_repo_url):
+            # One API call covers both "does this commit exist" and "is it too old".
+            error = helpers.efp_runner_version_error(
+                player_repo_url, last_known_player_sha
+            )
+            if error:
+                raise forms.ValidationError(error)
+        else:
+            # Custom repo: check the commit exists, but don't apply the version date cutoff.
+            # These may not even be hosted on GitHub, so we can't use the API.
+            try:
+                response = requests.get(
+                    f"{player_repo_url}/commit/{last_known_player_sha}",
+                    timeout=helpers.GITHUB_API_TIMEOUT,
+                )
+            except requests.exceptions.RequestException:
+                raise forms.ValidationError(
+                    f"Could not check whether frameplayer commit {last_known_player_sha} exists."
+                )
+            if not response.ok:
                 raise forms.ValidationError(
                     f"Frameplayer commit {last_known_player_sha} does not exist."
                 )

--- a/studies/forms.py
+++ b/studies/forms.py
@@ -452,6 +452,9 @@ class EFPForm(ModelForm):
     last_known_player_sha = forms.CharField(
         label="Experiment runner version (commit SHA)",
         required=False,
+        widget=forms.TextInput(
+            attrs={"placeholder": "Leave blank to use the latest version"}
+        ),
         help_text=(
             "Leave this blank to use the latest version, which will be filled in "
             "for you when you save. If you're using the default Ember Frame Player, "

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -202,14 +202,15 @@ def efp_runner_version_error(player_repo_url, last_known_player_sha):
 
     if commit_datetime < EFP_MINIMUM_COMMIT_DATE:
         return (
-            f"Experiment runner version {last_known_player_sha[:7]} is from "
+            f"Your experiment runner version {last_known_player_sha[:7]} is from "
             f"{commit_datetime:%B %-d, %Y} and is no longer supported. Versions from "
-            f"before {EFP_MINIMUM_COMMIT_DATE:%B %-d, %Y} can't be used. The easiest "
-            "way to update is to clear the experiment runner version field on the "
-            "study design page and save - we'll fill in the latest version for you. "
-            "You can also pick a specific commit from "
-            f"{settings.EMBER_EXP_PLAYER_REPO}/commits/{settings.EMBER_EXP_PLAYER_BRANCH}). "
-            "Either way, rebuild your experiment runner afterwards."
+            f"before {EFP_MINIMUM_COMMIT_DATE:%B %-d, %Y} use a 3rd party package that "
+            f"has been deprecated. The easiest way to update is to clear the experiment "
+            f"runner version field on the study design page and then save - we'll fill "
+            f"in the latest version for you. You can also select a specific version "
+            f"by clicking the 'Check for updates' button or from "
+            f"{settings.EMBER_EXP_PLAYER_REPO}/commits/{settings.EMBER_EXP_PLAYER_BRANCH}. "
+            "You will need to rebuild the experiment runner after updating and saving."
         )
 
     return None

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -35,6 +35,19 @@ EFP_VERSION_UNVERIFIABLE = (
     "this keeps happening, contact us on Slack or at support@childrenhelpingscience.org."
 )
 
+EFP_LATEST_VERSION_UNRESOLVABLE = (
+    "There was a problem looking up the latest experiment runner version on GitHub "
+    "just now. Please enter a commit SHA, or leave this blank and try again in a few "
+    "minutes. If this keeps happening, contact us on Slack or at "
+    "support@childrenhelpingscience.org."
+)
+
+# Retrying won't help here, so this deliberately doesn't suggest it.
+EFP_LATEST_VERSION_NOT_ON_GITHUB = (
+    "We can only look up the latest version automatically for experiment runner "
+    "repos hosted on GitHub. Please enter a commit SHA for this repo."
+)
+
 
 def get_absolute_url(path=""):
     return urljoin(settings.BASE_URL, path)
@@ -125,6 +138,45 @@ def get_commit_datetime(player_repo_url, sha):
     except (ValueError, KeyError, TypeError, requests.exceptions.JSONDecodeError):
         logger.warning(f"Unexpected GitHub response when checking commit {sha}.")
         return None, EFP_VERSION_UNVERIFIABLE
+
+
+def get_branch_head_sha(player_repo_url, branch):
+    """Look up the commit a branch currently points at, via the GitHub API.
+
+    Returns (sha, None) on success, or (None, error_message) on failure, matching
+    get_commit_datetime's contract.
+
+    Only works for repos hosted on GitHub. A custom repo hosted elsewhere has to
+    pin its version explicitly, since there's no portable way to ask a git host
+    what a branch points at over HTTP.
+    """
+    repo_path = get_repo_path(player_repo_url)
+    if repo_path is None:
+        return None, EFP_LATEST_VERSION_NOT_ON_GITHUB
+
+    api_url = f"https://api.github.com/repos/{repo_path}/git/refs/heads/{branch}"
+
+    try:
+        response = requests.get(
+            api_url,
+            timeout=GITHUB_API_TIMEOUT,
+            headers={"Accept": "application/vnd.github+json"},
+        )
+    except requests.exceptions.RequestException:
+        logger.warning(f"Could not reach GitHub to resolve branch {branch}.")
+        return None, EFP_LATEST_VERSION_UNRESOLVABLE
+
+    if not response.ok:
+        logger.warning(
+            f"GitHub returned {response.status_code} when resolving branch {branch}."
+        )
+        return None, EFP_LATEST_VERSION_UNRESOLVABLE
+
+    try:
+        return response.json()["object"]["sha"], None
+    except (KeyError, TypeError, requests.exceptions.JSONDecodeError):
+        logger.warning(f"Unexpected GitHub response when resolving branch {branch}.")
+        return None, EFP_LATEST_VERSION_UNRESOLVABLE
 
 
 def efp_runner_version_error(player_repo_url, last_known_player_sha):

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -2,9 +2,11 @@ import base64
 import copy
 import logging
 import re
+from datetime import datetime, timezone
 from email.mime.image import MIMEImage
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
+import requests
 from django.conf import settings
 from django.core.mail.message import EmailMultiAlternatives
 from django.db import models
@@ -19,6 +21,20 @@ from project.celery import app
 
 logger = logging.getLogger(__name__)
 
+# Experiment runner commits older than this date can no longer be used, but only
+# for the default repo (settings.EMBER_EXP_PLAYER_REPO). Custom forks are exempt.
+# Must stay timezone-aware: commit dates come back from GitHub as aware datetimes,
+# and comparing those against a naive one raises TypeError.
+EFP_MINIMUM_COMMIT_DATE = datetime(2024, 1, 30, tzinfo=timezone.utc)
+
+GITHUB_API_TIMEOUT = 10  # seconds
+
+EFP_VERSION_UNVERIFIABLE = (
+    "There was a problem checking your experiment runner version on GitHub just now, so we "
+    "can't confirm that it is still supported. Please try again in a few minutes. If "
+    "this keeps happening, contact us on Slack or at support@childrenhelpingscience.org."
+)
+
 
 def get_absolute_url(path=""):
     return urljoin(settings.BASE_URL, path)
@@ -26,6 +42,123 @@ def get_absolute_url(path=""):
 
 def get_experiment_absolute_url(path):
     return urljoin(settings.EXPERIMENT_BASE_URL, path)
+
+
+def get_repo_path(full_repo_path):
+    """Pull the "owner/repo" portion out of a GitHub repo URL.
+
+    Tolerates the same variations as normalize_repo_url (scheme, case, "www.",
+    trailing slash, ".git"). Returns None if this isn't a GitHub URL at all, so
+    callers can fall back rather than breaking on a repo hosted elsewhere.
+    """
+    parsed = urlparse((full_repo_path or "").strip())
+    if parsed.netloc.lower().removeprefix("www.") != "github.com":
+        return None
+    return parsed.path.strip("/").removesuffix(".git") or None
+
+
+def normalize_repo_url(url):
+    """Canonical form of a repo URL, for comparing the study's repo to the EFP default.
+
+    Insensitive to scheme, case, "www.", trailing slashes and a ".git" suffix, so
+    that e.g. "HTTP://www.GitHub.com/lookit/ember-lookit-frameplayer.git/" and
+    "https://github.com/lookit/ember-lookit-frameplayer" compare equal.
+    """
+    parsed = urlparse((url or "").strip())
+    netloc = parsed.netloc.lower().removeprefix("www.")
+    path = parsed.path.rstrip("/").lower().removesuffix(".git")
+    return f"{netloc}{path}"
+
+
+def is_default_player_repo(url):
+    """True if this URL points at the default experiment runner repo.
+
+    Reads the setting at call time so that it stays correct under override_settings
+    and when EMBER_EXP_PLAYER_REPO is set from the environment.
+    """
+    return bool(url) and normalize_repo_url(url) == normalize_repo_url(
+        settings.EMBER_EXP_PLAYER_REPO
+    )
+
+
+def get_commit_datetime(player_repo_url, sha):
+    """Look up when a commit landed, via the GitHub API.
+
+    Returns (datetime, None) on success, or (None, error_message) when the commit
+    doesn't exist or GitHub can't be reached. Exactly one of the two is ever set.
+
+    Uses the committer date rather than the author date: the author date is when the
+    patch was first written and survives rebases and cherry-picks, so a recently
+    merged commit can carry a years-old author date. The committer date is when the
+    code actually landed on the branch, which is what "how old is this version"
+    means here.
+    """
+    api_url = (
+        f"https://api.github.com/repos/{get_repo_path(player_repo_url)}/commits/{sha}"
+    )
+
+    try:
+        response = requests.get(
+            api_url,
+            timeout=GITHUB_API_TIMEOUT,
+            headers={"Accept": "application/vnd.github+json"},
+        )
+    except requests.exceptions.RequestException:
+        logger.warning(f"Could not reach GitHub to check commit {sha}.")
+        return None, EFP_VERSION_UNVERIFIABLE
+
+    # 404 is an unknown SHA, 422 a malformed one. Both mean "no such commit", which
+    # is the researcher's to fix. Everything else is our problem, not theirs.
+    if response.status_code in (404, 422):
+        return None, f"Frameplayer commit {sha} does not exist."
+
+    if not response.ok:
+        logger.warning(
+            f"GitHub returned {response.status_code} when checking commit {sha}."
+        )
+        return None, EFP_VERSION_UNVERIFIABLE
+
+    try:
+        return datetime.fromisoformat(
+            response.json()["commit"]["committer"]["date"]
+        ), None
+    except (ValueError, KeyError, TypeError, requests.exceptions.JSONDecodeError):
+        logger.warning(f"Unexpected GitHub response when checking commit {sha}.")
+        return None, EFP_VERSION_UNVERIFIABLE
+
+
+def efp_runner_version_error(player_repo_url, last_known_player_sha):
+    """Check whether a study may use this experiment runner version.
+
+    Returns a message ready to show the researcher, or None if the version is fine.
+    Callers wrap the message in whatever their context needs (a ValidationError, a
+    messages.error, a RuntimeError), which is why this returns a string rather than
+    raising.
+    """
+    if not last_known_player_sha:
+        # Nothing pinned, so the build resolves the branch HEAD, which can't be
+        # out of date by definition.
+        return None
+
+    if not is_default_player_repo(player_repo_url):
+        # Custom forks are exempt - we only deprecate versions of our own repo.
+        return None
+
+    commit_datetime, error = get_commit_datetime(player_repo_url, last_known_player_sha)
+    if error:
+        return error
+
+    if commit_datetime < EFP_MINIMUM_COMMIT_DATE:
+        return (
+            f"Experiment runner version {last_known_player_sha[:7]} is from "
+            f"{commit_datetime:%B %-d, %Y} and is no longer supported. Versions from "
+            f"before {EFP_MINIMUM_COMMIT_DATE:%B %-d, %Y} can't be used. Please update "
+            f"to a newer commit from {settings.EMBER_EXP_PLAYER_REPO}/commits/"
+            f"{settings.EMBER_EXP_PLAYER_BRANCH} (ideally the most recent one!), "
+            f"then save and rebuild your experiment runner."
+        )
+
+    return None
 
 
 @app.task

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -152,10 +152,12 @@ def efp_runner_version_error(player_repo_url, last_known_player_sha):
         return (
             f"Experiment runner version {last_known_player_sha[:7]} is from "
             f"{commit_datetime:%B %-d, %Y} and is no longer supported. Versions from "
-            f"before {EFP_MINIMUM_COMMIT_DATE:%B %-d, %Y} can't be used. Please update "
-            f"to a newer commit from {settings.EMBER_EXP_PLAYER_REPO}/commits/"
-            f"{settings.EMBER_EXP_PLAYER_BRANCH} (ideally the most recent one!), "
-            f"then save and rebuild your experiment runner."
+            f"before {EFP_MINIMUM_COMMIT_DATE:%B %-d, %Y} can't be used. The easiest "
+            "way to update is to clear the experiment runner version field on the "
+            "study design page and save - we'll fill in the latest version for you. "
+            "You can also pick a specific commit from "
+            f"{settings.EMBER_EXP_PLAYER_REPO}/commits/{settings.EMBER_EXP_PLAYER_BRANCH}). "
+            "Either way, rebuild your experiment runner afterwards."
         )
 
     return None

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 # and comparing those against a naive one raises TypeError.
 EFP_MINIMUM_COMMIT_DATE = datetime(2024, 1, 30, tzinfo=timezone.utc)
 
+# Formatted here rather than at each use so that the error messages and the warning on
+# the study design page always have the same display date.
+# (Not formatted with Django's date filter because that converts to settings.TIME_ZONE,
+# which would shift a UTC midnight cutoff back a day.)
+EFP_MINIMUM_COMMIT_DATE_DISPLAY = f"{EFP_MINIMUM_COMMIT_DATE:%B %-d, %Y}"
+
 GITHUB_API_TIMEOUT = 10  # seconds
 
 EFP_VERSION_UNVERIFIABLE = (
@@ -204,7 +210,7 @@ def efp_runner_version_error(player_repo_url, last_known_player_sha):
         return (
             f"Your experiment runner version {last_known_player_sha[:7]} is from "
             f"{commit_datetime:%B %-d, %Y} and is no longer supported. Versions from "
-            f"before {EFP_MINIMUM_COMMIT_DATE:%B %-d, %Y} use a 3rd party package that "
+            f"before {EFP_MINIMUM_COMMIT_DATE_DISPLAY} use a 3rd party package that "
             f"has been deprecated. The easiest way to update is to clear the experiment "
             f"runner version field on the study design page and then save - we'll fill "
             f"in the latest version for you. You can also select a specific version "

--- a/studies/models.py
+++ b/studies/models.py
@@ -30,6 +30,7 @@ from studies import workflow
 from studies.helpers import (
     FrameActionDispatcher,
     ResponseEligibility,
+    efp_runner_version_error,
     get_absolute_url,
     get_eligibility_for_response,
     send_mail,
@@ -895,6 +896,42 @@ class Study(models.Model):
         if self.has_reached_max_responses:
             raise RuntimeError(
                 f'Cannot activate the study "{self.name}" ({self.id}) because it has reached its maximum number of responses. Be sure to handle all pending consents and review existing responses, as this may open up slots. Then increase the response limit in the Study Ad if necessary, and try starting the study again.'
+            )
+
+    def check_efp_runner_version(self, ev):
+        """Check that this study isn't pinned to a deprecated experiment runner version.
+
+        This is only called in by state transitions in workflow.py, so it takes an event object,
+        which is the triggering event (state change).
+
+        Only applies to Ember Frame Player studies using the default runner repo;
+        everything else transitions freely.
+
+        :param ev: The event object
+        :type ev: transitions.core.EventData
+        :raise: RuntimeError
+        """
+        if not self.study_type.is_ember_frame_player:
+            return
+
+        metadata = self.metadata or {}
+
+        # URL falls back to the default repo when player_repo_url is missing, which is probably only
+        # the case for a study that has never been saved through the EFP design form.
+        # Use "or" rather than metadata.get() with a default, since the default only applies
+        # when the key is absent. We want the default when the URL key is present but has a value of None.
+        # (Otherwise the value would stay None, and is_default_player_repo(None) is False, and the study gets
+        # silently exempted from the check as if it were on a custom fork.)
+        player_repo_url = (
+            metadata.get("player_repo_url") or settings.EMBER_EXP_PLAYER_REPO
+        )
+
+        error = efp_runner_version_error(
+            player_repo_url, metadata.get("last_known_player_sha")
+        )
+        if error:
+            raise RuntimeError(
+                f'Cannot {ev.event.name} the study "{self.name}" ({self.id}): {error}'
             )
 
     def notify_administrators_of_activation(self, ev):

--- a/studies/models.py
+++ b/studies/models.py
@@ -898,21 +898,20 @@ class Study(models.Model):
                 f'Cannot activate the study "{self.name}" ({self.id}) because it has reached its maximum number of responses. Be sure to handle all pending consents and review existing responses, as this may open up slots. Then increase the response limit in the Study Ad if necessary, and try starting the study again.'
             )
 
-    def check_efp_runner_version(self, ev):
-        """Check that this study isn't pinned to a deprecated experiment runner version.
+    def get_efp_runner_version_error(self):
+        """Check whether this study's pinned experiment runner version is still usable.
 
-        This is only called in by state transitions in workflow.py, so it takes an event object,
-        which is the triggering event (state change).
+        Returns the researcher-facing EFP version message if it's a old Pipe version,
+        or None if the version is recent enough (newer than the cutoff date).
+        This only applies to Ember Frame Player studies using the default runner
+        repo; everything else is exempt and always returns None.
 
-        Only applies to Ember Frame Player studies using the default runner repo;
-        everything else transitions freely.
-
-        :param ev: The event object
-        :type ev: transitions.core.EventData
-        :raise: RuntimeError
+        Callers decide how to surface the message (a RuntimeError that aborts a state
+        transition, a messages.error that blocks a build), which is why this returns a
+        string rather than raising.
         """
         if not self.study_type.is_ember_frame_player:
-            return
+            return None
 
         metadata = self.metadata or {}
 
@@ -926,9 +925,23 @@ class Study(models.Model):
             metadata.get("player_repo_url") or settings.EMBER_EXP_PLAYER_REPO
         )
 
-        error = efp_runner_version_error(
+        return efp_runner_version_error(
             player_repo_url, metadata.get("last_known_player_sha")
         )
+
+    def check_efp_runner_version(self, ev):
+        """Refuse to change state if the experiment runner version is deprecated.
+
+        This is a wrapper for get_efp_runner_version_error. It is only called by
+        state transitions in workflow.py, so it takes an event object, which is
+        the triggering event (state change). If the version is too old, it raises
+        an error, which stops the state change, and provides the user-facing message.
+
+        :param ev: The event object
+        :type ev: transitions.core.EventData
+        :raise: RuntimeError
+        """
+        error = self.get_efp_runner_version_error()
         if error:
             raise RuntimeError(
                 f'Cannot {ev.event.name} the study "{self.name}" ({self.id}): {error}'

--- a/studies/templates/studies/experiment_runner/efp_edit.html
+++ b/studies/templates/studies/experiment_runner/efp_edit.html
@@ -7,7 +7,15 @@
     {% comment %} ace editor fix cannot be defered {% endcomment %}
     <script src="{% static 'js/ace-editor.js' %}"></script>
     <script src="{% static 'js/js-validation.js'%}" defer></script>
-    <script src="{% static 'js/efp-runner.js' %}" defer data-branch={{branch}}></script>
+    {% comment %}
+        The data attributes need to be quoted because min_commit_date is an ISO timestamp,
+        and an unquoted value would end at its first colon.
+    {% endcomment %}
+    <script src="{% static 'js/efp-runner.js' %}"
+            defer
+            data-branch="{{ branch }}"
+            data-default-repo="{{ default_repo }}"
+            data-min-commit-date="{{ min_commit_date }}"></script>
     {{ form.media }}
 {% endblock head %}
 {% block header %}
@@ -25,36 +33,71 @@
 {% endblock js_error %}
 {% block form %}
     {% bootstrap_form form label_class="fw-bold" %}
+    {% comment %}
+        Version deprecation warning shown by efp-runner.js when the version in the 
+        field is too old. This is just a pre-save warning - the form validation is what
+        enforces the cutoff, so a researcher with JS disabled still can't
+        get an unsupported version past the form.
+        Deliberately alert-warning (not danger), and worded as something
+        about to happen. The form's own validation errors on the submit action 
+        are red/danger, and this needs to read as advice about an unsaved value 
+        rather than a duplicate or additional error.
+    {% endcomment %}
+    <div id="version-deprecated-warning" class="alert alert-warning d-none" role="alert">
+        <strong>Before you save:</strong> This experiment runner version is no longer
+        supported. Versions from before {{ min_commit_date_display }} use a 3rd
+        party package that has been deprecated. You won't be able to save changes, build, or
+        start your study while it is set to this version. The easiest way to update the
+        experiment runner version is to clear the field above and then save this form, 
+        which will update your study to the latest version.
+    </div>
     <div id="commit-description" class="card bg-light my-4">
         <div class="card-header">
             <h3 class="card-subtitle my-1">
                 About this version
                 <div class="float-end me-4">
                     {% button_secondary_classes as btn_secondary_classes %}
+                    {% comment %}
+                        Hidden by efp-runner.js when no version is selected: there's no
+                        commit to compare the branch against, so the button has nothing
+                        to look for.
+                    {% endcomment %}
                     {% bootstrap_button "Check for updates" button_class=btn_secondary_classes id="update-button" %}
                 </div>
             </h3>
         </div>
         <div class="card-body">
-            <p>
-                Your study will use commit <a class="sha" href></a>:
+            {% comment %}
+                No version selection content shown by efp-runner.js when the version field is blank.
+                Stands in for the commit details when the version field is empty, so that
+                clearing the field (which sets the SHA to the latest version) doesn't just
+                leave a blank space where the version details were.
+            {% endcomment %}
+            <p id="no-version-selected" class="d-none mb-0">
+                No specific version selected: when you save this form, your study will be
+                set to use the latest experiment runner version.
             </p>
-            <div class="container">
-                <div class="row border-bottom py-2">
-                    <div class="col-2 fw-bold">Date</div>
-                    <div class="col date"></div>
-                </div>
-                <div class="row border-bottom py-2">
-                    <div class="col-2 fw-bold">Author</div>
-                    <div class="col name"></div>
-                </div>
-                <div class="row border-bottom pt-2">
-                    <div class="col-2 fw-bold">Message</div>
-                    <div class="col message"></div>
-                </div>
-                <div class="row py-2">
-                    <div class="col-2 fw-bold">Files changed</div>
-                    <div class="col files"></div>
+            <div id="commit-details">
+                <p>
+                    Your study will use commit <a class="sha" href></a>:
+                </p>
+                <div class="container">
+                    <div class="row border-bottom py-2">
+                        <div class="col-2 fw-bold">Date</div>
+                        <div class="col date"></div>
+                    </div>
+                    <div class="row border-bottom py-2">
+                        <div class="col-2 fw-bold">Author</div>
+                        <div class="col name"></div>
+                    </div>
+                    <div class="row border-bottom pt-2">
+                        <div class="col-2 fw-bold">Message</div>
+                        <div class="col message"></div>
+                    </div>
+                    <div class="row py-2">
+                        <div class="col-2 fw-bold">Files changed</div>
+                        <div class="col files"></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/studies/test_efp_runner_version.py
+++ b/studies/test_efp_runner_version.py
@@ -411,7 +411,11 @@ class StudyEFPRunnerVersionTestCase(TestCase):
         with self.assertRaises(RuntimeError) as ctx:
             getattr(study, trigger)()
 
-        self.assertIn("version too old", str(ctx.exception))
+        # Indirect test for check_efp_runner_version workflow callback
+        self.assertEqual(
+            str(ctx.exception),
+            f'Cannot {trigger} the study "{study.name}" ({study.id}): version too old',
+        )
         study.refresh_from_db()
         self.assertEqual(study.state, state, "State changed despite the check failing")
 

--- a/studies/test_efp_runner_version.py
+++ b/studies/test_efp_runner_version.py
@@ -1,0 +1,459 @@
+"""Tests for deprecating old Ember Frame Player experiment runner versions.
+
+Covers the shared helpers in studies/helpers.py and the Study methods that use them.
+Form-level tests live in exp/tests/test_runner_forms.py and the build gate is covered
+in exp/tests/test_study_views.py.
+"""
+
+from datetime import timedelta
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+import requests
+from django.test import TestCase, override_settings
+from parameterized import parameterized
+
+from studies.helpers import (
+    EFP_LATEST_VERSION_NOT_ON_GITHUB,
+    EFP_LATEST_VERSION_UNRESOLVABLE,
+    EFP_MINIMUM_COMMIT_DATE,
+    EFP_VERSION_UNVERIFIABLE,
+    efp_runner_version_error,
+    get_branch_head_sha,
+    get_commit_datetime,
+    get_repo_path,
+    is_default_player_repo,
+)
+from studies.models import Lab, Study, StudyType
+
+DEFAULT_REPO = "https://github.com/lookit/ember-lookit-frameplayer"
+CUSTOM_REPO = "https://github.com/someone/ember-lookit-frameplayer"
+NON_GITHUB_REPO = "https://gitlab.com/someone/ember-lookit-frameplayer"
+
+# Derived from the cutoff so these stay valid whenever the cutoff moves.
+DEPRECATED_COMMIT_DATE = EFP_MINIMUM_COMMIT_DATE - timedelta(days=1)
+SUPPORTED_COMMIT_DATE = EFP_MINIMUM_COMMIT_DATE + timedelta(days=1)
+
+DEPRECATED_SHA = "0" * 40
+SUPPORTED_SHA = "1" * 40
+HEAD_SHA = "2" * 40
+
+
+def mock_commit_response(commit_date):
+    """A GitHub commits API response pinning a commit to this committer date."""
+    return Mock(
+        ok=True,
+        status_code=HTTPStatus.OK,
+        json=Mock(
+            return_value={"commit": {"committer": {"date": commit_date.isoformat()}}}
+        ),
+    )
+
+
+@override_settings(EMBER_EXP_PLAYER_REPO=DEFAULT_REPO)
+class GetRepoPathTestCase(TestCase):
+    @parameterized.expand(
+        [
+            ("plain", DEFAULT_REPO),
+            ("trailing slash", f"{DEFAULT_REPO}/"),
+            ("dot git", f"{DEFAULT_REPO}.git"),
+            ("www", "https://www.github.com/lookit/ember-lookit-frameplayer"),
+            ("http", "http://github.com/lookit/ember-lookit-frameplayer"),
+            ("mixed case host", "https://GitHub.com/lookit/ember-lookit-frameplayer"),
+            ("surrounding whitespace", f"  {DEFAULT_REPO}  "),
+        ]
+    )
+    def test_extracts_owner_and_repo(self, _name, url):
+        """All URL variations that are parameterized above resolve to the same owner and repo"""
+        self.assertEqual(get_repo_path(url), "lookit/ember-lookit-frameplayer")
+
+    @parameterized.expand(
+        [
+            ("non github host", NON_GITHUB_REPO),
+            ("no host", "lookit/ember-lookit-frameplayer"),
+            ("github with no path", "https://github.com/"),
+            ("empty", ""),
+            ("none", None),
+        ]
+    )
+    def test_returns_none_when_not_a_github_repo_url(self, _name, url):
+        """Returns None rather than raising, so callers can fall back."""
+        self.assertIsNone(get_repo_path(url))
+
+
+@override_settings(EMBER_EXP_PLAYER_REPO=DEFAULT_REPO)
+class IsDefaultPlayerRepoTestCase(TestCase):
+    @parameterized.expand(
+        [
+            ("plain", DEFAULT_REPO),
+            ("trailing slash", f"{DEFAULT_REPO}/"),
+            ("dot git", f"{DEFAULT_REPO}.git"),
+            ("dot git and trailing slash", f"{DEFAULT_REPO}.git/"),
+            ("www", "https://www.github.com/lookit/ember-lookit-frameplayer"),
+            ("http", "http://github.com/lookit/ember-lookit-frameplayer"),
+            ("mixed case", "HTTP://www.GitHub.com/lookit/Ember-Lookit-Frameplayer"),
+        ]
+    )
+    def test_recognizes_default_repo(self, _name, url):
+        """All URL variations that are parameterized above resolve to the default EFP repository"""
+        self.assertTrue(is_default_player_repo(url))
+
+    @parameterized.expand(
+        [
+            ("different owner of same repo (fork)", CUSTOM_REPO),
+            ("same owner, different repo", "https://github.com/lookit/lookit-api"),
+            ("same path, different host", NON_GITHUB_REPO),
+            ("empty", ""),
+            ("none", None),
+        ]
+    )
+    def test_rejects_other_repos(self, _name, url):
+        """
+        All URL variations that are parameterized above are correctly identified
+        as not being the default EFP repository
+        """
+        self.assertFalse(is_default_player_repo(url))
+
+    @override_settings(EMBER_EXP_PLAYER_REPO=CUSTOM_REPO)
+    def test_reads_the_setting_at_call_time(self):
+        """The default repo is env-configurable, so it can't be captured at import."""
+        self.assertTrue(is_default_player_repo(CUSTOM_REPO))
+        self.assertFalse(is_default_player_repo(DEFAULT_REPO))
+
+
+class GetCommitDatetimeTestCase(TestCase):
+    @patch("studies.helpers.requests.get")
+    def test_returns_committer_date(self, mock_get):
+        mock_get.return_value = mock_commit_response(SUPPORTED_COMMIT_DATE)
+
+        commit_datetime, error = get_commit_datetime(DEFAULT_REPO, SUPPORTED_SHA)
+
+        self.assertEqual(commit_datetime, SUPPORTED_COMMIT_DATE)
+        self.assertIsNone(error)
+
+    @patch("studies.helpers.requests.get")
+    def test_queries_the_commits_api_for_the_right_repo(self, mock_get):
+        mock_get.return_value = mock_commit_response(SUPPORTED_COMMIT_DATE)
+
+        get_commit_datetime(DEFAULT_REPO, SUPPORTED_SHA)
+
+        self.assertEqual(
+            mock_get.call_args.args[0],
+            f"https://api.github.com/repos/lookit/ember-lookit-frameplayer/commits/{SUPPORTED_SHA}",
+        )
+
+    @parameterized.expand([("unknown sha", 404), ("malformed sha", 422)])
+    @patch("studies.helpers.requests.get")
+    def test_missing_commit_is_the_researchers_to_fix(self, _name, status, mock_get):
+        mock_get.return_value = Mock(ok=False, status_code=status)
+
+        commit_datetime, error = get_commit_datetime(DEFAULT_REPO, "nonsense")
+
+        self.assertIsNone(commit_datetime)
+        self.assertEqual(error, "Frameplayer commit nonsense does not exist.")
+
+    @patch("studies.helpers.requests.get")
+    def test_rate_limited_fails_closed(self, mock_get):
+        mock_get.return_value = Mock(ok=False, status_code=403)
+
+        commit_datetime, error = get_commit_datetime(DEFAULT_REPO, SUPPORTED_SHA)
+
+        self.assertIsNone(commit_datetime)
+        self.assertEqual(error, EFP_VERSION_UNVERIFIABLE)
+
+    @patch("studies.helpers.requests.get")
+    def test_unreachable_github_fails_closed(self, mock_get):
+        mock_get.side_effect = requests.exceptions.ConnectionError
+
+        commit_datetime, error = get_commit_datetime(DEFAULT_REPO, SUPPORTED_SHA)
+
+        self.assertIsNone(commit_datetime)
+        self.assertEqual(error, EFP_VERSION_UNVERIFIABLE)
+
+    @parameterized.expand(
+        [
+            ("missing keys", {"unexpected": "shape"}),
+            ("unparseable date", {"commit": {"committer": {"date": "not a date"}}}),
+            ("not a dict", []),
+        ]
+    )
+    @patch("studies.helpers.requests.get")
+    def test_unexpected_response_fails_closed(self, _name, payload, mock_get):
+        mock_get.return_value = Mock(
+            ok=True, status_code=HTTPStatus.OK, json=Mock(return_value=payload)
+        )
+
+        commit_datetime, error = get_commit_datetime(DEFAULT_REPO, SUPPORTED_SHA)
+
+        self.assertIsNone(commit_datetime)
+        self.assertEqual(error, EFP_VERSION_UNVERIFIABLE)
+
+
+class GetBranchHeadShaTestCase(TestCase):
+    @patch("studies.helpers.requests.get")
+    def test_returns_the_sha_the_branch_points_at(self, mock_get):
+        mock_get.return_value = Mock(
+            ok=True,
+            status_code=HTTPStatus.OK,
+            json=Mock(return_value={"object": {"sha": HEAD_SHA}}),
+        )
+
+        sha, error = get_branch_head_sha(DEFAULT_REPO, "master")
+
+        self.assertEqual(sha, HEAD_SHA)
+        self.assertIsNone(error)
+        self.assertEqual(
+            mock_get.call_args.args[0],
+            "https://api.github.com/repos/lookit/ember-lookit-frameplayer/git/refs/heads/master",
+        )
+
+    @patch("studies.helpers.requests.get")
+    def test_non_github_repo_is_told_to_pin_a_sha(self, mock_get):
+        """Retrying can't help here, so the message must not suggest it."""
+        sha, error = get_branch_head_sha(NON_GITHUB_REPO, "master")
+
+        self.assertIsNone(sha)
+        self.assertEqual(error, EFP_LATEST_VERSION_NOT_ON_GITHUB)
+        mock_get.assert_not_called()
+
+    @patch("studies.helpers.requests.get")
+    def test_unreachable_github_is_recoverable(self, mock_get):
+        mock_get.side_effect = requests.exceptions.Timeout
+
+        sha, error = get_branch_head_sha(DEFAULT_REPO, "master")
+
+        self.assertIsNone(sha)
+        self.assertEqual(error, EFP_LATEST_VERSION_UNRESOLVABLE)
+
+    @patch("studies.helpers.requests.get")
+    def test_unknown_branch_is_recoverable(self, mock_get):
+        mock_get.return_value = Mock(ok=False, status_code=404)
+
+        sha, error = get_branch_head_sha(DEFAULT_REPO, "no-such-branch")
+
+        self.assertIsNone(sha)
+        self.assertEqual(error, EFP_LATEST_VERSION_UNRESOLVABLE)
+
+    @patch("studies.helpers.requests.get")
+    def test_unexpected_response_is_recoverable(self, mock_get):
+        mock_get.return_value = Mock(
+            ok=True,
+            status_code=HTTPStatus.OK,
+            json=Mock(return_value={"unexpected": "shape"}),
+        )
+
+        sha, error = get_branch_head_sha(DEFAULT_REPO, "master")
+
+        self.assertIsNone(sha)
+        self.assertEqual(error, EFP_LATEST_VERSION_UNRESOLVABLE)
+
+
+@override_settings(EMBER_EXP_PLAYER_REPO=DEFAULT_REPO)
+class EFPRunnerVersionErrorTestCase(TestCase):
+    @patch("studies.helpers.requests.get")
+    def test_commit_before_the_cutoff_is_rejected(self, mock_get):
+        mock_get.return_value = mock_commit_response(DEPRECATED_COMMIT_DATE)
+
+        error = efp_runner_version_error(DEFAULT_REPO, DEPRECATED_SHA)
+
+        self.assertIsNotNone(error)
+        self.assertIn(DEPRECATED_SHA[:7], error)
+        self.assertIn(f"{DEPRECATED_COMMIT_DATE:%B %-d, %Y}", error)
+        self.assertIn(f"{EFP_MINIMUM_COMMIT_DATE:%B %-d, %Y}", error)
+
+    @patch("studies.helpers.requests.get")
+    def test_deprecation_message_offers_clearing_the_field(self, mock_get):
+        """The blank-means-latest behavior is the easiest fix, so it has to be advertised.
+
+        This is coupled to EFPForm.clean_last_known_player_sha resolving a blank SHA
+        to branch HEAD - if that ever changes, this message needs to change too.
+        """
+        mock_get.return_value = mock_commit_response(DEPRECATED_COMMIT_DATE)
+
+        error = efp_runner_version_error(DEFAULT_REPO, DEPRECATED_SHA)
+
+        self.assertIn("clear the experiment runner version field", error)
+
+    @patch("studies.helpers.requests.get")
+    def test_commit_after_the_cutoff_is_allowed(self, mock_get):
+        mock_get.return_value = mock_commit_response(SUPPORTED_COMMIT_DATE)
+
+        self.assertIsNone(efp_runner_version_error(DEFAULT_REPO, SUPPORTED_SHA))
+
+    @patch("studies.helpers.requests.get")
+    def test_commit_exactly_on_the_cutoff_is_allowed(self, mock_get):
+        """The cutoff is the oldest supported date, not the newest unsupported one."""
+        mock_get.return_value = mock_commit_response(EFP_MINIMUM_COMMIT_DATE)
+
+        self.assertIsNone(efp_runner_version_error(DEFAULT_REPO, DEPRECATED_SHA))
+
+    @parameterized.expand([("blank", ""), ("none", None)])
+    @patch("studies.helpers.requests.get")
+    def test_unpinned_version_is_allowed(self, _name, sha, mock_get):
+        """Nothing pinned means the build resolves branch HEAD, which can't be stale."""
+        self.assertIsNone(efp_runner_version_error(DEFAULT_REPO, sha))
+        mock_get.assert_not_called()
+
+    @parameterized.expand(
+        [("github fork", CUSTOM_REPO), ("hosted elsewhere", NON_GITHUB_REPO)]
+    )
+    @patch("studies.helpers.requests.get")
+    def test_custom_repos_are_exempt(self, _name, repo_url, mock_get):
+        """We only deprecate versions of our own repo."""
+        self.assertIsNone(efp_runner_version_error(repo_url, DEPRECATED_SHA))
+        mock_get.assert_not_called()
+
+    @patch("studies.helpers.requests.get")
+    def test_github_failure_fails_closed(self, mock_get):
+        mock_get.side_effect = requests.exceptions.ConnectionError
+
+        self.assertEqual(
+            efp_runner_version_error(DEFAULT_REPO, SUPPORTED_SHA),
+            EFP_VERSION_UNVERIFIABLE,
+        )
+
+
+@override_settings(EMBER_EXP_PLAYER_REPO=DEFAULT_REPO)
+class StudyEFPRunnerVersionTestCase(TestCase):
+    """Study.get_efp_runner_version_error and the state transitions that use it."""
+
+    def setUp(self):
+        self.lab = Lab.objects.create(
+            name="EFP Version Lab", institution="Test", contact_email="test@test.com"
+        )
+
+    def create_study(self, metadata, study_type=None, **kwargs):
+        return Study.objects.create(
+            name="EFP Version Study",
+            lab=self.lab,
+            study_type=study_type or StudyType.get_ember_frame_player(),
+            metadata=metadata,
+            **kwargs,
+        )
+
+    @patch("studies.models.efp_runner_version_error")
+    def test_passes_the_studys_pinned_version_through(self, mock_error):
+        """The metadata values are forwarded as-is; the helper owns the verdict."""
+        # study.get_efp_runner_version_error:
+        # - Reads player_repo_url and last_known_player_sha out of metadata and passes them to the
+        # efp_runner_version_error helper in that order.
+        # - Returns the helper's verdict (None) unchanged rather than deciding anything itself
+        mock_error.return_value = None
+        study = self.create_study(
+            {"player_repo_url": CUSTOM_REPO, "last_known_player_sha": DEPRECATED_SHA}
+        )
+
+        self.assertIsNone(study.get_efp_runner_version_error())
+        mock_error.assert_called_once_with(CUSTOM_REPO, DEPRECATED_SHA)
+
+    @patch("studies.models.efp_runner_version_error")
+    def test_returns_the_message_unchanged(self, mock_error):
+        mock_error.return_value = "version too old"
+        study = self.create_study(
+            {"player_repo_url": DEFAULT_REPO, "last_known_player_sha": DEPRECATED_SHA}
+        )
+
+        self.assertEqual(study.get_efp_runner_version_error(), "version too old")
+
+    @parameterized.expand(
+        [
+            ("key absent", {"last_known_player_sha": DEPRECATED_SHA}),
+            (
+                "key present but null",
+                {"player_repo_url": None, "last_known_player_sha": DEPRECATED_SHA},
+            ),
+            ("no metadata at all", {}),
+        ]
+    )
+    @patch("studies.models.efp_runner_version_error")
+    def test_missing_repo_url_falls_back_to_the_default_repo(
+        self, _name, metadata, mock_error
+    ):
+        """A null URL must not silently exempt the study as if it were a custom fork."""
+        # Instead, it falls back to the default repo URL.
+        mock_error.return_value = None
+        study = self.create_study(metadata)
+
+        study.get_efp_runner_version_error()
+
+        self.assertEqual(mock_error.call_args.args[0], DEFAULT_REPO)
+
+    @patch("studies.models.efp_runner_version_error")
+    def test_non_efp_studies_are_exempt(self, mock_error):
+        study = self.create_study(
+            {"url": "https://mit.edu"}, study_type=StudyType.get_external()
+        )
+
+        self.assertIsNone(study.get_efp_runner_version_error())
+        mock_error.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("submit", "created", "submit"),
+            ("resubmit after rejection", "rejected", "resubmit"),
+            ("resubmit after retraction", "retracted", "resubmit"),
+            ("activate", "approved", "activate"),
+            ("activate after pause", "paused", "activate"),
+        ]
+    )
+    @patch("studies.models.efp_runner_version_error")
+    def test_transition_blocked_by_deprecated_version(
+        self, _name, state, trigger, mock_error
+    ):
+        mock_error.return_value = "version too old"
+        study = self.create_study(
+            {"player_repo_url": DEFAULT_REPO, "last_known_player_sha": DEPRECATED_SHA},
+            built=True,
+        )
+        study.state = state
+        study.save()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            getattr(study, trigger)()
+
+        self.assertIn("version too old", str(ctx.exception))
+        study.refresh_from_db()
+        self.assertEqual(study.state, state, "State changed despite the check failing")
+
+    @parameterized.expand(
+        [
+            ("submit", "created", "submit", "notify_administrators_of_submission"),
+            ("resubmit", "rejected", "resubmit", "notify_administrators_of_submission"),
+            ("activate", "approved", "activate", "notify_administrators_of_activation"),
+        ]
+    )
+    @patch("studies.models.efp_runner_version_error")
+    def test_transition_allowed_by_supported_version(
+        self, _name, state, trigger, notify, mock_error
+    ):
+        mock_error.return_value = None
+        study = self.create_study(
+            {"player_repo_url": DEFAULT_REPO, "last_known_player_sha": SUPPORTED_SHA},
+            built=True,
+        )
+        study.state = state
+        study.save()
+
+        # No request user in this context, so the notification callback can't run.
+        with patch.object(study, notify):
+            getattr(study, trigger)()
+
+        study.refresh_from_db()
+        self.assertEqual(study.state, "submitted" if "submit" in trigger else "active")
+
+    @parameterized.expand([("reject", "submitted"), ("archive", "created")])
+    @patch("studies.models.efp_runner_version_error")
+    def test_ungated_transitions_ignore_the_version(self, trigger, state, mock_error):
+        """Only submit/resubmit/activate are gated - a study can always be shut down."""
+        mock_error.return_value = "version too old"
+        study = self.create_study(
+            {"player_repo_url": DEFAULT_REPO, "last_known_player_sha": DEPRECATED_SHA}
+        )
+        study.state = state
+        study.save()
+
+        with patch.object(study, "notify_submitter_of_rejection"):
+            getattr(study, trigger)()
+
+        study.refresh_from_db()
+        self.assertNotEqual(study.state, state)

--- a/studies/workflow.py
+++ b/studies/workflow.py
@@ -50,6 +50,7 @@ transitions = [
         "trigger": "submit",
         "source": "created",
         "dest": "submitted",
+        "before": "check_efp_runner_version",
         "after": "notify_administrators_of_submission",
     },
     {
@@ -94,13 +95,18 @@ transitions = [
         "trigger": "resubmit",
         "source": ["rejected", "retracted"],
         "dest": "submitted",
+        "before": "check_efp_runner_version",
         "after": "notify_administrators_of_submission",
     },
     {
         "trigger": "activate",
         "source": ["approved", "paused"],
         "dest": "active",
-        "before": ["check_if_built", "check_if_at_max_responses"],
+        "before": [
+            "check_if_built",
+            "check_if_at_max_responses",
+            "check_efp_runner_version",
+        ],
         "after": ["notify_administrators_of_activation"],
     },
     {

--- a/web/static/js/efp-runner.js
+++ b/web/static/js/efp-runner.js
@@ -18,16 +18,77 @@ function updateProtocolDisplay() {
     }
 }
 
+// The SHA the server last validated: what was saved, or what was rejected
+// by the last save attempt. Once this field has any other value, the error shown
+// for the field is no longer relevant.
+const SHA_FIELD = document.querySelector('#id_last_known_player_sha');
+const SUBMITTED_SHA = SHA_FIELD.value;
+
+// django_bootstrap5 marks a field that failed validation with is-invalid:
+// this is how we can tell whether the page was re-rendered after a rejected save
+// (versus when the page first loads with a version that was already saved)
+function shaFieldHasServerError() {
+    return SHA_FIELD.classList.contains('is-invalid');
+}
+
+// Hide the form validation/save error once the researcher edits the version, so it can't sit there
+// contradicting the live warning below it (otherwise it stays until the next form submission).
+function clearStaleServerError() {
+    if (!shaFieldHasServerError() || SHA_FIELD.value === SUBMITTED_SHA) {
+        return;
+    }
+
+    const fieldMessages = [...SHA_FIELD.parentNode.querySelectorAll('.invalid-feedback')];
+    const staleText = fieldMessages.map(message => message.textContent.trim());
+
+    SHA_FIELD.classList.remove('is-invalid');
+    fieldMessages.forEach(message => message.remove());
+
+    // The summary above the form repeats every field's errors, so remove only the lines
+    // matching this SHA field - errors on the structure or generator fields still stand.
+    document.querySelectorAll('ul.list-unstyled.text-danger').forEach(summary => {
+        summary.querySelectorAll('li').forEach(line => {
+            if (staleText.includes(line.textContent.trim())) {
+                line.remove();
+            }
+        });
+        if (!summary.querySelector('li')) {
+            summary.remove();
+        }
+    });
+}
+
+// Loose match on the repo URL, so that e.g. a trailing slash or a .git suffix doesn't
+// exempt a study from the warning. This is just meant to be a flag/warning 
+// (studies/helpers.py is_default_player_repo is what actually decides).
+function isDefaultRepo(repoUrl) {
+    const normalize = url => url.trim().toLowerCase()
+        .replace(/^http:/, 'https:')
+        .replace('://www.', '://')
+        .replace(/(\.git)?\/*$/, '');
+    return Boolean(DATA.defaultRepo) && normalize(repoUrl) === normalize(DATA.defaultRepo);
+}
+
 function updateCommitDescription() {
     const httpRequest = new XMLHttpRequest();
 
 
     const commitUpdateInfo = document.querySelector('#commit-update-info');
     const commitDescription = document.querySelector('#commit-description');
+    const commitDetails = document.querySelector('#commit-details');
+    const noVersionSelected = document.querySelector('#no-version-selected');
+    const updateButton = document.querySelector('#update-button');
+    const deprecationWarning = document.querySelector('#version-deprecated-warning');
+
+    const playerSha = SHA_FIELD.value.trim();
+    const playerRepoUrl = document.querySelector('#id_player_repo_url').value.trim();
 
     // Hide commit info cards
     commitUpdateInfo.classList.add('d-none');
     commitDescription.classList.add('d-none');
+
+    // Hide the deprecation warning until a commit comes back old, so that an unanswered or failed request does not leave a stale warning behind from the previous SHA in the field.
+    deprecationWarning.classList.add('d-none');
 
     httpRequest.onreadystatechange = () => {
 
@@ -55,18 +116,39 @@ function updateCommitDescription() {
                     .map(e => `<div>${e.status}: <a href = "${e.blob_url}"> ${e.filename}</a></div>`)
                     .join('');
 
-                // show commit description card
+                // show commit description card and update button, and hide the 'no version selected' message
+                commitDetails.classList.remove('d-none');
+                noVersionSelected.classList.add('d-none');
+                updateButton.classList.remove('d-none');
                 commitDescription.classList.remove('d-none');
+
+                // Skip the warning while the server error is up (shaFieldHasServerError), since the two say the same thing
+                // about the same SHA. If the form validation error was removed, then we can show a live warning based
+                // on the current value.
+                // Committer date, not the author date shown above it: the author date
+                // survives a rebase, so it can be much older than the version itself.
+                // studies/helpers.py get_commit_datetime gates on the same field.
+                if (DATA.minCommitDate && !shaFieldHasServerError()
+                    && isDefaultRepo(playerRepoUrl)
+                    && new Date(response.commit.committer.date) < new Date(DATA.minCommitDate)) {
+                    deprecationWarning.classList.remove('d-none');
+                }
             }
         }
     };
 
-    const playerSha = document.querySelector('#id_last_known_player_sha').value.trim();
-    const playerRepoUrl = document.querySelector('#id_player_repo_url').value.trim();
     if (playerSha && playerRepoUrl) {
         const githubApiUrl = `${playerRepoUrl}/commits/${playerSha}`.replace('github.com', 'api.github.com/repos');
         httpRequest.open("GET", githubApiUrl, true);
         httpRequest.send();
+    } else if (!playerSha) {
+        // If the commit field is blank then show the 'no version selected' message and description card, but
+        // hide any commit details and the update button.
+        // (Don't try to figure out which commit is latest since that is settled by the server when the form is saved, not here.)
+        commitDetails.classList.add('d-none');
+        noVersionSelected.classList.remove('d-none');
+        updateButton.classList.add('d-none');
+        commitDescription.classList.remove('d-none');
     }
 }
 
@@ -161,5 +243,9 @@ updateLastPlayerSha();
  */
 document.querySelector('#id_use_generator').addEventListener("click", updateProtocolDisplay);
 document.querySelector('#update-button').addEventListener("click", updateCommitUpdateInfo);
-document.querySelector('#id_last_known_player_sha').addEventListener('keyup', updateCommitDescription);
+// Use "input" event rather than "keyup" so that it is triggered by pasting a SHA from the context menu. 
+// Clearing runs first so that updateCommitDescription sees that any validation errors are
+// already gone and is free to warn about whatever version was typed instead.
+SHA_FIELD.addEventListener('input', clearStaleServerError);
+SHA_FIELD.addEventListener('input', updateCommitDescription);
 document.querySelector('form#experiment_runner_form').addEventListener('submit', validateGenerator);

--- a/web/static/js/efp-runner.js
+++ b/web/static/js/efp-runner.js
@@ -39,7 +39,7 @@ function clearStaleServerError() {
     }
 
     const fieldMessages = [...SHA_FIELD.parentNode.querySelectorAll('.invalid-feedback')];
-    const staleText = fieldMessages.map(message => message.textContent.trim());
+    const staleText = new Set(fieldMessages.map(message => message.textContent.trim()));
 
     SHA_FIELD.classList.remove('is-invalid');
     fieldMessages.forEach(message => message.remove());
@@ -48,7 +48,7 @@ function clearStaleServerError() {
     // matching this SHA field - errors on the structure or generator fields still stand.
     document.querySelectorAll('ul.list-unstyled.text-danger').forEach(summary => {
         summary.querySelectorAll('li').forEach(line => {
-            if (staleText.includes(line.textContent.trim())) {
+            if (staleText.has(line.textContent.trim())) {
                 line.remove();
             }
         });
@@ -62,10 +62,16 @@ function clearStaleServerError() {
 // exempt a study from the warning. This is just meant to be a flag/warning 
 // (studies/helpers.py is_default_player_repo is what actually decides).
 function isDefaultRepo(repoUrl) {
-    const normalize = url => url.trim().toLowerCase()
-        .replace(/^http:/, 'https:')
-        .replace('://www.', '://')
-        .replace(/(\.git)?\/*$/, '');
+    // Dropp the scheme rather than rewriting http to https, and split on "/"
+    // rather than matching a trailing-slash pattern, which keeps every step here linear
+    // (an anchored quantifier like /(\.git)?\/*$/ backtracks over a run of slashes).
+    const normalize = url => {
+        const withoutScheme = url.trim().toLowerCase()
+            .replace(/^https?:\/\//, '')
+            .replace(/^www\./, '');
+        const path = withoutScheme.split('/').filter(Boolean).join('/');
+        return path.endsWith('.git') ? path.slice(0, -'.git'.length) : path;
+    };
     return Boolean(DATA.defaultRepo) && normalize(repoUrl) === normalize(DATA.defaultRepo);
 }
 


### PR DESCRIPTION
This PR adds deprecation for old (Pipe recording) versions of EFP. It does the following:

- Adds a pre-save warning on the form, letting the researcher know that their commit is out-of-date (for default EFP repo only) and that they will need to update it if they want to make changes to the study design, build the experiment runner, or start data collection.
- Adds form validation that checks the commit date (for default EFP repo only) and, if the commit date is too old, fails to save the form with a message to the researcher.
- Adds a commit date check to study state transitions: created -> submit, rejected/retracted -> resubmit, approved/paused -> activate. If the commit is too old, the transition fails with a message to the researcher.
- Adds a commit date check to the study build trigger, and if the commit is too old, the build is blocked with a message to the researcher.
- Implements the ability to leave the commit SHA field blank to update to the latest version. If the field is blank when the form is saved, and the default EFP repo is used, then the study will use the latest commit. The study will be pinned to that commit going forward, and researchers can then modify the commit as usual if they want to.
- Updates the form's help text under the SHA field and its placeholder text to indicate that the user can leave it blank to automatically update to the latest version. The "About this version" box will also indicate the same thing whenever the field is empty.
- Adds tests for form changes, pre-build check, study state transitions, and helper functions.

Note that studies can continue to exist in our database with deprecated experiment runner versions - this might be important for archiving/record-keeping purposes. The changes in this PR just prevent researchers from submitting or activating those studies, or continuing to work on them without updating (you can't modify the JSON/JS for a study that uses a deprecated version - if someone wants to build on an existing study without updating the EFP version for that study, then they can clone it and update/modify the clone).

## Screenshots

Pre-save warning on the EFP design page with a deprecated version:

<img width="973" height="643" alt="efp_version_presubmit_warning" src="https://github.com/user-attachments/assets/eec222b9-a0ee-4f27-81db-b723b0d24b55" />

Form validation error following a save button click with a deprecated version. Note that, as soon as the researcher edits the SHA field on this page, the form validation warnings will disappear and the JS will check for commit validity/age. If a deprecated commit value is entered again, then the pre-save warning (above) will appear.

<img width="973" height="613" alt="efp_version_form_submit_error" src="https://github.com/user-attachments/assets/ce865011-7577-4155-b819-826cbacfc3ba" />

Researchers can leave the SHA field blank to automatically update to the latest version. There is now help text under this field and placeholder text to let researchers know. Also, when the SHA field is blank, the "About this version" box will indicate that the latest commit will be used (if the form is submitted).
If the researcher is using a custom repository, then we cannot automatically grab the latest commit. Therefore the SHA field needs to have a value (same as before).

<img width="973" height="486" alt="efp_version_blank_field" src="https://github.com/user-attachments/assets/342c1916-2d0e-4dec-b564-cb35107694f6" />

A build attempt is blocked when the study uses a deprecated EFP version:

<img width="1158" height="183" alt="efp_version_blocked_build" src="https://github.com/user-attachments/assets/8d7d2a6a-ca26-4e5b-9780-4c7a77275a51" />

A study cannot be started when it uses a deprecated EFP version:

<img width="1121" height="173" alt="efp_version_cannot_activate" src="https://github.com/user-attachments/assets/4e8b8c8b-f69b-462f-8f09-5876f807d650" />

A study cannot be submitted when it uses a deprecated EFP version:

<img width="1121" height="173" alt="efp_version_cannot_submit" src="https://github.com/user-attachments/assets/d94e619b-bf98-497f-a52a-43618c0a5dce" />

A study cannot be resubmitted when it uses a deprecated EFP version:

<img width="1121" height="173" alt="efp_version_cannot_resubmit" src="https://github.com/user-attachments/assets/f8eb23d5-4999-42be-9743-801041cda702" />
