### PR TITLE
Fix email unsubscribe link generation error

### DIFF
--- a/exp/tests/test_email_templates.py
+++ b/exp/tests/test_email_templates.py
@@ -81,6 +81,46 @@ class EmailTemplatesTestCase(TestCase):
             txt,
         )
 
+    @parameterized.expand(
+        [
+            ({},),
+            ({"username": "fake@email.com", "token": ""},),
+            ({"username": "", "token": "1abc:signature"},),
+        ]
+    )
+    def test_base_html_omits_unsubscribe_link_without_username_and_token(self, context):
+        """A missing unsubscribe context should drop the link, not break the send.
+
+        Reversing the unsubscribe URL with an empty username or token raises
+        NoReverseMatch, which would otherwise fail the whole email.
+        """
+        html = render_to_string("emails/base.html", context)
+        bs = BeautifulSoup(html, "html.parser")
+        links = list(bs.findAll("a"))
+
+        self.assertEqual(len(links), 2)
+        self.assertEqual(links[0]["href"], f"{fake_website}account/email/")
+        self.assertEqual(
+            links[1]["href"],
+            "mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question",
+        )
+
+    @parameterized.expand(
+        [
+            ({},),
+            ({"username": "fake@email.com", "token": ""},),
+            ({"username": "", "token": "1abc:signature"},),
+        ]
+    )
+    def test_base_txt_omits_unsubscribe_link_without_username_and_token(self, context):
+        txt = render_to_string("emails/base.txt", context)
+
+        self.assertNotIn("Unsubscribe from all CHS emails", txt)
+        self.assertIn(
+            f"Update your CHS email preferences here: {fake_website}account/email/\n",
+            txt,
+        )
+
     def test_notify_admins_of_lab_creation_html_url(self):
         context = {"lab_id": 4321}
         html = render_to_string("emails/notify_admins_of_lab_creation.html", context)

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -54,6 +54,10 @@ EFP_LATEST_VERSION_NOT_ON_GITHUB = (
     "repos hosted on GitHub. Please enter a commit SHA for this repo."
 )
 
+# List of templates that extend emails/base. These templates include a footer that
+# needs the recipient's username and a signed token to build the unsubscribe link.
+PARTICIPANT_EMAIL_TEMPLATES = ("custom_email", "study_announcement")
+
 
 def get_absolute_url(path=""):
     return urljoin(settings.BASE_URL, path)
@@ -247,6 +251,18 @@ def send_mail(
     :param str custom_message Custom email message - for use instead of a template
     :kwargs: Context vars for the email template
     """
+    # For ppt email templates, log emails that are missing a username and/or token.
+    # These will still be sent, but will not include an unsubscribe link in the footer.
+    if template_name in PARTICIPANT_EMAIL_TEMPLATES and not (
+        context.get("username") and context.get("token")
+    ):
+        logger.warning(
+            "Sending %s to %s without an unsubscribe link: username and/or token "
+            "missing from the email context.",
+            template_name,
+            to_addresses,
+        )
+
     # For text version: replace images with [IMAGE] so they're not removed entirely
     context_plain_text = copy.deepcopy(context)
     # TODO: use a custom filter rather than striptags to preserve image placeholders in the

--- a/studies/templates/emails/base.html
+++ b/studies/templates/emails/base.html
@@ -3,6 +3,6 @@
 <br />
 <a href="{% absolute_url 'web:email-preferences' %}">Update your CHS email preferences</a>
 <br />
-<a href="{% absolute_url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all CHS emails</a>
+{% if username and token %}<a href="{% absolute_url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all CHS emails</a>
 <br />
-<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>
+{% endif %}<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>

--- a/studies/templates/emails/base.txt
+++ b/studies/templates/emails/base.txt
@@ -1,5 +1,5 @@
 {% load web_extras %}{% block content %}{% endblock content %}
 
 Update your CHS email preferences here: {% absolute_url 'web:email-preferences' %}
-Unsubscribe from all CHS emails: {% absolute_url 'web:email-unsubscribe-link' username=username token=token %}
-Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com
+{% if username and token %}Unsubscribe from all CHS emails: {% absolute_url 'web:email-unsubscribe-link' username=username token=token %}
+{% endif %}Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -738,6 +738,26 @@ class TestSendMail(TestCase):
             "Email image attachment does not have expected headers",
         )
 
+    def test_send_email_without_username_and_token(self):
+        """A participant email sent without unsubscribe context still goes out.
+
+        This happens when send_mail is called directly (e.g. testing the email queue)
+        rather than through Message.send_as_email, and used to raise NoReverseMatch
+        while rendering the footer.
+        """
+        with self.assertLogs("studies.helpers", level="WARNING") as logs:
+            email = send_mail(
+                "custom_email",
+                "Test email",
+                ["lookit-test-email@mit.edu"],
+                custom_message=mark_safe("<p>no unsubscribe context here</p>"),
+            )
+
+        self.assertIn("without an unsubscribe link", logs.output[0])
+        self.assertNotIn("Unsubscribe from all CHS emails", email.body)
+        self.assertNotIn("Unsubscribe from all CHS emails", email.alternatives[0][0])
+        self.assertIn("Update your CHS email preferences", email.body)
+
     def test_empty_reply_to(self):
         reply_to = []
         email = send_mail(


### PR DESCRIPTION
Fixes #1928 

This PR puts a conditional around the unsubscribe link in participant-facing email templates, to avoid throwing an error (which stops the email from sending) if the username and/or token is missing. Instead, now the email will still send but will not include the unsubscribe link, and it will be logged. This also adds tests to cover `send_mail` for participant template emails sent with missing/empty usernames and/or tokens, and template rendering for these same cases.