### PR TITLE
Fix failing celery task triggers

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -129,6 +129,37 @@ else:
         integrations=[DjangoIntegration(), CeleryIntegration()],
     )
 
+# Without logging config, unhandled 500s are captured by Sentry but
+# never written to stdout, so tracebacks don't appear in the
+# GKE pod logs - only uwsgi's HTTP 500 request line does. Add an
+# explicit stdout StreamHandler for non-DEBUG so request-exception tracebacks
+# are also visible in cloud logs.
+# `disable_existing_loggers=False` keeps Django's other default loggers intact.
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "%(asctime)s %(levelname)s %(name)s %(process)d %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        # Unhandled request exceptions (HTTP 500s) log an ERROR here, with the
+        # traceback attached via exc_info.
+        "django.request": {
+            "handlers": ["console"],
+            "level": "ERROR",
+            "propagate": False,
+        },
+    },
+}
+
 
 INTERNAL_IPS = ["127.0.0.1"]
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -382,7 +382,15 @@ CELERY_TASK_ROUTES = {
     "studies.tasks.send_announcement_emails": {"queue": "email"},
 }
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
-CELERY_BROKER_POOL_LIMIT = 0
+# Do not set CELERY_BROKER_POOL_LIMIT to 0 / None - leave it unset (default 10).
+# Either value (None is coerced to 0 by kombu.pools.set_limit) is below kombu's
+# default pool size of 10, so the first `.delay()` in a process takes kombu's
+# pool-*shrink* path (Resource.resize -> _shrink_down -> resource.queue.popleft()).
+# Under our gevent web/worker processes (manage.py / uwsgi run gevent
+# monkey.patch_all) that path crashes with `AttributeError: 'list' object has no
+# attribute 'popleft'` and rolls back any enclosing transaction.
+# It was only set to 0 to silence a benign RabbitMQ "client
+# unexpectedly closed TCP connection" warning (#1432).
 
 LOCALE_PATHS = (os.path.join(BASE_DIR, "../locale"),)
 

--- a/project/tests.py
+++ b/project/tests.py
@@ -46,12 +46,11 @@ class CeleryBrokerPoolLimitTests(SimpleTestCase):
             (0, None),
             "CELERY_BROKER_POOL_LIMIT must not be 0 or None -- both take kombu's "
             "crashing pool-shrink path. Leave the setting unset so Celery's "
-            "default applies. See CELERY_KOMBU_POOL_BUG.md.",
+            "default applies.",
         )
         self.assertGreaterEqual(
             limit,
             KOMBU_DEFAULT_POOL_LIMIT,
             "CELERY_BROKER_POOL_LIMIT must not be smaller than kombu's default "
-            "pool size, or the first pool build takes the crashing shrink path. "
-            "See CELERY_KOMBU_POOL_BUG.md.",
+            "pool size, or the first pool build takes the crashing shrink path. ",
         )

--- a/project/tests.py
+++ b/project/tests.py
@@ -1,0 +1,57 @@
+"""Project-level configuration regression tests."""
+
+from django.test import SimpleTestCase
+
+# kombu's (and Celery's) default broker connection pool size. A pool is first
+# built at this size, so any configured limit below it makes kombu take
+# Resource.resize()'s *shrink* path.
+KOMBU_DEFAULT_POOL_LIMIT = 10
+
+
+class CeleryBrokerPoolLimitTests(SimpleTestCase):
+    """Guard against reintroducing the kombu shrink-to-zero crash.
+
+    Setting CELERY_BROKER_POOL_LIMIT to 0 or None (or any value
+    below kombu's default pool size of 10) makes kombu take Resource.resize()'s
+    shrink path the first time a broker pool is built. That path calls
+    resource.queue.popleft(). In our gevent web/worker processes
+    (manage.py, uwsgi run gevent.monkey.patch_all()) that queue is a
+    plain list with no popleft, so it raises AttributeError:
+    'list' object has no attribute 'popleft'. That kills the
+    first .delay() in a new process and rolls back any enclosing
+    transaction.
+
+    monkey.patch_all() replaces stdlib queue.LifoQueue with gevent's C
+    LifoQueue, whose __init__ never calls the Python-level _init
+    hook, so kombu's _init (which would back the queue with a deque) is
+    bypassed, and the queue stays a list. In a plain (non-gevent)
+    interpreter the queue is a deque and the crash is invisible, which is
+    why it never reproduced locally or in bare python on the pod.
+
+    Other options for fixing this are:
+    - update gevent to >= 25.9.1
+    - exclude queue from monkey patching: patch_all(queue=False).
+    If we do either of these things, we could reset the pool limit to 0
+    and/or remove these tests.
+    """
+
+    def test_broker_pool_limit_is_not_a_shrinking_value(self):
+        from project.celery import app
+
+        # The value Celery will actually hand to kombu.pools.set_limit().
+        limit = app.conf.broker_pool_limit
+
+        self.assertNotIn(
+            limit,
+            (0, None),
+            "CELERY_BROKER_POOL_LIMIT must not be 0 or None -- both take kombu's "
+            "crashing pool-shrink path. Leave the setting unset so Celery's "
+            "default applies. See CELERY_KOMBU_POOL_BUG.md.",
+        )
+        self.assertGreaterEqual(
+            limit,
+            KOMBU_DEFAULT_POOL_LIMIT,
+            "CELERY_BROKER_POOL_LIMIT must not be smaller than kombu's default "
+            "pool size, or the first pool build takes the crashing shrink path. "
+            "See CELERY_KOMBU_POOL_BUG.md.",
+        )


### PR DESCRIPTION
Fixes #1925 

This fixes the "AttributeError: 'list' object has no attribute 'popleft'" (server 500) error that occasionally appears when a task is triggered, such as sending a message to a participant or triggering a study build. This error causes the task request to fail.

