### PR TITLE
Lock the lab edit form after approved to test

### DIFF
--- a/exp/tests/test_lab_views.py
+++ b/exp/tests/test_lab_views.py
@@ -113,6 +113,39 @@ class LabViewsTestCase(TestCase):
             "Incorrect template used for displaying lab detail page",
         )
 
+    # Lab detail view: only links to pages the researcher can actually open
+    def testLabDetailViewLinksWithoutPerms(self):
+        # In the lab, but no lab admin permissions
+        self.client.force_login(self.researcher)
+        page = self.client.get(self.lab_detail_url)
+        self.assertNotContains(
+            page,
+            f'href="{self.lab_update_url}"',
+            msg_prefix="Edit lab link shown to researcher without edit permissions",
+        )
+        self.assertContains(page, f'href="{self.lab_members_url}"')
+
+    def testLabDetailViewLinksOutsideLab(self):
+        self.client.force_login(self.researcher_outside_lab)
+        page = self.client.get(self.lab_detail_url)
+        self.assertNotContains(page, f'href="{self.lab_update_url}"')
+        self.assertNotContains(
+            page,
+            f'href="{self.lab_members_url}"',
+            msg_prefix="Lab members link shown to researcher outside the lab",
+        )
+
+    def testLabDetailViewLinksWithPerms(self):
+        assign_perm(LabPermission.EDIT_LAB_METADATA.codename, self.researcher, self.lab)
+        self.client.force_login(self.researcher)
+        page = self.client.get(self.lab_detail_url)
+        self.assertContains(
+            page,
+            f'href="{self.lab_update_url}"',
+            msg_prefix="Edit lab link hidden from researcher with edit permissions",
+        )
+        self.assertContains(page, f'href="{self.lab_members_url}"')
+
     # Lab detail view: cannot see as participant
     def testCanGetLabDetailViewAsParticipant(self):
         self.client.force_login(self.participant)
@@ -257,6 +290,15 @@ class LabViewsTestCase(TestCase):
             200,
             "Researcher not able to access lab update view despite permissions",
         )
+        self.assertFalse(
+            page.context["lab_is_locked"],
+            "Lab that is not approved to test is locked for editing",
+        )
+        self.assertFalse(
+            any(field.disabled for field in page.context["form"].fields.values()),
+            "Fields disabled for a lab that is not approved to test",
+        )
+        self.assertNotContains(page, "This lab is approved to run studies on CHS")
 
     # Lab update view: cannot post as researcher w/o edit perms
     def testPostLabUpdateViewIncorrectPerms(self):
@@ -352,6 +394,133 @@ class LabViewsTestCase(TestCase):
         self.assertTrue(
             updated_lab.approved_to_test,
             "Researcher could not approve lab to test despite permission",
+        )
+
+    # Lab update view: form is locked/read-only once lab is approved to test
+    def testGetLabUpdateViewApprovedLab(self):
+        Lab.objects.filter(pk=self.lab.pk).update(approved_to_test=True)
+        assign_perm(LabPermission.EDIT_LAB_METADATA.codename, self.researcher, self.lab)
+        self.client.force_login(self.researcher)
+        page = self.client.get(self.lab_update_url)
+        self.assertEqual(page.status_code, 200)
+        self.assertTrue(
+            page.context["lab_is_locked"],
+            "Approved lab not marked as locked for researcher",
+        )
+        self.assertTrue(
+            all(field.disabled for field in page.context["form"].fields.values()),
+            "Fields are still editable for a lab that is approved to test",
+        )
+        self.assertContains(page, "This lab is approved to run studies on CHS")
+        self.assertContains(page, 'disabled="disabled"')
+
+    # Lab update view: admins can still edit an approved lab
+    def testGetLabUpdateViewApprovedLabAsAdmin(self):
+        Lab.objects.filter(pk=self.lab.pk).update(approved_to_test=True)
+        assign_perm(LabPermission.EDIT_LAB_APPROVAL.prefixed_codename, self.researcher)
+        assign_perm(LabPermission.EDIT_LAB_METADATA.prefixed_codename, self.researcher)
+        self.client.force_login(self.researcher)
+        page = self.client.get(self.lab_update_url)
+        self.assertEqual(page.status_code, 200)
+        self.assertFalse(
+            page.context["lab_is_locked"],
+            "Approved lab locked for admin who can edit lab approval",
+        )
+        self.assertFalse(
+            any(field.disabled for field in page.context["form"].fields.values()),
+            "Fields disabled for admin who can edit lab approval",
+        )
+
+    # Lab update view: cannot post changes to a lab that is approved to test
+    def testPostLabUpdateViewApprovedLab(self):
+        Lab.objects.filter(pk=self.lab.pk).update(approved_to_test=True)
+        assign_perm(LabPermission.EDIT_LAB_METADATA.codename, self.researcher, self.lab)
+        self.client.force_login(self.researcher)
+        post_data = {
+            "name": "New lab",
+            "principal_investigator_name": "Jane Smith",
+            "institution": "New institution",
+            "contact_email": "abc@def.org",
+            "contact_phone": "(123) 456-7890",
+            "lab_website": "https://mit.edu",
+            "description": "ABCDEFG",
+            "irb_contact_info": "how to reach the IRB",
+            "slug": "new-lab",
+        }
+        page = self.client.post(self.lab_update_url, post_data)
+        self.assertEqual(page.status_code, 302)
+        updated_lab = Lab.objects.get(pk=self.lab.pk)
+        self.assertEqual(
+            updated_lab.institution,
+            "MIT",
+            "Researcher able to edit lab metadata after lab was approved to test",
+        )
+
+    # Lab update view: admins can post changes to a lab that is approved to test
+    def testPostLabUpdateViewApprovedLabAsAdmin(self):
+        Lab.objects.filter(pk=self.lab.pk).update(approved_to_test=True)
+        assign_perm(LabPermission.EDIT_LAB_APPROVAL.prefixed_codename, self.researcher)
+        assign_perm(LabPermission.EDIT_LAB_METADATA.prefixed_codename, self.researcher)
+        self.client.force_login(self.researcher)
+        post_data = {
+            "name": "New lab",
+            "principal_investigator_name": "Jane Smith",
+            "institution": "New institution",
+            "contact_email": "abc@def.org",
+            "contact_phone": "(123) 456-7890",
+            "lab_website": "https://mit.edu",
+            "description": "ABCDEFG",
+            "irb_contact_info": "how to reach the IRB",
+            "approved_to_test": True,
+            "slug": "new-lab",
+        }
+        page = self.client.post(self.lab_update_url, post_data)
+        self.assertEqual(page.status_code, 302)
+        updated_lab = Lab.objects.get(pk=self.lab.pk)
+        self.assertEqual(
+            updated_lab.institution,
+            "New institution",
+            "Admin unable to edit lab metadata for a lab approved to test",
+        )
+
+    # Lab update view: form unlocks again if approval is removed
+    def testLabUpdateViewUnlockedWhenApprovalRemoved(self):
+        assign_perm(LabPermission.EDIT_LAB_METADATA.codename, self.researcher, self.lab)
+        self.client.force_login(self.researcher)
+
+        Lab.objects.filter(pk=self.lab.pk).update(approved_to_test=True)
+        page = self.client.get(self.lab_update_url)
+        self.assertTrue(page.context["lab_is_locked"])
+
+        Lab.objects.filter(pk=self.lab.pk).update(approved_to_test=False)
+        page = self.client.get(self.lab_update_url)
+        self.assertFalse(
+            page.context["lab_is_locked"],
+            "Lab still locked after approval to test was removed",
+        )
+        self.assertFalse(
+            any(field.disabled for field in page.context["form"].fields.values()),
+            "Fields still disabled after approval to test was removed",
+        )
+
+        post_data = {
+            "name": "New lab",
+            "principal_investigator_name": "Jane Smith",
+            "institution": "New institution",
+            "contact_email": "abc@def.org",
+            "contact_phone": "(123) 456-7890",
+            "lab_website": "https://mit.edu",
+            "description": "ABCDEFG",
+            "irb_contact_info": "how to reach the IRB",
+            "slug": "new-lab",
+        }
+        page = self.client.post(self.lab_update_url, post_data)
+        self.assertEqual(page.status_code, 302)
+        updated_lab = Lab.objects.get(pk=self.lab.pk)
+        self.assertEqual(
+            updated_lab.institution,
+            "New institution",
+            "Researcher unable to edit lab after approval to test was removed",
         )
 
     # Lab membership request: can make as researcher

--- a/exp/views/lab.py
+++ b/exp/views/lab.py
@@ -347,19 +347,57 @@ class LabUpdateView(
 ):
     """
     LabUpdateView allows updating lab metadata.
+
+    Once a lab has been approved to test, its metadata is locked: the form is shown
+    read-only and changes are rejected on submission. Admins who can edit lab approval
+    are exempt so that they can make edits and change approval status.
     """
 
     template_name = "studies/lab_update.html"
     model = Lab
     raise_exception = True
 
-    def get_form_class(self):
-        if self.request.user.has_perm(
+    def user_can_edit_approval(self):
+        return self.request.user.has_perm(
             LabPermission.EDIT_LAB_APPROVAL.prefixed_codename
-        ):
+        )
+
+    def lab_is_locked(self):
+        return self.get_object().approved_to_test and not self.user_can_edit_approval()
+
+    def get_form_class(self):
+        if self.user_can_edit_approval():
             return LabApprovalForm
         else:
             return LabForm
+
+    def get_form(self, form_class=None):
+        """
+        Render every field read-only when the lab is locked
+        (approved to test is True and user is not an admin).
+        """
+        form = super().get_form(form_class)
+        if self.lab_is_locked():
+            for field in form.fields.values():
+                field.disabled = True
+        return form
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["lab_is_locked"] = self.lab_is_locked()
+        return context
+
+    def post(self, request, *args, **kwargs):
+        """Reject edits to an approved lab, even if the disabled form is bypassed."""
+        if self.lab_is_locked():
+            messages.error(
+                request,
+                "This lab has been approved to run studies on CHS, so its details "
+                "can no longer be edited. Please contact CHS staff at "
+                "support@childrenhelpingscience.org if you need to make changes.",
+            )
+            return HttpResponseRedirect(self.get_success_url())
+        return super().post(request, *args, **kwargs)
 
     def user_can_edit_lab(self):
         lab = self.get_object()

--- a/studies/templates/emails/notify_lab_admins_of_approval.html
+++ b/studies/templates/emails/notify_lab_admins_of_approval.html
@@ -6,6 +6,10 @@
     You can view your lab <a href="{% absolute_url 'exp:lab-detail' pk=lab_id %}">here</a>.
 </p>
 <p>
+    Now that your lab is approved, its details can no longer be edited. If you need to change any of your lab's information, please contact us at
+    <a href="mailto:support@childrenhelpingscience.org">support@childrenhelpingscience.org</a>.
+</p>
+<p>
     Best,
     Lookit Admin
 </p>

--- a/studies/templates/emails/notify_lab_admins_of_approval.txt
+++ b/studies/templates/emails/notify_lab_admins_of_approval.txt
@@ -5,5 +5,7 @@ Your lab, {{ lab_name }}, has been approved to begin using Lookit for data colle
 
 You can view your lab here: {% absolute_url 'exp:lab-detail' pk=lab_id %}
 
+Now that your lab is approved, its details can no longer be edited. If you need to change any of your lab's information, please contact us at support@childrenhelpingscience.org.
+
 Best,
 Lookit Admin

--- a/studies/templates/studies/lab_detail.html
+++ b/studies/templates/studies/lab_detail.html
@@ -17,8 +17,21 @@
 {% block content %}
     {% url 'exp:lab-edit' pk=lab.id as url_lab_edit %}
     {% url 'exp:lab-members' pk=lab.id as url_lab_members %}
-    {% set_variable '<div><a href="'|add:url_lab_edit|add:'">Edit lab</a></div>' as link_edit_lab %}
-    {% set_variable '<div><a href="'|add:url_lab_members|add:'">View/manage lab members</a></div>' as link_lab_members %}
+    {% comment %}
+        Only link to pages this researcher can actually open: both views raise a 403
+        for researchers without the relevant permissions, so an ungated link is a
+        dead end.
+    {% endcomment %}
+    {% if can_edit_lab %}
+        {% set_variable '<div><a href="'|add:url_lab_edit|add:'">Edit lab</a></div>' as link_edit_lab %}
+    {% else %}
+        {% set_variable "" as link_edit_lab %}
+    {% endif %}
+    {% if can_see_lab_researchers %}
+        {% set_variable '<div><a href="'|add:url_lab_members|add:'">View/manage lab members</a></div>' as link_lab_members %}
+    {% else %}
+        {% set_variable "" as link_lab_members %}
+    {% endif %}
     {% if in_this_lab %}
         {% set_variable "<div>You have joined this lab.</div>" as lab_join_message %}
     {% elif requested_this_lab %}

--- a/studies/templates/studies/lab_update.html
+++ b/studies/templates/studies/lab_update.html
@@ -19,15 +19,35 @@
 {% endblock breadcrumb %}
 {% block content %}
     {% url 'exp:lab-edit' pk=lab.id as url_lab_edit %}
+    {% url 'exp:lab-detail' pk=lab.id as url_lab_detail %}
     {% button_primary_classes as btn_primary_classes %}
     {% button_secondary_classes as btn_secondary_classes %}
     {% page_title "Update Lab" %}
+    {% comment %}
+        Shown when the lab has been approved to test, which locks its metadata for
+        everyone except admins who can edit lab approval. The fields are also disabled
+        and the form rejects any changes on submission, so this is informational rather
+        than an error: deliberately alert-info, not warning/danger.
+    {% endcomment %}
+    {% if lab_is_locked %}
+        <div class="alert alert-info" role="alert">
+            <strong>This lab is approved to run studies on CHS!</strong> Approved labs
+            can no longer be edited, so the details below are read-only. Please contact
+            CHS staff at <a href="mailto:support@childrenhelpingscience.org">support@childrenhelpingscience.org</a>
+            if you need to make changes.
+        </div>
+    {% endif %}
     <form action="" enctype="multipart/form-data" method="post">
         {% csrf_token %}
         {% bootstrap_form form %}
         {% form_buttons %}
-        {% bootstrap_button "Discard Changes" href=url_lab_edit button_class=btn_secondary_classes %}
-        {% bootstrap_button "Save" type="submit" button_class=btn_primary_classes %}
+        {% if lab_is_locked %}
+            {% bootstrap_button "Back to Lab" href=url_lab_detail button_class=btn_secondary_classes %}
+            {% bootstrap_button "Save" type="submit" button_class=btn_primary_classes disabled="disabled" %}
+        {% else %}
+            {% bootstrap_button "Discard Changes" href=url_lab_edit button_class=btn_secondary_classes %}
+            {% bootstrap_button "Save" type="submit" button_class=btn_primary_classes %}
+        {% endif %}
     {% endform_buttons %}
 </form>
 {% endblock content %}


### PR DESCRIPTION
Fixes #1910

This PR makes the Lab Update form read-only once a Lab has been approved to test. Researchers (with permissions to view that page) will see a message about the lab being approved to test and no longer being editable, with info about how to contact us if they need to make changes. Also, the Save button will be disabled, and the Discard Changes button is replaced with "Back to Lab".

When a lab is not 'approved to test', the form is editable by researchers with permissions. 

CHS admins can always edit the form. So if a researcher wants to make changes, we can do that for them. Or if a researcher wants to make the changes themselves, we can toggle their approved to test status (assuming the lab does not have any active or soon-to-be active studies).

This PR also removes the "Edit lab" and "View/manage lab members" links on the Lab details page for users who do not have permissions for each of those. Previously those links would show up for everyone but (correctly) produce a 403 Forbidden response if a user clicked on the link but did not have the right permissions for the page.

## Screenshots

### Researchers

If a researcher has permissions to edit the lab details and the lab is NOT currently approved to test, then the update form looks the same as before.

<img width="1159" height="204" alt="update_lab_not_approved" src="https://github.com/user-attachments/assets/2d5ad66e-4d0c-46a1-94b9-dccc52526843" />

<img width="1159" height="135" alt="update_lab_not_approved_2" src="https://github.com/user-attachments/assets/03ae1dad-58f5-47d4-a3b7-0642128c7c49" />

If the lab IS approved to test, then a researcher with lab edit permissions can view the form but not edit, with a message about why.

<img width="1159" height="293" alt="update_lab_approved" src="https://github.com/user-attachments/assets/00803580-b992-48be-a3b8-b4a22be756c6" />

<img width="1159" height="163" alt="update_lab_approved_2" src="https://github.com/user-attachments/assets/2853f20b-4e16-4120-894f-6a50f1439e8b" />

If a researcher does not have lab edit permissions, then they will not see the Edit Lab link.

<img width="1159" height="135" alt="hide_edit_lab" src="https://github.com/user-attachments/assets/2c745379-fdba-47dd-80cc-33126e185e9e" />

And if the researcher does not have permission to view lab members, then they will not see the View/Manage Lab Members link either.

<img width="1159" height="199" alt="hide_edit_view_researchers" src="https://github.com/user-attachments/assets/8668cc7e-28b5-4615-b73a-7a1e6cb73fe2" />

### CHS Admins

Admins can always see the Edit Lab and View/Manage Lab Members links, regardless of their lab membership status.

<img width="1159" height="199" alt="admin_edit_view_researchers" src="https://github.com/user-attachments/assets/433ff26d-249e-4b7c-af61-4d458306e3ed" />

Admins can always edit the Lab details, regardless of whether or not the lab is approved to test, and regardless of their lab membership status.

<img width="1159" height="199" alt="admin_update_lab_approved" src="https://github.com/user-attachments/assets/920daf85-5dcf-4dbc-8ff8-afcda401bfbe" />

<img width="1159" height="113" alt="admin_update_lab_approved_2" src="https://github.com/user-attachments/assets/a3d56dd9-159a-4535-aaa3-87e35d3a0159" />


