### PR TITLE
Exclude prior jsPsych participation from study announcement email targets

### DIFF
--- a/studies/tasks.py
+++ b/studies/tasks.py
@@ -74,7 +74,9 @@ WITH message_targets AS ( -- all valid user-child-study triplets
         FROM studies_response sr
                  INNER JOIN accounts_child ac on sr.child_id = ac.id
                  INNER JOIN studies_studytype sst on sr.study_type_id = sst.id
-        WHERE (sr.completed_consent_frame = true AND sst.id = 1)
+        -- Internal studies (EFP id 1, jsPsych id 3) count as participation once the
+        -- child has completed the consent frame; external studies (id 2) always count.
+        WHERE (sr.completed_consent_frame = true AND sst.id IN (1, 3))
 	            OR (sst.id = 2)
     )
 ),

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -664,6 +664,72 @@ class TestAnnouncementEmailFunctionality(TestCase):
         # Check that the message target no longer has this child for this study
         self.assertNotIn(message_target, potential_message_targets())
 
+    def _active_jspsych_study_target(self):
+        """Set up an active, public jsPsych study with an eligible user/child."""
+        user = G(User, is_active=True)
+        child = G(
+            Child,
+            user=user,
+            birthday=date.today() - timedelta(days=365),
+        )
+        study = G(
+            Study,
+            name="jsPsych Study",
+            study_type=StudyType.get_jspsych(),
+            image=SimpleUploadedFile("fake_image.png", b"", content_type="image/png"),
+            public=True,
+            max_age_years=2,
+            criteria_expression="",
+        )
+        study.state = "active"
+        study.save()
+
+        # Double check this is a jsPsych study
+        self.assertTrue(study.study_type.is_jspsych)
+
+        return (
+            child,
+            study,
+            MessageTarget(
+                user_id=user.pk,
+                child_id=child.pk,
+                study_id=study.pk,
+            ),
+        )
+
+    def test_potential_message_targets_jspsych(self):
+        child, study, message_target = self._active_jspsych_study_target()
+
+        # Check that user/child are potential message targets in new jsPsych study
+        self.assertIn(message_target, potential_message_targets())
+
+        # Add response from this child for this study, past the consent trial
+        G(
+            Response,
+            study=study,
+            study_type=study.study_type,
+            child=child,
+            completed_consent_frame=True,
+        )
+
+        # Check that the message target no longer has this child for this study
+        self.assertNotIn(message_target, potential_message_targets())
+
+    def test_potential_message_targets_jspsych_without_consent(self):
+        child, study, message_target = self._active_jspsych_study_target()
+
+        # A response that never got past the consent trial does not count as
+        # participation, so the child should still be a potential message target.
+        G(
+            Response,
+            study=study,
+            study_type=study.study_type,
+            child=child,
+            completed_consent_frame=False,
+        )
+
+        self.assertIn(message_target, potential_message_targets())
+
     def test_validated_skips_none_user(self):
         result = list(_validated([(None, [])]))
         self.assertEqual(result, [])


### PR DESCRIPTION
This PR proposes excluding a child who has already completed a jsPsych study's consent trial from that study's announcement emails, the same way the target query already excludes prior participation in Ember Frame Player and external studies. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/390. You can sign in with your GitHub ID to claim ownership of the project.

## What's happening

`MESSAGE_TARGET_QUERY` in `studies/tasks.py` drops user/child/study triplets with prior participation in its `EXCEPT` block, but only for two of the three study types:

```sql
WHERE (sr.completed_consent_frame = true AND sst.id = 1)
	            OR (sst.id = 2)
```

`StudyType` id 1 is the Ember Frame Player and id 2 is External. jsPsych is id 3, and it is missing here. So once a child gets past the consent trial of a jsPsych study, that child/study pair stays in the announcement email target set, and the family can still be emailed an invitation to a study the child has already taken — the case written up as "Child participates in a jsPsych study and then gets email invitation for that study" in #1902.

The rest of the site already treats jsPsych participation exactly like Ember Frame Player participation: `StudiesListView.studies_without_completed_consent_frame` (the "hide studies we've done" filter) and `PastStudiesListView.get_queryset` both pair `study_type=jsPsych` with `completed_consent_frame=True`. The announcement targets are the one place where that pairing is missing.

## Reproducing it on `develop` (aab3254)

The first test added here is the reproduction. With the test in place and `studies/tasks.py` untouched:

```
$ ./manage.py test studies.tests.TestAnnouncementEmailFunctionality.test_potential_message_targets_jspsych
FAIL: test_potential_message_targets_jspsych (studies.tests.TestAnnouncementEmailFunctionality.test_potential_message_targets_jspsych)
AssertionError: MessageTarget(user_id=4, child_id=9, study_id=5) unexpectedly found in <generator object potential_message_targets at 0x10a1d5d50>
```

The child has an active jsPsych study response with `completed_consent_frame=True`, and is still returned as a target for that same study.

## The change

One condition in the SQL: `sst.id = 1` becomes `sst.id IN (1, 3)`, so a completed consent frame counts as participation for both internal study types. External studies (id 2) keep counting on any response, and nothing else about the query changes.

## Verification

- `test_potential_message_targets_jspsych` fails on `develop` (output above) and passes with the change.
- `test_potential_message_targets_jspsych_without_consent` is the control for the opposite direction: a jsPsych response that never reached the consent trial must still leave the family in the target set, so the change cannot over-exclude. It passes both before and after.
- Full suite before the change: `Ran 860 tests in 1116.319s` / `FAILED (failures=1, skipped=9)`. After the change: `Ran 862 tests in 1052.543s` / `FAILED (failures=1, skipped=9)`. The single failure is identical in both runs — `api.tests.test_video.VideoTestCase.testPostResponse`, which compares a stored timestamp against local wall-clock time and fails on any machine that is not on UTC — so this change adds nothing red.
- `ruff` and `ruff-format` at 0.11.6 (the versions your `.pre-commit-config.yaml` pins) are clean on both changed files.

This edits the same SQL constant as #1905, but a different part of it: that one changes how prior *messages* are counted, this one changes how prior *responses* are counted. They are independent, and the two edits are far enough apart in the string to merge cleanly in either order.

## How this was managed

The board at https://eastagiletracker.com/projects/390 was imported from this repository — 1717 stories from your issues and pull requests, with your 39 labels — and this work was tracked on it as https://eastagiletracker.com/projects/390/stories/279043, the story matching issue #1902.

![board](https://raw.githubusercontent.com/eastagiletracker/lookit-api/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
