### PR TITLE
Fix Sentry issues

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -265,7 +265,7 @@ class PasswordChangeForm(DjangoPasswordChangeForm):
             password = self.cleaned_data.get("new_password2")
             if len(password) < 16:
                 raise ValidationError("Password must be at least 16 characters.")
-        return super().clean_new_password2()
+        return self.cleaned_data.get("new_password2")
 
     class Meta:
         model = User

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -57,8 +57,13 @@ class TwoFactorAuthLoginView(UserPassesTestMixin, LoginView):
     form_class = TOTPCheckForm
 
     def user_is_researcher_or_staff(self):
-        return getattr(self.request.user, "is_researcher") or getattr(
-            self.request.user, "is_staff"
+        # We need a default value (False) when trying to retrieve the is_researcher
+        # attribute from the requesting user to handle AnonymousUser cases,
+        # otherwise this throws 'AnonymousUser' object has no attribute 'is_researcher'
+        # (normally a view that needs user attributes sits behind LoginRequiredMixin
+        # or ResearcherLoginRequiredMixin, but login pages are deliberately public).
+        return getattr(self.request.user, "is_researcher", False) or getattr(
+            self.request.user, "is_staff", False
         )
 
     test_func = user_is_researcher_or_staff

--- a/api/views.py
+++ b/api/views.py
@@ -264,8 +264,12 @@ class StudyViewSet(FilterByUrlKwargsMixin, views.ModelViewSet):
         if "List" in self.get_view_name():
             qs = qs.filter(public=True)
 
-        # Researchers
-        if self.request.user.is_researcher:
+        # Researchers can also see studies they may preview.
+        # Need to handle Anonymous requests here, because the browsable API renderer
+        # calls get_queryset() even when rendering a permission-denied response, and AnonymousUser
+        # has no is_researcher attribute, which will cause this line to throw.
+        # So we need to short-circuit with is_authenticated first.
+        if self.request.user.is_authenticated and self.request.user.is_researcher:
             preview_studies = Study.objects.filter(
                 shared_preview=True
             ) | studies_for_which_user_has_perm(

--- a/exp/views/responses.py
+++ b/exp/views/responses.py
@@ -1078,10 +1078,14 @@ class StudyResponseVideoAttachment(
             return redirect(view_url)
 
 
-class StudyResponseSubmitFeedback(StudyLookupMixin, UserPassesTestMixin, View):
+class StudyResponseSubmitFeedback(
+    ResearcherLoginRequiredMixin, UserPassesTestMixin, StudyLookupMixin, View
+):
     """
     View to create or edit response feedback.
     """
+
+    raise_exception = True
 
     def user_can_edit_feedback(self):
         user = self.request.user

--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -688,16 +688,24 @@ def complete_multipart_upload(bucket_name, filename, id, parts):
         else:
             logger.debug(f"Error completing file {filename}. S3 response: {resp}")
     except ClientError as error:
-        # If the file cannot be completed because of a problem with size/parts, log it for our info but
-        # ignore it and move on. It will be deleted via the S3 bucket's lifecycle rule.
-        logger.error(f"Error completing file {filename}: {error}")
+        # Some completion failures are expected for incomplete uploads (too few/small
+        # parts, or an upload that no longer exists). Log those at warning level for
+        # visibility but ignore them and move on - the file will be deleted via the S3
+        # bucket's lifecycle rule. Any other ClientError is unexpected: log it as an
+        # error and re-raise.
         ignore_errors = [
             "EntityTooSmall",
             "InvalidPart",
             "InvalidPartOrder",
             "NoSuchUpload",
         ]
-        if error.response["Error"]["Code"] not in ignore_errors:
+        error_code = error.response["Error"]["Code"]
+        if error_code in ignore_errors:
+            logger.warning(
+                f"Skipping incomplete file {filename} ({error_code}): {error}"
+            )
+        else:
+            logger.error(f"Error completing file {filename}: {error}")
             raise error
     except ParamValidationError as error:
         raise ValueError(f"The parameters you provided are incorrect: {error}")

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -2485,9 +2485,9 @@ class TestCompleteMultipartUpload(TestCase):
             [{"PartNumber": 1, "ETag": "etag1"}],
         )
 
-        # complete_multipart_upload should log this error but not raise it
-        mock_logger.error.assert_called_with(
-            "Error completing file example_video.webm: An error occurred (EntityTooSmall) when calling the CompleteMultipartUpload operation: Your proposed upload is smaller than the minimum allowed size"
+        # complete_multipart_upload should log this warning but not raise it
+        mock_logger.warning.assert_called_with(
+            "Skipping incomplete file example_video.webm (EntityTooSmall): An error occurred (EntityTooSmall) when calling the CompleteMultipartUpload operation: Your proposed upload is smaller than the minimum allowed size"
         )
 
 

--- a/web/tests/test_views.py
+++ b/web/tests/test_views.py
@@ -428,12 +428,18 @@ class StudiesListViewTestCase(TestCase):
     @parameterized.expand([(True, 302), (False, 200)])
     @patch("web.views.StudiesListView.get_form")
     @patch.object(StudiesListView, "request", create=True)
-    def test_post(self, is_valid, status_code, mock_request, mock_get_form):
-        with patch.object(StudiesListView, "object_list", create=True):
-            mock_get_form().is_valid.return_value = is_valid
-            view = StudiesListView()
-            response = view.post(mock_request)
-            self.assertEqual(response.status_code, status_code)
+    @patch.object(StudiesListView, "get_queryset", return_value=[])
+    def test_post(
+        self, is_valid, status_code, mock_get_queryset, mock_request, mock_get_form
+    ):
+        mock_get_form().is_valid.return_value = is_valid
+        view = StudiesListView()
+        response = view.post(mock_request)
+        self.assertEqual(response.status_code, status_code)
+        # post() must set object_list, since get_context_data() requires it when
+        # this view is reached via POST and the form is invalid.
+        mock_get_queryset.assert_called_once_with()
+        self.assertEqual(view.object_list, [])
 
     def test_search_options_auth_user(self):
         mock_request = MagicMock(method="GET")

--- a/web/views.py
+++ b/web/views.py
@@ -429,6 +429,11 @@ class StudiesListView(generic.ListView, FormView):
     model = Study
 
     def post(self, request, *args, **kwargs):
+        # ListView.get() normally sets object_list, rather than POST.
+        # But since this is also a form, this view can be reached first via POST,
+        # which calls form_invalid(), then get_context_data(),
+        # which requires the object_list. So we need to set it here.
+        self.object_list = self.get_queryset()
         form = self.get_form()
 
         if form.is_valid():
@@ -676,6 +681,11 @@ class StudiesHistoryView(
     responses_per_study = 10
 
     def post(self, request, *args, **kwargs):
+        # ListView.get() normally sets object_list, rather than POST.
+        # But since this is also a form, this view can be reached first via POST,
+        # which calls form_invalid(), then get_context_data(),
+        # which requires the object_list. So we need to set it here.
+        self.object_list = self.get_queryset()
         form = self.get_form()
 
         if form.is_valid():


### PR DESCRIPTION
This PR fixes some very frequent issues that aren't major but stack up in Sentry. Clearing this will help improve the site overall, plus it clears the Sentry issue log for other errors that need our attention.

- Fix regression from Django update that caused the "'super' object has no attribute 'clean_new_password2'" error. The updated version removed the clean_[field] methods on the parent class, so now the clean_[field] methods need to return the cleaned value, rather than calling the same method on super. 
- Fix "AnonymousUser has no attribute 'is_researcher'": 2fa-login and StudyViewSet views need to guard against AnonymousUser
- StudyResponseSubmitFeedback view was missing researcher login requirement/check (also guards against AnonymousUser error)
- Fix "StudiesListView object has no attribute object_list" / "StudiesHistoryView object has no attribute object_list": usually object_list in just defined in GET, but since these lists are also forms, we need to handle the case where POST produces an invalid form, which calls get_context_data, which requires the object_list, which was never set.
- Fix several expected errors related to incomplete videos ("Error completing file...: An error occurred (NoSuchUpload, etc.) when calling the CompleteMultipartUpload operation"). These are still logged, but they are downgraded to warnings so that they are not also sent to Sentry as errors.