### PR TITLE
jsPsych local plugin overlay

### DIFF
--- a/env_dist
+++ b/env_dist
@@ -52,6 +52,32 @@ JSPSYCH_S3_ACCESS_KEY_ID=
 JSPSYCH_S3_SECRET_ACCESS_KEY=
 JSPSYCH_S3_BUCKET=
 
+# Serve the CHS jsPsych (@lookit/*) packages from locally running dev builds instead of
+# the published unpkg URLs stored in the database. When enabled, the jsPsych study runner
+# swaps in local dev-server URLs (built in project/settings.py) and drops SRI integrity
+# for them. Requires serving each package locally (npm run dev -w @lookit/* in each 
+# lookit-jspsych package, or honcho start if used to serve multiple packages; 
+# see https://github.com/lookit/lookit-jspsych#serve-multiple-packages).
+# Uncomment to enable, then recreate the web container so the new .env value is
+# picked up (`docker compose up -d web` -- a plain `restart` does NOT re-read this file).
+# To use the published/unpkg URLs from the DB, either comment this out or set it to a
+# falsy value (False/false/0/no/off/empty all disable it).
+# JSPSYCH_LOCAL_PLUGINS=True
+#
+# The dev-server ports below match the defaults set in settings.py and rollup.config.dev.mjs
+# files for lookit-jspsych packages, so normally you should only need to set
+# JSPSYCH_LOCAL_PLUGINS=True above. The variables below can be uncommented and changed to
+# override the host and/or individual ports - only needed if the local lookit-jspsych packages are
+# hosted elsewhere or are served on different ports (e.g. because of a conflict).
+# These should match whatever you're using to serve each package.
+# JSPSYCH_LOCAL_PLUGIN_HOST=http://localhost
+# JSPSYCH_LOCAL_PORT_INITJSPSYCH=10001
+# JSPSYCH_LOCAL_PORT_DATA=10002
+# JSPSYCH_LOCAL_PORT_SURVEYS=10003
+# JSPSYCH_LOCAL_PORT_RECORD=10004
+# JSPSYCH_LOCAL_PORT_STYLE=10005
+# JSPSYCH_LOCAL_PORT_TEMPLATES=10006
+
 # Default repo and branch to use for experiment runner
 EMBER_EXP_PLAYER_BRANCH=master
 EMBER_EXP_PLAYER_REPO=https://github.com/lookit/ember-lookit-frameplayer

--- a/exp/tests/test_runner_views.py
+++ b/exp/tests/test_runner_views.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 from unittest.mock import Mock, patch
 
 import requests
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django_dynamic_fixture import G
 from guardian.shortcuts import assign_perm
@@ -498,3 +498,62 @@ class JsPsychPreviewViewTestCase(TestCase):
 
         # Should include the autoload plugin
         self.assertIn(self.autoload_plugin, autoload_plugins)
+
+    @override_settings(JSPSYCH_LOCAL_PLUGINS=False)
+    @patch("exp.views.study.get_jspsych_aws_values")
+    def test_preview_chs_plugins_keep_db_urls_without_local_overlay(self, mock_aws):
+        """With JSPSYCH_LOCAL_PLUGINS off, preview CHS plugins use their DB URLs."""
+        mock_aws.return_value = {
+            "accessKeyId": "test-key",
+            "secretAccessKey": "test-secret",
+            "sessionToken": "test-token",
+            "expiration": "2099-12-31T23:59:59Z",
+        }
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse(
+                "exp:preview-jspsych",
+                kwargs={"uuid": self.study.uuid, "child_id": self.child.uuid},
+            )
+        )
+
+        chs_plugin = next(
+            p for p in response.context["chs_plugins"] if p.name == "CHS Templates"
+        )
+        self.assertEqual(chs_plugin.url, "https://unpkg.com/@lookit/templates@3.2.0")
+        self.assertEqual(chs_plugin.integrity, "sha384-test3")
+
+    @override_settings(
+        JSPSYCH_LOCAL_PLUGINS=True,
+        JSPSYCH_LOCAL_PLUGIN_URLS={
+            "CHS Templates": "http://localhost:10006/index.browser.js"
+        },
+    )
+    @patch("exp.views.study.get_jspsych_aws_values")
+    def test_preview_chs_plugins_use_local_urls_with_overlay(self, mock_aws):
+        """With JSPSYCH_LOCAL_PLUGINS on, mapped preview CHS plugins point at the local
+        dev server and have their SRI integrity cleared."""
+        mock_aws.return_value = {
+            "accessKeyId": "test-key",
+            "secretAccessKey": "test-secret",
+            "sessionToken": "test-token",
+            "expiration": "2099-12-31T23:59:59Z",
+        }
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse(
+                "exp:preview-jspsych",
+                kwargs={"uuid": self.study.uuid, "child_id": self.child.uuid},
+            )
+        )
+
+        chs_plugin = next(
+            p for p in response.context["chs_plugins"] if p.name == "CHS Templates"
+        )
+        self.assertEqual(chs_plugin.url, "http://localhost:10006/index.browser.js")
+        self.assertEqual(chs_plugin.integrity, "")
+        # The overlay only mutates in-memory objects, not the database.
+        self.chs_plugin.refresh_from_db()
+        self.assertEqual(
+            self.chs_plugin.url, "https://unpkg.com/@lookit/templates@3.2.0"
+        )

--- a/exp/views/study.py
+++ b/exp/views/study.py
@@ -4,6 +4,7 @@ import re
 from functools import reduce
 from typing import Any, Dict, NamedTuple, Text
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db.models import Q
@@ -27,7 +28,6 @@ from exp.views.mixins import (
     ResearcherLoginRequiredMixin,
     SingleObjectFetchProtocol,
 )
-from project import settings
 from studies.forms import (
     DEFAULT_GENERATOR,
     EFPForm,
@@ -57,6 +57,7 @@ from studies.workflow import (
     TRANSITION_LABELS,
 )
 from web.views import (
+    _apply_local_plugin_overlay,
     create_external_response,
     get_external_url,
     get_jspsych_aws_values,
@@ -977,9 +978,14 @@ class JsPsychPreviewView(
         context["jspsych_library"] = JSPsychPlugin.objects.filter(
             category=JSPsychPlugin.Category.JSPSYCH_LIBRARY, autoload=True
         ).order_by("order")
-        context["chs_plugins"] = JSPsychPlugin.objects.filter(
+        chs_plugins = JSPsychPlugin.objects.filter(
             category=JSPsychPlugin.Category.CHS_JSPSYCH, autoload=True
         ).order_by("order")
+        # In local development, serve the CHS (@lookit/*) packages from local dev builds
+        # instead of the published URLs stored in the database. No-op in staging/prod.
+        if settings.JSPSYCH_LOCAL_PLUGINS:
+            chs_plugins = _apply_local_plugin_overlay(chs_plugins)
+        context["chs_plugins"] = chs_plugins
         context["autoload_plugins"] = (
             JSPsychPlugin.objects.filter(autoload=True)
             .exclude(

--- a/project/settings.py
+++ b/project/settings.py
@@ -66,6 +66,44 @@ JSPSYCH_S3_SECRET_ACCESS_KEY = os.environ.get(
 )
 JSPSYCH_S3_BUCKET = os.environ.get("JSPSYCH_S3_BUCKET", "fakeBucketName")
 
+# Local development overlay for CHS jsPsych (@lookit/*) packages. When enabled, the
+# jsPsych study runner views swap the DB URLs for the CHS plugins below to locally
+# served dev builds and drop their SRI integrity/crossorigin (local bundles change on
+# every rebuild, so a fixed hash would fail). Leave JSPSYCH_LOCAL_PLUGINS unset (or set
+# to a falsy value) in staging/production so plugins load from the database URLs.
+# NB: parse the string explicitly because bool("False") is True, so a plain
+# bool(os.environ.get(...)) would treat JSPSYCH_LOCAL_PLUGINS=False as enabled.
+JSPSYCH_LOCAL_PLUGINS = os.environ.get("JSPSYCH_LOCAL_PLUGINS", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+# Host serving the local lookit-jspsych dev builds. Override in .env only if you serve
+# them somewhere other than plain-http localhost.
+JSPSYCH_LOCAL_PLUGIN_HOST = os.environ.get(
+    "JSPSYCH_LOCAL_PLUGIN_HOST", "http://localhost"
+)
+# Per-CHS-plugin dev-server definition: (JSPsychPlugin.name, port env var, default
+# port, served file). Default ports match the lookit-jspsych `npm run serve` ports;
+# override an individual port in .env (e.g. JSPSYCH_LOCAL_PORT_DATA=20002) if you have a
+# local conflict. The plugin names must match JSPsychPlugin.name records and the file
+# names are fixed by each package's build, so both stay in code rather than .env.
+_JSPSYCH_LOCAL_PLUGIN_DEFS = [
+    ("CHS Init jsPsych", "JSPSYCH_LOCAL_PORT_INITJSPSYCH", "10001", "index.browser.js"),
+    ("CHS Data", "JSPSYCH_LOCAL_PORT_DATA", "10002", "index.browser.js"),
+    ("CHS Surveys", "JSPSYCH_LOCAL_PORT_SURVEYS", "10003", "index.browser.js"),
+    ("CHS Record", "JSPSYCH_LOCAL_PORT_RECORD", "10004", "index.browser.js"),
+    ("CHS Style", "JSPSYCH_LOCAL_PORT_STYLE", "10005", "index.css"),
+    ("CHS Templates", "JSPSYCH_LOCAL_PORT_TEMPLATES", "10006", "index.browser.js"),
+]
+# Built map of JSPsychPlugin.name -> locally served URL, consumed by the view when
+# JSPSYCH_LOCAL_PLUGINS is on.
+JSPSYCH_LOCAL_PLUGIN_URLS = {
+    name: f"{JSPSYCH_LOCAL_PLUGIN_HOST}:{os.environ.get(port_var, default_port)}/{filename}"
+    for name, port_var, default_port, filename in _JSPSYCH_LOCAL_PLUGIN_DEFS
+}
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/web/templates/web/jspsych-study-detail.html
+++ b/web/templates/web/jspsych-study-detail.html
@@ -33,19 +33,19 @@
         <!-- External style sheets -->
         {% for plugin in jspsych_library %}
             {% if plugin.file_type == "css" %}
-                <link rel="stylesheet" href="{{ plugin.url }}" integrity="{{ plugin.integrity }}" crossorigin="anonymous">
+                <link rel="stylesheet" href="{{ plugin.url }}"{% if plugin.integrity %} integrity="{{ plugin.integrity }}" crossorigin="anonymous"{% endif %}>
             {% endif %}
         {% endfor %}
         <!-- Auto-loaded plugins style sheets -->
         {% for plugin in autoload_plugins %}
             {% if plugin.file_type == "css" %}
-                <link rel="stylesheet" href="{{ plugin.url }}" integrity="{{ plugin.integrity }}" crossorigin="anonymous">
+                <link rel="stylesheet" href="{{ plugin.url }}"{% if plugin.integrity %} integrity="{{ plugin.integrity }}" crossorigin="anonymous"{% endif %}>
             {% endif %}
         {% endfor %}
         <!-- CHS jsPsych style sheets (load last to take precedence) -->
         {% for plugin in chs_plugins %}
             {% if plugin.file_type == "css" %}
-                <link rel="stylesheet" href="{{ plugin.url }}" integrity="{{ plugin.integrity }}" crossorigin="anonymous">
+                <link rel="stylesheet" href="{{ plugin.url }}"{% if plugin.integrity %} integrity="{{ plugin.integrity }}" crossorigin="anonymous"{% endif %}>
             {% endif %}
         {% endfor %}
     </head>
@@ -57,23 +57,23 @@
         <!-- External JS: core library -->
         {% for plugin in jspsych_library %}
             {% if plugin.file_type == "js" %}
-                <script src="{{ plugin.url }}" integrity="{{ plugin.integrity }}" crossorigin="anonymous"></script>
+                <script src="{{ plugin.url }}"{% if plugin.integrity %} integrity="{{ plugin.integrity }}" crossorigin="anonymous"{% endif %}></script>
             {% endif %}
         {% endfor %}
         <!-- Auto-loaded plugins JS -->
         {% for plugin in autoload_plugins %}
             {% if plugin.file_type == "js" %}
-                <script src="{{ plugin.url }}" integrity="{{ plugin.integrity }}" crossorigin="anonymous"></script>
+                <script src="{{ plugin.url }}"{% if plugin.integrity %} integrity="{{ plugin.integrity }}" crossorigin="anonymous"{% endif %}></script>
             {% endif %}
         {% endfor %}
         <!-- External JS: study-specific plugins/extensions (any autoload plugins are excluded, as they load above) -->
         {% for plugin in study_plugins %}
-            <script src="{{ plugin.url }}" integrity="{{ plugin.integrity }}" crossorigin="anonymous"></script>
+            <script src="{{ plugin.url }}"{% if plugin.integrity %} integrity="{{ plugin.integrity }}" crossorigin="anonymous"{% endif %}></script>
         {% endfor %}
         <!-- CHS jsPsych JS: CHS-specific plugins/extensions, load order set by JSPsychPlugin order field -->
         {% for plugin in chs_plugins %}
             {% if plugin.file_type == "js" %}
-                <script src="{{ plugin.url }}" integrity="{{ plugin.integrity }}" crossorigin="anonymous"></script>
+                <script src="{{ plugin.url }}"{% if plugin.integrity %} integrity="{{ plugin.integrity }}" crossorigin="anonymous"{% endif %}></script>
             {% endif %}
         {% endfor %}
         <!-- Once everything has loaded, run experiment and remove loader div -->

--- a/web/tests/test_views.py
+++ b/web/tests/test_views.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, PropertyMock, patch, sentinel
 
 from django.contrib.sites.models import Site
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 from django.views.generic.list import MultipleObjectMixin
 from django_dynamic_fixture import G
@@ -1052,6 +1052,67 @@ class JsPsychExperimentViewTestCase(TestCase):
 
         # Should include CHS plugin (no show_in_ui filter for participant view)
         self.assertIn(self.chs_plugin, chs_plugins)
+
+    @override_settings(JSPSYCH_LOCAL_PLUGINS=False)
+    @patch("web.views.get_jspsych_aws_values")
+    def test_chs_plugins_keep_db_urls_without_local_overlay(self, mock_aws):
+        """With JSPSYCH_LOCAL_PLUGINS off, CHS plugins use their DB URLs."""
+        mock_aws.return_value = {
+            "accessKeyId": "test-key",
+            "secretAccessKey": "test-secret",
+            "sessionToken": "test-token",
+            "expiration": "2099-12-31T23:59:59Z",
+        }
+        client = Client()
+        client.force_login(self.user)
+        response = client.get(
+            reverse(
+                "web:jspsych-experiment",
+                kwargs={"uuid": self.study.uuid, "child_id": self.child.uuid},
+            )
+        )
+
+        chs_plugin = next(
+            p for p in response.context["chs_plugins"] if p.name == "CHS Templates"
+        )
+        self.assertEqual(chs_plugin.url, "https://unpkg.com/@lookit/templates@3.2.0")
+        self.assertEqual(chs_plugin.integrity, "sha384-test3")
+
+    @override_settings(
+        JSPSYCH_LOCAL_PLUGINS=True,
+        JSPSYCH_LOCAL_PLUGIN_URLS={
+            "CHS Templates": "http://localhost:10006/index.browser.js"
+        },
+    )
+    @patch("web.views.get_jspsych_aws_values")
+    def test_chs_plugins_use_local_urls_with_overlay(self, mock_aws):
+        """With JSPSYCH_LOCAL_PLUGINS on, mapped CHS plugins point at the local dev
+        server and have their SRI integrity cleared."""
+        mock_aws.return_value = {
+            "accessKeyId": "test-key",
+            "secretAccessKey": "test-secret",
+            "sessionToken": "test-token",
+            "expiration": "2099-12-31T23:59:59Z",
+        }
+        client = Client()
+        client.force_login(self.user)
+        response = client.get(
+            reverse(
+                "web:jspsych-experiment",
+                kwargs={"uuid": self.study.uuid, "child_id": self.child.uuid},
+            )
+        )
+
+        chs_plugin = next(
+            p for p in response.context["chs_plugins"] if p.name == "CHS Templates"
+        )
+        self.assertEqual(chs_plugin.url, "http://localhost:10006/index.browser.js")
+        self.assertEqual(chs_plugin.integrity, "")
+        # The overlay only mutates in-memory objects, not the database.
+        self.chs_plugin.refresh_from_db()
+        self.assertEqual(
+            self.chs_plugin.url, "https://unpkg.com/@lookit/templates@3.2.0"
+        )
 
     @patch("web.views.get_jspsych_aws_values")
     def test_jspsych_experiment_context_contains_autoload_plugins(self, mock_aws):

--- a/web/views.py
+++ b/web/views.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 import boto3
 from botocore.exceptions import ClientError
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, signals
 from django.contrib.auth.mixins import UserPassesTestMixin
@@ -39,7 +40,6 @@ from accounts.queries import (
 )
 from accounts.utils import hash_id
 from exp.mixins.paginator_mixin import PaginatorMixin
-from project import settings
 from studies.helpers import get_experiment_absolute_url
 from studies.models import (
     JSPsychPlugin,
@@ -107,6 +107,26 @@ def get_external_url(study: Study, response: Response) -> Text:
 
     url = url._replace(query=urlencode(qs, doseq=True))
     return url.geturl()
+
+
+def _apply_local_plugin_overlay(plugins):
+    """Point CHS plugins at locally served dev builds for local development.
+
+    Any plugin whose name appears in settings.JSPSYCH_LOCAL_PLUGIN_URLS has its ``url``
+    pointed at the local dev server and its ``integrity`` cleared (local bundles change
+    on every rebuild, so a fixed SRI hash would fail; a blank integrity also drops the
+    crossorigin attr in the template). Objects are mutated in memory only -- nothing is
+    written to the DB.
+
+    Callers should gate this on settings.JSPSYCH_LOCAL_PLUGINS.
+    """
+    local_urls = settings.JSPSYCH_LOCAL_PLUGIN_URLS
+    overlaid = list(plugins)
+    for plugin in overlaid:
+        if plugin.name in local_urls:
+            plugin.url = local_urls[plugin.name]
+            plugin.integrity = ""
+    return overlaid
 
 
 def get_jspsych_response(context, is_preview=False):
@@ -959,9 +979,14 @@ class JsPsychExperimentView(
         context["jspsych_library"] = JSPsychPlugin.objects.filter(
             category=JSPsychPlugin.Category.JSPSYCH_LIBRARY, autoload=True
         ).order_by("order")
-        context["chs_plugins"] = JSPsychPlugin.objects.filter(
+        chs_plugins = JSPsychPlugin.objects.filter(
             category=JSPsychPlugin.Category.CHS_JSPSYCH, autoload=True
         ).order_by("order")
+        # In local development, serve the CHS (@lookit/*) packages from local dev builds
+        # instead of the published URLs stored in the database. No-op in staging/prod.
+        if settings.JSPSYCH_LOCAL_PLUGINS:
+            chs_plugins = _apply_local_plugin_overlay(chs_plugins)
+        context["chs_plugins"] = chs_plugins
         context["autoload_plugins"] = (
             JSPsychPlugin.objects.filter(autoload=True)
             .exclude(


### PR DESCRIPTION
This PR adds a new optional environment variable for setting the jsPsych experiment views to use local jsPsych package versions instead of loading the published versions stored in the database. There are also variables that can be used to override the locally-served jsPsych packages' host and ports. It also adds tests for plugin URLs in the jsPsych views based on the env variable / settings.

Now devs can set `JSPSYCH_LOCAL_PLUGINS=True` in `.env` to use local lookit-jspsych packages, and comment out or set to `False` to use the DB URLs (same as current behavior). The inclusion of this `.env` is totally optional, so existing environments without `JSPSYCH_LOCAL_PLUGINS` will not change/break.