### PR TITLE
Harden CircleCI CSS job against network failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: Run linters
           command: uv run pre-commit run --all-files
-  css: 
+  css:
     docker:
       - image: cimg/python:3.13
     steps:
@@ -44,9 +44,16 @@ jobs:
       - run:
           name: Install dependencies with uv
           command: uv sync --frozen
+      - restore_cache:
+          keys:
+            - bootstrap-src-v1-5.2.0
       - run:
           name: Compile css
           command: uv run ./manage.py custom_bootstrap5
+      - save_cache:
+          key: bootstrap-src-v1-5.2.0
+          paths:
+            - bootstrap-5.2.0
 
 workflows:
   ci: 

--- a/web/management/commands/custom_bootstrap5.py
+++ b/web/management/commands/custom_bootstrap5.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         bs5_filename = bs5_url.split("/")[-1]
 
         # the known root directory of the BS5 archive zip file
-        zip_root_dir = Path("bootstrap-5.2.0")
+        zip_root_dir = Path(f"bootstrap-{bs5_version}")
 
         # get the hash of the exisiting compiled css file
         css_hash = self.get_css_hash()


### PR DESCRIPTION
This PR adds caching for the bootstrap5 source file, which is currently being requested/downloaded on every CI job. These network requests are vulnerable to intermittent failures, which causes the whole CSS job to fail. Once the BS5 file is successfully retrieved by CircleCI, it should be cached for all future jobs. 

When we update the BS5 version it will be vulnerable to network issues again until cached.