### PR TITLE
Prod release: fix celery bug, update privacy page

### DIFF
--- a/exp/tests/test_email_templates.py
+++ b/exp/tests/test_email_templates.py
@@ -81,6 +81,46 @@ class EmailTemplatesTestCase(TestCase):
             txt,
         )
 
+    @parameterized.expand(
+        [
+            ({},),
+            ({"username": "fake@email.com", "token": ""},),
+            ({"username": "", "token": "1abc:signature"},),
+        ]
+    )
+    def test_base_html_omits_unsubscribe_link_without_username_and_token(self, context):
+        """A missing unsubscribe context should drop the link, not break the send.
+
+        Reversing the unsubscribe URL with an empty username or token raises
+        NoReverseMatch, which would otherwise fail the whole email.
+        """
+        html = render_to_string("emails/base.html", context)
+        bs = BeautifulSoup(html, "html.parser")
+        links = list(bs.findAll("a"))
+
+        self.assertEqual(len(links), 2)
+        self.assertEqual(links[0]["href"], f"{fake_website}account/email/")
+        self.assertEqual(
+            links[1]["href"],
+            "mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question",
+        )
+
+    @parameterized.expand(
+        [
+            ({},),
+            ({"username": "fake@email.com", "token": ""},),
+            ({"username": "", "token": "1abc:signature"},),
+        ]
+    )
+    def test_base_txt_omits_unsubscribe_link_without_username_and_token(self, context):
+        txt = render_to_string("emails/base.txt", context)
+
+        self.assertNotIn("Unsubscribe from all CHS emails", txt)
+        self.assertIn(
+            f"Update your CHS email preferences here: {fake_website}account/email/\n",
+            txt,
+        )
+
     def test_notify_admins_of_lab_creation_html_url(self):
         context = {"lab_id": 4321}
         html = render_to_string("emails/notify_admins_of_lab_creation.html", context)

--- a/project/settings.py
+++ b/project/settings.py
@@ -129,6 +129,37 @@ else:
         integrations=[DjangoIntegration(), CeleryIntegration()],
     )
 
+# Without logging config, unhandled 500s are captured by Sentry but
+# never written to stdout, so tracebacks don't appear in the
+# GKE pod logs - only uwsgi's HTTP 500 request line does. Add an
+# explicit stdout StreamHandler for non-DEBUG so request-exception tracebacks
+# are also visible in cloud logs.
+# `disable_existing_loggers=False` keeps Django's other default loggers intact.
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "%(asctime)s %(levelname)s %(name)s %(process)d %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        # Unhandled request exceptions (HTTP 500s) log an ERROR here, with the
+        # traceback attached via exc_info.
+        "django.request": {
+            "handlers": ["console"],
+            "level": "ERROR",
+            "propagate": False,
+        },
+    },
+}
+
 
 INTERNAL_IPS = ["127.0.0.1"]
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -382,7 +382,15 @@ CELERY_TASK_ROUTES = {
     "studies.tasks.send_announcement_emails": {"queue": "email"},
 }
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
-CELERY_BROKER_POOL_LIMIT = 0
+# Do not set CELERY_BROKER_POOL_LIMIT to 0 / None - leave it unset (default 10).
+# Either value (None is coerced to 0 by kombu.pools.set_limit) is below kombu's
+# default pool size of 10, so the first `.delay()` in a process takes kombu's
+# pool-*shrink* path (Resource.resize -> _shrink_down -> resource.queue.popleft()).
+# Under our gevent web/worker processes (manage.py / uwsgi run gevent
+# monkey.patch_all) that path crashes with `AttributeError: 'list' object has no
+# attribute 'popleft'` and rolls back any enclosing transaction.
+# It was only set to 0 to silence a benign RabbitMQ "client
+# unexpectedly closed TCP connection" warning (#1432).
 
 LOCALE_PATHS = (os.path.join(BASE_DIR, "../locale"),)
 

--- a/project/tests.py
+++ b/project/tests.py
@@ -46,12 +46,11 @@ class CeleryBrokerPoolLimitTests(SimpleTestCase):
             (0, None),
             "CELERY_BROKER_POOL_LIMIT must not be 0 or None -- both take kombu's "
             "crashing pool-shrink path. Leave the setting unset so Celery's "
-            "default applies. See CELERY_KOMBU_POOL_BUG.md.",
+            "default applies.",
         )
         self.assertGreaterEqual(
             limit,
             KOMBU_DEFAULT_POOL_LIMIT,
             "CELERY_BROKER_POOL_LIMIT must not be smaller than kombu's default "
-            "pool size, or the first pool build takes the crashing shrink path. "
-            "See CELERY_KOMBU_POOL_BUG.md.",
+            "pool size, or the first pool build takes the crashing shrink path. ",
         )

--- a/project/tests.py
+++ b/project/tests.py
@@ -1,0 +1,57 @@
+"""Project-level configuration regression tests."""
+
+from django.test import SimpleTestCase
+
+# kombu's (and Celery's) default broker connection pool size. A pool is first
+# built at this size, so any configured limit below it makes kombu take
+# Resource.resize()'s *shrink* path.
+KOMBU_DEFAULT_POOL_LIMIT = 10
+
+
+class CeleryBrokerPoolLimitTests(SimpleTestCase):
+    """Guard against reintroducing the kombu shrink-to-zero crash.
+
+    Setting CELERY_BROKER_POOL_LIMIT to 0 or None (or any value
+    below kombu's default pool size of 10) makes kombu take Resource.resize()'s
+    shrink path the first time a broker pool is built. That path calls
+    resource.queue.popleft(). In our gevent web/worker processes
+    (manage.py, uwsgi run gevent.monkey.patch_all()) that queue is a
+    plain list with no popleft, so it raises AttributeError:
+    'list' object has no attribute 'popleft'. That kills the
+    first .delay() in a new process and rolls back any enclosing
+    transaction.
+
+    monkey.patch_all() replaces stdlib queue.LifoQueue with gevent's C
+    LifoQueue, whose __init__ never calls the Python-level _init
+    hook, so kombu's _init (which would back the queue with a deque) is
+    bypassed, and the queue stays a list. In a plain (non-gevent)
+    interpreter the queue is a deque and the crash is invisible, which is
+    why it never reproduced locally or in bare python on the pod.
+
+    Other options for fixing this are:
+    - update gevent to >= 25.9.1
+    - exclude queue from monkey patching: patch_all(queue=False).
+    If we do either of these things, we could reset the pool limit to 0
+    and/or remove these tests.
+    """
+
+    def test_broker_pool_limit_is_not_a_shrinking_value(self):
+        from project.celery import app
+
+        # The value Celery will actually hand to kombu.pools.set_limit().
+        limit = app.conf.broker_pool_limit
+
+        self.assertNotIn(
+            limit,
+            (0, None),
+            "CELERY_BROKER_POOL_LIMIT must not be 0 or None -- both take kombu's "
+            "crashing pool-shrink path. Leave the setting unset so Celery's "
+            "default applies. See CELERY_KOMBU_POOL_BUG.md.",
+        )
+        self.assertGreaterEqual(
+            limit,
+            KOMBU_DEFAULT_POOL_LIMIT,
+            "CELERY_BROKER_POOL_LIMIT must not be smaller than kombu's default "
+            "pool size, or the first pool build takes the crashing shrink path. "
+            "See CELERY_KOMBU_POOL_BUG.md.",
+        )

--- a/studies/helpers.py
+++ b/studies/helpers.py
@@ -54,6 +54,10 @@ EFP_LATEST_VERSION_NOT_ON_GITHUB = (
     "repos hosted on GitHub. Please enter a commit SHA for this repo."
 )
 
+# List of templates that extend emails/base. These templates include a footer that
+# needs the recipient's username and a signed token to build the unsubscribe link.
+PARTICIPANT_EMAIL_TEMPLATES = ("custom_email", "study_announcement")
+
 
 def get_absolute_url(path=""):
     return urljoin(settings.BASE_URL, path)
@@ -247,6 +251,18 @@ def send_mail(
     :param str custom_message Custom email message - for use instead of a template
     :kwargs: Context vars for the email template
     """
+    # For ppt email templates, log emails that are missing a username and/or token.
+    # These will still be sent, but will not include an unsubscribe link in the footer.
+    if template_name in PARTICIPANT_EMAIL_TEMPLATES and not (
+        context.get("username") and context.get("token")
+    ):
+        logger.warning(
+            "Sending %s to %s without an unsubscribe link: username and/or token "
+            "missing from the email context.",
+            template_name,
+            to_addresses,
+        )
+
     # For text version: replace images with [IMAGE] so they're not removed entirely
     context_plain_text = copy.deepcopy(context)
     # TODO: use a custom filter rather than striptags to preserve image placeholders in the

--- a/studies/templates/emails/base.html
+++ b/studies/templates/emails/base.html
@@ -3,6 +3,6 @@
 <br />
 <a href="{% absolute_url 'web:email-preferences' %}">Update your CHS email preferences</a>
 <br />
-<a href="{% absolute_url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all CHS emails</a>
+{% if username and token %}<a href="{% absolute_url 'web:email-unsubscribe-link' username=username token=token %}">Unsubscribe from all CHS emails</a>
 <br />
-<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>
+{% endif %}<a href="mailto:childrenhelpingscience@gmail.com?subject=CHS Family Feedback or Question">Questions or feedback for Children Helping Science?</a>

--- a/studies/templates/emails/base.txt
+++ b/studies/templates/emails/base.txt
@@ -1,5 +1,5 @@
 {% load web_extras %}{% block content %}{% endblock content %}
 
 Update your CHS email preferences here: {% absolute_url 'web:email-preferences' %}
-Unsubscribe from all CHS emails: {% absolute_url 'web:email-unsubscribe-link' username=username token=token %}
-Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com
+{% if username and token %}Unsubscribe from all CHS emails: {% absolute_url 'web:email-unsubscribe-link' username=username token=token %}
+{% endif %}Questions or feedback for Children Helping Science?: childrenhelpingscience@gmail.com

--- a/studies/tests.py
+++ b/studies/tests.py
@@ -738,6 +738,26 @@ class TestSendMail(TestCase):
             "Email image attachment does not have expected headers",
         )
 
+    def test_send_email_without_username_and_token(self):
+        """A participant email sent without unsubscribe context still goes out.
+
+        This happens when send_mail is called directly (e.g. testing the email queue)
+        rather than through Message.send_as_email, and used to raise NoReverseMatch
+        while rendering the footer.
+        """
+        with self.assertLogs("studies.helpers", level="WARNING") as logs:
+            email = send_mail(
+                "custom_email",
+                "Test email",
+                ["lookit-test-email@mit.edu"],
+                custom_message=mark_safe("<p>no unsubscribe context here</p>"),
+            )
+
+        self.assertIn("without an unsubscribe link", logs.output[0])
+        self.assertNotIn("Unsubscribe from all CHS emails", email.body)
+        self.assertNotIn("Unsubscribe from all CHS emails", email.alternatives[0][0])
+        self.assertIn("Update your CHS email preferences", email.body)
+
     def test_empty_reply_to(self):
         reply_to = []
         email = send_mail(

--- a/uv.lock
+++ b/uv.lock
@@ -1444,11 +1444,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.4"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/67/701f86b28d63b2086de47c942eccf8ca2208b3be69715a1119a4e384415a/sqlparse-0.5.4.tar.gz", hash = "sha256:4396a7d3cf1cd679c1be976cf3dc6e0a51d0111e87787e7a8d780e7d5a998f9e", size = 120112, upload-time = "2025-11-28T07:10:18.377Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/70/001ee337f7aa888fb2e3f5fd7592a6afc5283adb1ed44ce8df5764070f22/sqlparse-0.5.4-py3-none-any.whl", hash = "sha256:99a9f0314977b76d776a0fcb8554de91b9bb8a18560631d6bc48721d07023dcb", size = 45933, upload-time = "2025-11-28T07:10:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/web/templates/web/privacy.html
+++ b/web/templates/web/privacy.html
@@ -218,7 +218,7 @@
         administrative tasks and legal obligations.{% endblocktranslate %}
         </p>
     </div>
-    <h3 class="m-4">{% trans "Compliance with Institutional Data Governance Requirements" %}</h3>
+    <h3 class="m-4">{% trans "Compliance with institutional data governance requirements" %}</h3>
     <div class="m-4">
         <p>
             {% blocktranslate %}Children Helping Science is designed specifically for the secure collection and storage of human subject research data. To help you assess whether the Platform meets your institutional requirements, we provide:{% endblocktranslate %}
@@ -261,13 +261,13 @@
         </p>
         <p>{% trans "You are under no statutory or contractual obligation to provide any personal data to us." %}</p>
     </div>
-    <h3 class="m-4">{% trans "Funder- and Institution-specific confidentiality requirements" %}</h3>
+    <h3 class="m-4">{% trans "Funder- and institution-specific confidentiality requirements" %}</h3>
     <div class="m-4">
         <p>
             {% blocktranslate %}Children Helping Science recognizes and respects legal protections such as Certificates of Confidentiality and other data governance requirements imposed by funding agencies or institutions. Consistent with applicable law, Children Helping Science will refuse to disclose identifiable research data that is subject to such protections, except as permitted by the terms of those protections themselves. We will not voluntarily disclose such protected data in response to requests from third parties, including but not limited to subpoenas, court orders, or other demands, except as required by law or as expressly permitted under the applicable data protection agreement.{% endblocktranslate %}
         </p>
     </div>
-    <h3 class="m-4">{% trans "Additional Information" %}</h3>
+    <h3 class="m-4">{% trans "Additional information" %}</h3>
     <div class="m-4">
         <p>
             {% blocktranslate %}We may change this Privacy Statement from time to time. If we make any significant changes in the way we

--- a/web/templates/web/privacy.html
+++ b/web/templates/web/privacy.html
@@ -6,6 +6,7 @@
     Privacy
 {% endblock title %}
 {% block content %}
+{% url "web:termsofuse" as termsofuse %}
     {% trans "Privacy statement" as trans_priv_statement %}
     {% page_title trans_priv_statement %}
     <h3 class="subheading">{% trans "Introduction" %}</h3>
@@ -217,6 +218,21 @@
         administrative tasks and legal obligations.{% endblocktranslate %}
         </p>
     </div>
+    <h3 class="m-4">{% trans "Compliance with Institutional Data Governance Requirements" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}Children Helping Science is designed specifically for the secure collection and storage of human subject research data. To help you assess whether the Platform meets your institutional requirements, we provide:{% endblocktranslate %}
+        </p>
+        <ul>
+            <li><a href="{{ termsofuse }}" target="_blank" rel="noopener">{% trans "CHS Website Terms of Use" %}</a></li>
+            <li>{% trans "This Privacy Policy" %}</li>
+            <li><a href="https://lookit.readthedocs.io/" target="_blank" rel="noopener">{% trans "Technical documentation" %}</a> {% trans "about Platform security and data storage practices" %}</li>
+            <li>{% trans "The ability to contact us with specific questions about data security, retention, storage location, access controls, and other technical specifications." %}</li>
+        </ul>
+        <p>
+            {% blocktranslate %}If your Institution has imposed specific data governance requirements on you as a condition of funding or participation (such as a Certificate of Confidentiality, a Data Use Agreement, or other data protection policies), you are solely responsible for ensuring that your use of the Children Helping Science Platform complies with those requirements.{% endblocktranslate %}
+        </p>
+    </div>
     <h3 class="subheading">{% trans "For everyone" %}</h3>
     <h3 class="m-4">{% trans "Rights for individuals in the European Economic Area" %}</h3>
     <div class="m-4">
@@ -245,6 +261,12 @@
         </p>
         <p>{% trans "You are under no statutory or contractual obligation to provide any personal data to us." %}</p>
     </div>
+    <h3 class="m-4">{% trans "Funder- and Institution-specific confidentiality requirements" %}</h3>
+    <div class="m-4">
+        <p>
+            {% blocktranslate %}Children Helping Science recognizes and respects legal protections such as Certificates of Confidentiality and other data governance requirements imposed by funding agencies or institutions. Consistent with applicable law, Children Helping Science will refuse to disclose identifiable research data that is subject to such protections, except as permitted by the terms of those protections themselves. We will not voluntarily disclose such protected data in response to requests from third parties, including but not limited to subpoenas, court orders, or other demands, except as required by law or as expressly permitted under the applicable data protection agreement.{% endblocktranslate %}
+        </p>
+    </div>
     <h3 class="m-4">{% trans "Additional Information" %}</h3>
     <div class="m-4">
         <p>
@@ -254,6 +276,6 @@
         <p>
             {% trans "The controller for your personal information is MIT. We can be contacted at dataprotection@mit.edu." %}
         </p>
-        <p class="text-center fst-italic">{% trans "This policy was last updated in June 2018." %}</p>
+        <p class="text-center fst-italic">{% trans "This policy was last updated in August 2026." %}</p>
     </div>
 {% endblock content %}


### PR DESCRIPTION
This PR moves the following changes into production:
- fixes a celery task scheduling bug: #1927
- fixes an email sending error (probably only occurs in dev): #1929
- update privacy page: #1930 
- bump sqlparse (fixes security risk): #1922